### PR TITLE
release: OpenClaw 0.6.14, Bub 0.2.0

### DIFF
--- a/nowledge-mem-bub-plugin/CHANGELOG.md
+++ b/nowledge-mem-bub-plugin/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 0.2.0 (2026-03-17)
+
+- Fixed: memory context (Working Memory + recalled knowledge) no longer injected into system prompt, which was breaking LLM prefix cache and causing full KV recomputation every turn. Context now injected via `build_prompt` hook into user prompt space. System prompt stays static and cacheable. Contributed by @frostming.
+- Changed: `system_prompt` hook now returns only static behavioral guidance (identical every turn), preserving prefix cache.
+- Changed: memory loading moved from `load_state` hook to private `_load_memory` method called from `build_prompt`.
+- Changed: skill directory renamed from `bub_skills/` to `skills/` for consistency.
+
 ## 0.1.2 (2026-03-12)
 
 - Fixed: nmem cli argument issue by @ferstar via https://github.com/nowledge-co/community/pull/118

--- a/nowledge-mem-bub-plugin/README.md
+++ b/nowledge-mem-bub-plugin/README.md
@@ -20,7 +20,7 @@ nmem status             # verify connection
 ## Verify
 
 ```bash
-uv run bub hooks        # should list nowledge_mem for system_prompt, load_state, save_state
+uv run bub hooks        # should list nowledge_mem for system_prompt, build_prompt, save_state
 uv run bub run "what was I working on this week?"
 ```
 

--- a/nowledge-mem-bub-plugin/pyproject.toml
+++ b/nowledge-mem-bub-plugin/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "nowledge-mem-bub"
-version = "0.1.2"
+version = "0.2.0"
 description = "Nowledge Mem plugin for Bub — cross-ai context for your agent."
 readme = "README.md"
 license = "Apache-2.0"

--- a/nowledge-mem-bub-plugin/src/nowledge_mem_bub/plugin.py
+++ b/nowledge-mem-bub-plugin/src/nowledge_mem_bub/plugin.py
@@ -1,8 +1,8 @@
 """Bub hook implementations for Nowledge Mem.
 
 Hooks:
-  system_prompt  — behavioural guidance (~50 tokens) + optional WM / recall
-  load_state     — fetch Working Memory and (if session_context) recalled memories
+  system_prompt  — static behavioural guidance (~50 tokens), identical every turn
+  build_prompt   — when session_context is on, inject WM + recalled memories
   save_state     — capture each turn to a Nowledge Mem thread (incremental)
 """
 
@@ -138,7 +138,7 @@ class NowledgeMemPlugin:
             # mem.context or mem.search on demand.
             return "", []
         if not self.client.is_available():
-            logger.debug("nmem not in PATH, skipping load_state")
+            logger.debug("nmem not in PATH, skipping memory load")
             return "", []
 
         # Session context mode: fetch WM + recalled memories

--- a/nowledge-mem-openclaw-plugin/CHANGELOG.md
+++ b/nowledge-mem-openclaw-plugin/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to the Nowledge Mem OpenClaw plugin will be documented in this file.
 
+## [0.6.14] - 2026-03-17
+
+### Added
+
+- **Configurable thread message truncation.** New `maxThreadMessageChars` setting (200-20000, default 800) controls how many characters are preserved per captured thread message. Higher values keep more context in long conversations. Configurable via dashboard, config file, or `NMEM_MAX_THREAD_MESSAGE_CHARS` env var. Contributed by @blessonism.
+
 ## [0.6.13] - 2026-03-17
 
 ### Fixed

--- a/nowledge-mem-openclaw-plugin/CLAUDE.md
+++ b/nowledge-mem-openclaw-plugin/CLAUDE.md
@@ -101,6 +101,7 @@ Optional config file at `~/.nowledge-mem/openclaw.json`. Falls through to OpenCl
 | `digestMinInterval` | integer 0-86400 | `300` | `NMEM_DIGEST_MIN_INTERVAL` | Minimum seconds between session digests |
 | `maxContextResults` | integer 1-20 | `5` | `NMEM_MAX_CONTEXT_RESULTS` | How many memories to inject at prompt time |
 | `recallMinScore` | integer 0-100 | `0` | `NMEM_RECALL_MIN_SCORE` | Min relevance score (%) to include in auto-recall |
+| `maxThreadMessageChars` | integer 200-20000 | `800` | `NMEM_MAX_THREAD_MESSAGE_CHARS` | Max chars per captured thread message before truncation |
 | `apiUrl` | string | `""` | `NMEM_API_URL` | Remote server URL. Empty = local (127.0.0.1:14242) |
 | `apiKey` | string | `""` | `NMEM_API_KEY` | API key. Never logged. |
 

--- a/nowledge-mem-openclaw-plugin/openclaw.plugin.json
+++ b/nowledge-mem-openclaw-plugin/openclaw.plugin.json
@@ -1,6 +1,6 @@
 {
 	"id": "openclaw-nowledge-mem",
-	"version": "0.6.13",
+	"version": "0.6.14",
 	"kind": "memory",
 	"skills": ["skills/memory-guide"],
 	"uiHints": {

--- a/nowledge-mem-openclaw-plugin/package.json
+++ b/nowledge-mem-openclaw-plugin/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@nowledge/openclaw-nowledge-mem",
-	"version": "0.6.13",
+	"version": "0.6.14",
 	"type": "module",
 	"description": "Nowledge Mem memory plugin for OpenClaw, local-first personal knowledge base",
 	"author": {


### PR DESCRIPTION
OpenClaw 0.6.14:
- maxThreadMessageChars config (200-20000, default 800) by @blessonism
- CLAUDE.md config table updated

Bub 0.2.0:
- Prefix-cache fix: memory context moved from system_prompt to build_prompt by @frostming — system prompt is now static, preserving LLM KV cache
- Stale hook references fixed in README, plugin.py docstring, debug log

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable thread message truncation in openclaw-plugin with maxThreadMessageChars setting (200-20,000 characters, default 800). Configurable via dashboard, config file, or environment variable.
  * Enhanced memory context handling in bub-plugin v0.2.0 with improved system prompt caching.

* **Chores**
  * Updated bub-plugin to v0.2.0, openclaw-plugin to v0.6.14.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->