### PR TITLE
fix: Hermes integration for global usage, merge guidance, and general…

### DIFF
--- a/nowledge-mem-hermes/AGENTS.md
+++ b/nowledge-mem-hermes/AGENTS.md
@@ -1,6 +1,6 @@
 # Nowledge Mem for Hermes
 
-You have access to the user's knowledge graph through MCP tools provided by the `nowledge-mem` server.
+You have access to the user's knowledge graph through MCP tools from the `nowledge-mem` server. In Hermes, these tools appear with the `mcp_nowledge_mem_` prefix (e.g., `mcp_nowledge_mem_memory_search`). The guidance below uses the base tool names for readability.
 
 ## Working Memory
 
@@ -19,15 +19,15 @@ Do not re-read unless the user asks or the session context changes materially.
 Search when past insights would improve the response. Do not wait for the user to say "search my memory".
 
 **Search when:**
-- The user references previous work, a prior fix, or an earlier decision
-- The task resumes a named feature, bug, refactor, or subsystem
-- A debugging pattern resembles something solved before
-- The user asks for rationale, preferences, or procedures
-- The user uses recall language: "that approach", "like before", "the pattern we used"
+- The user references previous work, a prior decision, or an earlier conversation
+- The task connects to a named project, initiative, or recurring topic
+- A question resembles something discussed or resolved before
+- The user asks for rationale, preferences, or established procedures
+- The user uses recall language: "that approach", "like before", "the thing we decided"
 
 **Skip when:**
 - Fundamentally new topic with no prior history
-- Generic syntax or API questions answerable from documentation
+- Generic factual questions answerable from general knowledge
 - User explicitly asks for a fresh perspective
 
 ```
@@ -49,12 +49,12 @@ Save proactively when the conversation produces a decision, procedure, learning,
 memory_add content="What was decided and why" title="Descriptive title" unit_type="decision" labels=["relevant-label"] importance=0.8
 ```
 
-**Good candidates:** architectural decisions with rationale, repeatable procedures, lessons from debugging, durable preferences, plans that future sessions will need.
+**Good candidates:** decisions with rationale, repeatable procedures, lessons from experience, durable preferences, plans that future sessions will need.
 
 **Quality bar:**
-- Importance 0.8 to 1.0: major decisions, architectural choices, critical learnings
+- Importance 0.8 to 1.0: major decisions, critical learnings, core preferences
 - Importance 0.5 to 0.7: useful patterns, conventions, secondary decisions
-- Importance 0.3 to 0.4: minor notes, preferences, contextual observations
+- Importance 0.3 to 0.4: minor notes, observations, contextual details
 
 One strong memory is better than three weak ones.
 

--- a/nowledge-mem-hermes/README.md
+++ b/nowledge-mem-hermes/README.md
@@ -35,7 +35,7 @@ Start a new Hermes session and ask:
 
 > Search my memories for recent decisions.
 
-Hermes should call `memory_search` and return results from your knowledge graph. If Mem is not running, you will see a connection error.
+Hermes should call `mcp_nowledge_mem_memory_search` and return results from your knowledge graph. If Mem is not running, you will see a connection error.
 
 ## Update
 
@@ -43,7 +43,7 @@ The MCP server runs inside Nowledge Mem. When you update the desktop app, all MC
 
 ## MCP tools
 
-These tools are available to Hermes once the MCP server is connected:
+These tools are available to Hermes once the MCP server is connected. Hermes prefixes them as `mcp_nowledge_mem_<tool>` (see [Hermes MCP naming convention](https://hermes-agent.ai/docs/user-guide/features/overview)):
 
 | Tool | Purpose |
 |------|---------|
@@ -59,15 +59,41 @@ These tools are available to Hermes once the MCP server is connected:
 
 Additional tools for graph exploration, source analysis, and knowledge processing are available depending on your server configuration.
 
-## Behavioral guidance (optional)
+## Behavioral guidance
 
-For stronger memory behavior in a specific project, copy the included `AGENTS.md` into your project root as `AGENTS.md` or `HERMES.md`. Hermes reads these files for project-level context.
+Hermes discovers `.hermes.md` and `HERMES.md` files by walking from the working directory upward. This means you can place guidance at two levels:
+
+### Global (all sessions)
+
+Create `~/HERMES.md` (or `~/.hermes.md`). When Hermes runs outside a git repository, it walks all the way to `~`, so this file provides memory behavior guidance for every session: research, writing, planning, coding, anything.
+
+Append the contents of the included `AGENTS.md` to your `~/HERMES.md`:
 
 ```bash
-cp AGENTS.md /path/to/your/project/HERMES.md
+cat AGENTS.md >> ~/HERMES.md
 ```
 
-This tells Hermes when to search, when to save, and how to use Working Memory. Without it, the MCP tools still work, but Hermes relies on its own judgment for when to call them.
+If you don't have a `~/HERMES.md` yet, you can use ours as a starting point:
+
+```bash
+cp AGENTS.md ~/HERMES.md
+```
+
+### Project-level (specific projects)
+
+For project-specific guidance, append the contents to your existing project context file. Do not overwrite it, as your project instructions are valuable:
+
+```bash
+cat AGENTS.md >> /path/to/your/project/HERMES.md
+```
+
+Or if the project uses `AGENTS.md`:
+
+```bash
+cat AGENTS.md >> /path/to/your/project/AGENTS.md
+```
+
+Without behavioral guidance, the MCP tools still work, but Hermes relies on its own judgment for when to call them.
 
 ## Remote access
 


### PR DESCRIPTION
…-purpose behavioral guidance

README: Replace destructive `cp` with append/merge guidance. Add global ~/HERMES.md section (Hermes walks to ~ outside git repos, enabling non-dev use for research, writing, planning). Note MCP tool prefix convention (mcp_nowledge_mem_*).

AGENTS.md: Broaden from coding-centric to general-purpose triggers. Remove dev-only language ("debugging", "refactor", "architecture"). Add MCP prefix explanation at top.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Documentation
* Clarified MCP tool naming conventions and prefixes for Hermes integration
* Refined guidance on when to use proactive search and save knowledge based on updated decision and topic criteria
* Enhanced documentation explaining how Hermes discovers configuration files globally and at project level
* Updated example prompts and behavioral guidance instructions for better clarity

<!-- end of auto-generated comment: release notes by coderabbit.ai -->