### PR TITLE
fix(nowledge-mem-bub): update nmem CLI flags

### DIFF
--- a/nowledge-mem-bub-plugin/src/nowledge_mem_bub/client.py
+++ b/nowledge-mem-bub-plugin/src/nowledge_mem_bub/client.py
@@ -184,7 +184,7 @@ class NmemClient:
         if event_end:
             args.extend(["--event-end", event_end])
         if temporal_context:
-            args.extend(["--temporal-context", temporal_context])
+            args.extend(["--when", temporal_context])
         args.extend(["-s", "bub"])
         result = await self._exec_json(*args)
         return result if isinstance(result, dict) else {}
@@ -240,13 +240,13 @@ class NmemClient:
         date_from: str | None = None,
         date_to: str | None = None,
     ) -> list:
-        args = ["f", "--last-n-days", str(days)]
+        args = ["f", "--days", str(days)]
         if event_type:
             args.extend(["--type", event_type])
         if date_from:
-            args.extend(["--date-from", date_from])
+            args.extend(["--from", date_from])
         if date_to:
-            args.extend(["--date-to", date_to])
+            args.extend(["--to", date_to])
         result = await self._exec_json(*args)
         if isinstance(result, list):
             return result


### PR DESCRIPTION
## Summary
Fix `nowledge-mem-bub` / `nmem` CLI flag compatibility.

## What changed
- `NmemClient.add_memory()`:
  - `--temporal-context` -> `--when`
- `NmemClient.feed_events()`:
  - `--last-n-days` -> `--days`
  - `--date-from` -> `--from`
  - `--date-to` -> `--to`

## Why
Current `nmem-cli` no longer accepts `--temporal-context` for `memories add`, and uses the newer feed flag names as shown by `nmem feed --help`.

This caused `mem.save` to fail with:

```text
nmem: error: unrecognized arguments: --temporal-context present
```

## Validation
- Reproduced `mem.save` failure locally with:
  - `nowledge-mem-bub==0.1.1`
  - `nmem-cli==0.6.9`
- Patched flag name to `--when`
- Restarted Bub session
- Confirmed `mem.save` succeeds after patch
- Audited other CLI calls and updated likely outdated feed flags as well

## Follow-up suggestion
It may be worth adding a small compatibility test around generated CLI args for:
- add memory
- feed events

to catch future `nmem` CLI flag changes earlier.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified command-line interface flags for improved consistency: `--temporal-context` now `--when`; date-filtering flags renamed: `--last-n-days` → `--days`, `--date-from` → `--from`, `--date-to` → `--to`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->