### PR TITLE
fix: update hooks.json to Claude Code plugin format (v0.6.1)

### DIFF
--- a/nowledge-mem-claude-code-plugin/CHANGELOG.md
+++ b/nowledge-mem-claude-code-plugin/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to the Nowledge Mem Claude Code plugin will be documented in
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.6.1] - 2026-02-28
+
+### Fixed
+
+- Fixed hooks.json format to comply with Claude Code plugin specification
+  - Added top-level "hooks" wrapper key as required by plugin system
+  - Added description field for hook documentation
+  - Resolves validation error: "expected record, received undefined"
+  - Fixes compatibility with Claude Code 2.1.51+
+
 ## [0.6.0] - 2026-02-14
 
 ### Added

--- a/nowledge-mem-claude-code-plugin/hooks/hooks.json
+++ b/nowledge-mem-claude-code-plugin/hooks/hooks.json
@@ -1,22 +1,25 @@
 {
-  "SessionStart": [
-    {
-      "matcher": "startup",
-      "hooks": [
-        {
-          "type": "command",
-          "command": "cat ~/ai-now/memory.md 2>/dev/null || true"
-        }
-      ]
-    },
-    {
-      "matcher": "compact",
-      "hooks": [
-        {
-          "type": "command",
-          "command": "{ cat ~/ai-now/memory.md 2>/dev/null; printf '\\n---\\nContext was compacted. Please checkpoint any important decisions or findings from this session before continuing:\\n  nmem m add \"<your insight>\" --title \"<short title>\"\\n'; } 2>/dev/null || true"
-        }
-      ]
-    }
-  ]
+  "description": "Lifecycle hooks for Working Memory context injection",
+  "hooks": {
+    "SessionStart": [
+      {
+        "matcher": "startup",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "cat ~/ai-now/memory.md 2>/dev/null || true"
+          }
+        ]
+      },
+      {
+        "matcher": "compact",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "{ cat ~/ai-now/memory.md 2>/dev/null; printf '\\n---\\nContext was compacted. Please checkpoint any important decisions or findings from this session before continuing:\\n  nmem m add \"<your insight>\" --title \"<short title>\"\\n'; } 2>/dev/null || true"
+          }
+        ]
+      }
+    ]
+  }
 }

--- a/nowledge-mem-claude-code-plugin/plugin.json
+++ b/nowledge-mem-claude-code-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "nowledge-mem",
   "description": "Memory and Thread Management for AI Agents using nmem CLI",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "author": {
     "name": "Nowledge Labs",
     "email": "hello@nowledge-labs.ai",


### PR DESCRIPTION
## 问题描述

当前 `nowledge-mem-claude-code-plugin/hooks/hooks.json` 的格式不符合 Claude Code 插件系统规范，导致插件加载时报错：

```
Failed to load hooks from .../hooks/hooks.json: [
  {
    "expected": "record",
    "code": "invalid_type",
    "path": ["hooks"],
    "message": "Invalid input: expected record, received undefined"
  }
]
```

## 根本原因

根据 [Claude Code 官方文档](https://github.com/anthropics/claude-code/blob/main/plugins/plugin-dev/skills/hook-development/SKILL.md)，插件的 `hooks.json` 必须使用顶层 `"hooks"` 包裹键：

> For plugin hooks.json, wrap these in `{"hooks": {...}}`

当前格式直接将事件名（`SessionStart`）放在顶层，这是用户 `settings.json` 的格式，不是插件格式。

## 修复内容

- ✅ 添加顶层 `"hooks"` 键包裹所有事件配置
- ✅ 添加 `"description"` 字段说明 hooks 用途
- ✅ 更新版本号到 0.6.1
- ✅ 更新 CHANGELOG.md 记录修复详情
- ✅ 保持内部逻辑完全不变

## 兼容性

- **向后兼容**：新格式在 Claude Code 2.1.45+ 都支持
- **无功能变更**：只是格式调整，hooks 的实际行为完全相同
- **用户影响**：已安装用户需要重新安装插件以获取修复

## 测试

在 Claude Code 2.1.62 上测试通过：
1. 插件加载无报错
2. SessionStart hooks 正常触发
3. Working Memory 成功注入会话上下文

## 参考

- [Claude Code Plugin Hooks Documentation](https://github.com/anthropics/claude-code/blob/main/plugins/plugin-dev/skills/hook-development/SKILL.md)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Resolved validation error with hooks configuration format

* **Documentation**
  * Updated changelog documenting structural improvements to hooks configuration for enhanced compatibility with Claude Code 2.1.51+
  * Added support for description field in hook documentation

* **Chores**
  * Bumped plugin version to 0.6.1

<!-- end of auto-generated comment: release notes by coderabbit.ai -->