### PR TITLE
feat(openclaw-nowledge-mem): make thread truncation configurable

### DIFF
--- a/nowledge-mem-openclaw-plugin/README.md
+++ b/nowledge-mem-openclaw-plugin/README.md
@@ -338,6 +338,7 @@ To change settings, use the OpenClaw plugin settings UI. Changes take effect on 
 | `digestMinInterval` | integer | `300` | Minimum seconds between session digests for the same thread (0-86400) |
 | `maxContextResults` | integer | `5` | Max memories to inject at prompt time (1-20, only used when sessionContext is enabled) |
 | `recallMinScore` | integer | `0` | Min relevance score (0-100%) to include in auto-recall. 0 = include all |
+| `maxThreadMessageChars` | integer | `800` | Maximum characters preserved per captured OpenClaw thread message before truncation |
 | `apiUrl` | string | `""` | Remote server URL. Empty = local (`http://127.0.0.1:14242`) |
 | `apiKey` | string | `""` | API key for remote access. Injected as `NMEM_API_KEY` env var, never logged |
 
@@ -352,6 +353,7 @@ For persistent or scripted config, create `~/.nowledge-mem/openclaw.json`:
   "digestMinInterval": 300,
   "maxContextResults": 5,
   "recallMinScore": 0,
+  "maxThreadMessageChars": 800,
   "apiUrl": "",
   "apiKey": ""
 }

--- a/nowledge-mem-openclaw-plugin/openclaw.plugin.json
+++ b/nowledge-mem-openclaw-plugin/openclaw.plugin.json
@@ -23,6 +23,10 @@
 			"label": "Min recall score (%)",
 			"help": "Only inject memories with relevance score above this threshold (0-100). Set to 0 to include all results."
 		},
+		"maxThreadMessageChars": {
+			"label": "Max thread message chars",
+			"help": "Maximum characters preserved per captured OpenClaw thread message (200-20000). Higher values keep more of long messages in Nowledge thread history."
+		},
 		"apiUrl": {
 			"label": "Server URL (remote mode)",
 			"help": "Leave empty for local mode (default: http://127.0.0.1:14242). Set to your remote server URL for cross-device or team access. See: https://docs.nowledge.co/docs/remote-access"
@@ -66,6 +70,13 @@
 				"minimum": 0,
 				"maximum": 100,
 				"description": "Minimum relevance score (0-100%) to include a memory in auto-recall. Set to 0 to include all results."
+			},
+			"maxThreadMessageChars": {
+				"type": "integer",
+				"default": 800,
+				"minimum": 200,
+				"maximum": 20000,
+				"description": "Maximum characters preserved per captured OpenClaw thread message before truncation."
 			},
 			"apiUrl": {
 				"type": "string",

--- a/nowledge-mem-openclaw-plugin/src/config.js
+++ b/nowledge-mem-openclaw-plugin/src/config.js
@@ -20,6 +20,7 @@ const ALLOWED_KEYS = new Set([
 	"digestMinInterval",
 	"maxContextResults",
 	"recallMinScore",
+	"maxThreadMessageChars",
 	"apiUrl",
 	"apiKey",
 	// Legacy aliases — accepted but not advertised
@@ -136,7 +137,7 @@ function firstDefined(...options) {
  * will configure via OpenClaw's plugin settings UI (pluginConfig).
  *
  * Canonical keys: sessionContext, sessionDigest, digestMinInterval,
- *                 maxContextResults, recallMinScore, apiUrl, apiKey
+ *                 maxContextResults, recallMinScore, maxThreadMessageChars, apiUrl, apiKey
  *
  * Legacy aliases (accepted from all sources; never shown in docs):
  *   autoRecall → sessionContext
@@ -150,6 +151,7 @@ function firstDefined(...options) {
  *   NMEM_DIGEST_MIN_INTERVAL   — seconds (0-86400)
  *   NMEM_MAX_CONTEXT_RESULTS   — integer (1-20)
  *   NMEM_RECALL_MIN_SCORE      — integer (0-100)
+ *   NMEM_MAX_THREAD_MESSAGE_CHARS — integer (200-20000)
  *   NMEM_API_URL               — remote server URL
  *   NMEM_API_KEY               — API key (never logged)
  */
@@ -250,6 +252,23 @@ export function parseConfig(raw, logger) {
 	const recallMinScore = Math.min(100, Math.max(0, Math.trunc(rms.value)));
 	_sources.recallMinScore = rms.source;
 
+	// --- maxThreadMessageChars: file > pluginConfig > env > default ---
+	const mtmcEnv = envInt("NMEM_MAX_THREAD_MESSAGE_CHARS");
+	const mtmc = firstDefined(
+		{ value: pickNum(resolvedFile, "maxThreadMessageChars"), source: "file" },
+		{
+			value: pickNum(resolvedPlugin, "maxThreadMessageChars"),
+			source: "pluginConfig",
+		},
+		{ value: mtmcEnv, source: "env" },
+		{ value: 800, source: "default" },
+	);
+	const maxThreadMessageChars = Math.min(
+		20000,
+		Math.max(200, Math.trunc(mtmc.value)),
+	);
+	_sources.maxThreadMessageChars = mtmc.source;
+
 	// --- apiUrl: file > pluginConfig > env > "" ---
 	const fileUrl =
 		typeof resolvedFile.apiUrl === "string" && resolvedFile.apiUrl.trim();
@@ -284,6 +303,7 @@ export function parseConfig(raw, logger) {
 		digestMinInterval,
 		maxContextResults,
 		recallMinScore,
+		maxThreadMessageChars,
 		apiUrl,
 		apiKey,
 		_sources,

--- a/nowledge-mem-openclaw-plugin/src/hooks/capture.js
+++ b/nowledge-mem-openclaw-plugin/src/hooks/capture.js
@@ -1,7 +1,7 @@
 import { createHash } from "node:crypto";
 import { readFile } from "node:fs/promises";
 
-const MAX_MESSAGE_CHARS = 800;
+const DEFAULT_MAX_MESSAGE_CHARS = 800;
 const MAX_DISTILL_MESSAGE_CHARS = 2000;
 const MAX_CONVERSATION_CHARS = 30_000;
 const MIN_MESSAGES_FOR_DISTILL = 4;
@@ -23,7 +23,7 @@ function _setLastCapture(threadId, now) {
 	}
 }
 
-function truncate(text, max = MAX_MESSAGE_CHARS) {
+function truncate(text, max = DEFAULT_MAX_MESSAGE_CHARS) {
 	const str = String(text || "").trim();
 	if (!str) return "";
 	return str.length > max ? `${str.slice(0, max)}…` : str;
@@ -48,7 +48,7 @@ function extractText(content) {
 	return parts.join("\n").trim();
 }
 
-function normalizeRoleMessage(raw) {
+function normalizeRoleMessage(raw, maxMessageChars = DEFAULT_MAX_MESSAGE_CHARS) {
 	if (!raw || typeof raw !== "object") return null;
 	const msg =
 		raw.message && typeof raw.message === "object" ? raw.message : raw;
@@ -80,7 +80,7 @@ function normalizeRoleMessage(raw) {
 
 	return {
 		role,
-		content: truncate(text),
+		content: truncate(text, maxMessageChars),
 		fullContent: text,
 		timestamp,
 		externalHint,
@@ -170,7 +170,7 @@ async function resolveHookMessages(event) {
 	return loadMessagesFromSessionFile(sessionFile);
 }
 
-async function appendOrCreateThread({ client, logger, event, ctx, reason }) {
+async function appendOrCreateThread({ client, logger, event, ctx, reason, maxMessageChars = DEFAULT_MAX_MESSAGE_CHARS }) {
 	const rawMessages = await resolveHookMessages(event);
 	if (!Array.isArray(rawMessages) || rawMessages.length === 0) return;
 
@@ -178,7 +178,9 @@ async function appendOrCreateThread({ client, logger, event, ctx, reason }) {
 	const sessionKey = String(ctx?.sessionKey || ctx?.sessionId || "session");
 	const sessionId = String(ctx?.sessionId || "").trim();
 	const title = buildThreadTitle(ctx, reason);
-	const normalized = rawMessages.map(normalizeRoleMessage).filter(Boolean);
+	const normalized = rawMessages
+		.map((message) => normalizeRoleMessage(message, maxMessageChars))
+		.filter(Boolean);
 	if (normalized.length === 0) return;
 
 	const messages = normalized.map((message, index) => ({
@@ -291,6 +293,7 @@ export function buildAgentEndCaptureHandler(client, cfg, logger) {
 			event,
 			ctx,
 			reason: "agent_end",
+			maxMessageChars: cfg.maxThreadMessageChars,
 		});
 
 		// 2. Triage + distill: language-agnostic LLM-based capture.
@@ -376,6 +379,13 @@ export function buildAgentEndCaptureHandler(client, cfg, logger) {
 export function buildBeforeResetCaptureHandler(client, _cfg, logger) {
 	return async (event, ctx) => {
 		const reason = typeof event?.reason === "string" ? event.reason : undefined;
-		await appendOrCreateThread({ client, logger, event, ctx, reason });
+		await appendOrCreateThread({
+			client,
+			logger,
+			event,
+			ctx,
+			reason,
+			maxMessageChars: _cfg?.maxThreadMessageChars,
+		});
 	};
 }

--- a/nowledge-mem-openclaw-plugin/src/tools/status.js
+++ b/nowledge-mem-openclaw-plugin/src/tools/status.js
@@ -109,6 +109,9 @@ export function createStatusTool(client, _logger, cfg) {
 			lines.push(
 				`  recallMinScore: ${cfg.recallMinScore}% (${sources.recallMinScore || "?"})`,
 			);
+			lines.push(
+				`  maxThreadMessageChars: ${cfg.maxThreadMessageChars} (${sources.maxThreadMessageChars || "?"})`,
+			);
 
 			details.config = {
 				sessionContext: {
@@ -130,6 +133,10 @@ export function createStatusTool(client, _logger, cfg) {
 				recallMinScore: {
 					value: cfg.recallMinScore,
 					source: sources.recallMinScore,
+				},
+				maxThreadMessageChars: {
+					value: cfg.maxThreadMessageChars,
+					source: sources.maxThreadMessageChars,
 				},
 				apiUrl: { value: cfg.apiUrl || "(local)", source: sources.apiUrl },
 				apiKey: {


### PR DESCRIPTION
## Motivation
The plugin currently hard-truncates each captured OpenClaw thread message to 800 chars before persistence. This makes Nowledge thread history much less useful for reviewing long OpenClaw conversations, especially when inbound messages include envelope metadata or injected memory context.

## What this change does
- Adds a new config key: `maxThreadMessageChars`
- Keeps backward compatibility with default `800`
- Applies the configured limit when normalizing OpenClaw user/assistant messages before thread persistence
- Exposes the new setting in:
  - `openclaw.plugin.json` configSchema
  - UI hints
  - `nowledge_mem_status`
  - README docs

## Suggested defaults
- default: `800`
- range: `200-20000`

## Files changed
- `src/config.js`
- `src/hooks/capture.js`
- `src/tools/status.js`
- `openclaw.plugin.json`
- `README.md`

## Validation already done locally
- Plugin imports cleanly after the change
- Runtime config parsing confirms `maxThreadMessageChars` is read from pluginConfig
- OpenClaw instance successfully reloaded with `maxThreadMessageChars: 4000`
- Thread capture continues to work after reload

## Notes for reviewers
This change intentionally does **not** remove truncation entirely. It only converts the current hard-coded limit into a documented config option so users can tune fidelity vs noise/storage for their own OpenClaw workflows.

Closes #101


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configurable message truncation for thread capture via maxThreadMessageChars (default 800, range 200–20,000).

* **Documentation**
  * Updated plugin README, config examples, UI hints, and status output to surface the new configuration and its source.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->