### PR TITLE
dev branch with 0.6.17: fix codex plugin && new hermes plugin with 0.7.0 memory abstractions!

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 temp*
 
 .DS_Store
+
+__pycache__

--- a/integrations.json
+++ b/integrations.json
@@ -78,7 +78,7 @@
       "name": "Codex CLI",
       "category": "coding",
       "type": "plugin",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "directory": "nowledge-mem-codex-plugin",
       "legacyDirectory": "nowledge-mem-codex-prompts",
       "transport": "cli",
@@ -97,8 +97,9 @@
         "command": "nmem t save --from codex"
       },
       "install": {
-        "command": "Copy nowledge-mem-codex-plugin to ~/.codex/plugins/nowledge-mem or .agents/plugins/nowledge-mem",
-        "updateCommand": "Replace the plugin directory with the latest version from the community repo",
+        "command": "mkdir -p ~/.codex/plugins/cache/local/nowledge-mem/local && cp -r nowledge-mem-codex-plugin/* ~/.codex/plugins/cache/local/nowledge-mem/local/",
+        "updateCommand": "cp -r nowledge-mem-codex-plugin/* ~/.codex/plugins/cache/local/nowledge-mem/local/",
+        "configRequired": "[features] plugins = true AND [plugins.\"nowledge-mem@local\"] enabled = true in ~/.codex/config.toml",
         "detectionHint": "Running as Codex CLI agent; ~/.codex/ exists",
         "docsUrl": "/docs/integrations/codex-cli"
       },

--- a/integrations.json
+++ b/integrations.json
@@ -324,31 +324,33 @@
       "id": "hermes",
       "name": "Hermes Agent",
       "category": "coding",
-      "type": "connector",
-      "version": "0.4.0",
+      "type": "plugin",
+      "version": "0.5.0",
       "directory": "nowledge-mem-hermes",
-      "transport": "mcp",
+      "transport": "cli+http",
       "capabilities": {
         "workingMemory": true,
         "search": true,
-        "distill": true,
-        "autoRecall": false,
+        "distill": false,
+        "autoRecall": true,
         "autoCapture": false,
         "graphExploration": true,
         "status": false
       },
       "threadSave": {
-        "method": "mcp-tool",
-        "note": "thread_persist available via MCP; full transcript depends on client capabilities"
+        "method": "none",
+        "note": "Thread auto-persist planned for v0.6.0 when backend thread creation API is available"
       },
       "install": {
-        "command": "Add nowledge-mem MCP server to ~/.hermes/config.yaml",
+        "command": "bash <(curl -sL https://raw.githubusercontent.com/nowledge-co/community/main/nowledge-mem-hermes/setup.sh)",
+        "updateCommand": "bash <(curl -sL https://raw.githubusercontent.com/nowledge-co/community/main/nowledge-mem-hermes/setup.sh)",
         "detectionHint": "Running as Hermes agent; ~/.hermes/ exists",
         "docsUrl": "/docs/integrations/hermes"
       },
       "toolNaming": {
-        "convention": "mcp-backend",
-        "note": "MCP tools defined by backend (memory_search, memory_add, etc.)"
+        "convention": "provider-native",
+        "note": "Plugin mode: nmem_ prefix (nmem_search, nmem_save, etc.). MCP mode: mcp_nowledge_mem_ prefix.",
+        "tools": ["nmem_search", "nmem_save", "nmem_update", "nmem_delete", "nmem_labels", "nmem_thread_search", "nmem_thread_messages", "nmem_neighbors", "nmem_evolves"]
       },
       "skills": [],
       "slashCommands": []

--- a/integrations.json
+++ b/integrations.json
@@ -327,14 +327,14 @@
       "type": "plugin",
       "version": "0.5.0",
       "directory": "nowledge-mem-hermes",
-      "transport": "cli+http",
+      "transport": "cli",
       "capabilities": {
         "workingMemory": true,
         "search": true,
         "distill": false,
         "autoRecall": true,
         "autoCapture": false,
-        "graphExploration": true,
+        "graphExploration": false,
         "status": false
       },
       "threadSave": {
@@ -350,7 +350,7 @@
       "toolNaming": {
         "convention": "provider-native",
         "note": "Plugin mode: nmem_ prefix (nmem_search, nmem_save, etc.). MCP mode: mcp_nowledge_mem_ prefix.",
-        "tools": ["nmem_search", "nmem_save", "nmem_update", "nmem_delete", "nmem_labels", "nmem_thread_search", "nmem_thread_messages", "nmem_neighbors", "nmem_evolves"]
+        "tools": ["nmem_search", "nmem_save", "nmem_update", "nmem_delete", "nmem_thread_search", "nmem_thread_messages"]
       },
       "skills": [],
       "slashCommands": []

--- a/nowledge-mem-codex-plugin/.codex-plugin/plugin.json
+++ b/nowledge-mem-codex-plugin/.codex-plugin/plugin.json
@@ -1,5 +1,6 @@
 {
   "name": "nowledge-mem",
+  "version": "0.1.1",
   "description": "Your Codex agent remembers past decisions, finds relevant context, and learns from every session, across all your AI tools.",
   "skills": "./skills/",
   "interface": {

--- a/nowledge-mem-codex-plugin/.codex-plugin/plugin.json
+++ b/nowledge-mem-codex-plugin/.codex-plugin/plugin.json
@@ -1,15 +1,6 @@
 {
   "name": "nowledge-mem",
-  "version": "0.1.0",
   "description": "Your Codex agent remembers past decisions, finds relevant context, and learns from every session, across all your AI tools.",
-  "author": {
-    "name": "Nowledge Labs",
-    "url": "https://nowledge-labs.ai"
-  },
-  "homepage": "https://mem.nowledge.co/docs/integrations/codex-cli",
-  "repository": "https://github.com/nowledge-co/community",
-  "license": "MIT",
-  "keywords": ["memory", "context", "knowledge", "recall", "working-memory"],
   "skills": "./skills/",
   "interface": {
     "displayName": "Nowledge Mem",

--- a/nowledge-mem-codex-plugin/CHANGELOG.md
+++ b/nowledge-mem-codex-plugin/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## [0.1.1] - 2026-04-05
+
+### Fixed
+
+- **Install path**: corrected to `~/.codex/plugins/cache/local/nowledge-mem/local/` to match Codex plugin store layout.
+- **Config**: added missing `[features] plugins = true` gate required by Codex to enable the plugin system.
+- **Repo-level install**: replaced incorrect `cp` to `.agents/plugins/` with proper `marketplace.json` approach.
+- **plugin.json**: removed fields Codex does not parse (`version`, `author`, `homepage`, `repository`, `license`, `keywords`).
+- **Troubleshooting**: added "plugin is not installed" entry for path-related failures.
+
 ## [0.1.0] - 2026-03-31
 
 ### Added

--- a/nowledge-mem-codex-plugin/README.md
+++ b/nowledge-mem-codex-plugin/README.md
@@ -68,6 +68,7 @@ Place the plugin source in your repo and create a `marketplace.json` so Codex di
 
 ```bash
 git clone https://github.com/nowledge-co/community.git /tmp/nowledge-community
+mkdir -p .agents
 cp -r /tmp/nowledge-community/nowledge-mem-codex-plugin ./.agents/nowledge-mem
 rm -rf /tmp/nowledge-community
 mkdir -p .agents/plugins

--- a/nowledge-mem-codex-plugin/README.md
+++ b/nowledge-mem-codex-plugin/README.md
@@ -40,23 +40,62 @@ Or `pip install nmem-cli`. Then verify with `nmem status`.
 
 ## Install
 
+### Home-level (all projects)
+
 ```bash
-# Clone the community repo
 git clone https://github.com/nowledge-co/community.git /tmp/nowledge-community
-
-# Home-level install (available in all projects)
-cp -r /tmp/nowledge-community/nowledge-mem-codex-plugin ~/.codex/plugins/nowledge-mem
-
-# Or repo-level install (this project only)
-cp -r /tmp/nowledge-community/nowledge-mem-codex-plugin ./.agents/plugins/nowledge-mem
+mkdir -p ~/.codex/plugins/cache/local/nowledge-mem/local
+cp -r /tmp/nowledge-community/nowledge-mem-codex-plugin/* \
+  ~/.codex/plugins/cache/local/nowledge-mem/local/
+rm -rf /tmp/nowledge-community
 ```
 
-Enable in `~/.codex/config.toml`:
+Add both entries to `~/.codex/config.toml`:
 
 ```toml
+[features]
+plugins = true
+
 [plugins."nowledge-mem@local"]
 enabled = true
 ```
+
+Restart Codex after installation.
+
+### Repo-level (this project only)
+
+Place the plugin source in your repo and create a `marketplace.json` so Codex discovers it:
+
+```bash
+git clone https://github.com/nowledge-co/community.git /tmp/nowledge-community
+cp -r /tmp/nowledge-community/nowledge-mem-codex-plugin ./.agents/nowledge-mem
+rm -rf /tmp/nowledge-community
+mkdir -p .agents/plugins
+```
+
+Create `.agents/plugins/marketplace.json`:
+
+```json
+{
+  "name": "local",
+  "plugins": [
+    {
+      "name": "nowledge-mem",
+      "source": {
+        "source": "local",
+        "path": "./.agents/nowledge-mem"
+      },
+      "policy": {
+        "installation": "INSTALLED_BY_DEFAULT"
+      }
+    }
+  ]
+}
+```
+
+The path is relative to the repo root, not to the `marketplace.json` file.
+
+You still need the feature gate and plugin entry in `~/.codex/config.toml` (see Home-level above). Codex will discover the marketplace on startup and load the plugin from the repo-local source.
 
 ## Verify
 
@@ -65,9 +104,10 @@ Start a new Codex session and ask: "What was I working on?" The agent should loa
 ## Update
 
 ```bash
-cd /tmp && git clone https://github.com/nowledge-co/community.git nowledge-community-update
-cp -r nowledge-community-update/nowledge-mem-codex-plugin ~/.codex/plugins/nowledge-mem
-rm -rf nowledge-community-update
+git clone https://github.com/nowledge-co/community.git /tmp/nowledge-community-update
+cp -r /tmp/nowledge-community-update/nowledge-mem-codex-plugin/* \
+  ~/.codex/plugins/cache/local/nowledge-mem/local/
+rm -rf /tmp/nowledge-community-update
 ```
 
 Restart Codex after updating.
@@ -108,7 +148,8 @@ If you used `nowledge-mem-codex-prompts` before:
 
 - **"Command not found: nmem"**: `pip install nmem-cli` or use `uvx --from nmem-cli nmem`. See [Getting Started](https://mem.nowledge.co/docs/installation).
 - **"Cannot connect to server"**: Run `nmem status`. For remote setups, check `~/.nowledge-mem/config.json`. See [Remote Access](https://mem.nowledge.co/docs/remote-access).
-- **Skills not appearing**: Restart Codex after installing. Verify the plugin is enabled in `~/.codex/config.toml`.
+- **Skills not appearing**: Restart Codex after installing. Verify both `[features] plugins = true` and `[plugins."nowledge-mem@local"] enabled = true` are in `~/.codex/config.toml`.
+- **"plugin is not installed"**: Check that the plugin files are at `~/.codex/plugins/cache/local/nowledge-mem/local/` and that `.codex-plugin/plugin.json` exists inside that directory.
 
 ## Links
 

--- a/nowledge-mem-hermes/AGENTS.md
+++ b/nowledge-mem-hermes/AGENTS.md
@@ -2,19 +2,13 @@
 
 **Core behavior: Read Working Memory at session start. Search proactively when past context would help. Save decisions and learnings without being asked.**
 
-You have access to the user's cross-tool knowledge graph through MCP tools from the `nowledge-mem` server. In Hermes, these tools appear with the `mcp_nowledge_mem_` prefix (e.g., `mcp_nowledge_mem_memory_search`). The guidance below uses the base tool names for readability.
+You have access to the user's cross-tool knowledge graph through six tools. In plugin mode these have the `nmem_` prefix. In MCP mode they appear as `mcp_nowledge_mem_*`. The guidance below uses plugin-mode names.
 
 **Nowledge Mem vs Hermes built-in memory:** Hermes' built-in memory stores Hermes-specific facts (env details, tool quirks). Nowledge Mem stores cross-tool knowledge: decisions, procedures, and learnings that future sessions in any tool should know about. Use both. When in doubt about where to save, ask: "Would this matter in a Claude Code, Cursor, or Codex session?" If yes, save to Nowledge Mem.
 
 ## Working Memory
 
-At session start, load the user's current context:
-
-```
-read_working_memory
-```
-
-This returns priorities, recent decisions, and open questions. If relevant items relate to the current task, mention them briefly. If it returns empty, note there is no briefing yet and continue.
+At session start, load the user's current context. The plugin injects this automatically via the system prompt. If it's empty, note there is no briefing yet and continue.
 
 Do not re-read unless the user asks or the session context changes materially.
 
@@ -35,24 +29,26 @@ Search when past insights would improve the response. Do not wait for the user t
 - User explicitly asks for a fresh perspective
 
 ```
-memory_search query="your search query"
+nmem_search query="your search query"
 ```
 
 For past conversations specifically:
 
 ```
-thread_search query="your search query"
-thread_fetch_messages thread_id="<id>" limit=8
+nmem_thread_search query="your search query"
+nmem_thread_messages thread_id="<id>" limit=8
 ```
 
 ## Saving Knowledge
 
 Save proactively when the conversation produces a decision, procedure, learning, or important context. Do not wait to be asked.
 
-Before calling `memory_add`, do a quick `memory_search` with the key concept. If a matching memory exists, use `memory_update` instead.
+**Upsert by ID:** Pass a stable `id` to `nmem_save` to create-or-update in one call. If a memory with that ID already exists it is updated; otherwise a new one is created. Use this when you have a natural key (e.g. topic or decision name) instead of the search-then-update dance.
+
+Without an `id`, search first with `nmem_search`. If a matching memory exists, use `nmem_update` instead.
 
 ```
-memory_add content="What was decided and why" title="Descriptive title" unit_type="decision" labels=["relevant-label"] importance=0.8
+nmem_save content="What was decided and why" title="Descriptive title" unit_type="decision" labels="relevant-label" importance=0.8
 ```
 
 **Good candidates:** decisions with rationale, repeatable procedures, lessons from experience, durable preferences, plans that future sessions will need.
@@ -73,45 +69,26 @@ Unit types: `fact`, `preference`, `decision`, `plan`, `procedure`, `learning`, `
 Update when the new information refines an existing memory:
 
 ```
-memory_update memory_id="<existing_id>" content="Updated content with new information"
+nmem_update memory_id="<existing_id>" content="Updated content with new information"
 ```
 
 Remove memories that are outdated or incorrect:
 
 ```
-memory_delete memory_id="<id>"
+nmem_delete memory_id="<id>"
 ```
 
 Prefer updating over deleting when the core insight is still valid.
 
-## Graph Exploration
-
-When a memory is relevant but you need broader context:
-
-```
-memory_neighbors memory_id="<id>"
-memory_evolves_chain memory_id="<id>"
-```
-
-`memory_neighbors` discovers related memories and entities. `memory_evolves_chain` traces how a decision or understanding changed over time.
-
 ## Thread Tools
-
-Save the current conversation when the user asks:
-
-```
-thread_persist summary="Brief description of what was discussed"
-```
-
-Be transparent: `thread_persist` creates a structured save based on Hermes' session context. The completeness of the captured transcript depends on what Hermes passes to MCP. This is not guaranteed to be a verbatim record of every message.
 
 Browse past conversations to recover context:
 
 ```
-thread_search query="topic from a previous session"
-thread_fetch_messages thread_id="<id>" limit=8
+nmem_thread_search query="topic from a previous session"
+nmem_thread_messages thread_id="<id>" limit=8
 ```
 
-## Labels
+## Additional MCP Tools
 
-Use `list_memory_labels` to see existing categories before creating new labels. Reuse existing labels when they fit. Apply 1 to 3 labels per memory. Prefer broad categories (e.g., `architecture`, `product-strategy`) over narrow ones.
+In MCP mode, additional graph exploration tools are available: `memory_neighbors` discovers related memories and entities, `memory_evolves_chain` traces how a decision changed over time, and `list_memory_labels` shows existing categories. These are not available in plugin mode.

--- a/nowledge-mem-hermes/CHANGELOG.md
+++ b/nowledge-mem-hermes/CHANGELOG.md
@@ -12,6 +12,7 @@
 - **6 native tools** with clean `nmem_` prefix (e.g. `nmem_search` instead of `mcp_nowledge_mem_memory_search`). Graph tools (neighbors, evolves, labels) deferred until `nmem` CLI adds those commands.
 - **`hermes memory setup` integration** via `get_config_schema()` and `save_config()`.
 - **CLI-only client** (`client.py`) using only stdlib (subprocess + json). Shells out to `nmem` CLI, which handles server URL, API key, and remote access. No duplicate HTTP transport or config surface.
+- **Upsert by ID** on `nmem_save`: pass a stable `id` to create-or-update in one call. Eliminates the search-then-update dance for agents that track their own memory keys.
 
 ### Changed
 

--- a/nowledge-mem-hermes/CHANGELOG.md
+++ b/nowledge-mem-hermes/CHANGELOG.md
@@ -1,5 +1,23 @@
 # Changelog
 
+## [0.5.0] - 2026-04-04
+
+### Added
+
+- **Native memory provider plugin** for Hermes v0.7.0+. Implements the `MemoryProvider` ABC with lifecycle hooks that replace behavioral guidance with deterministic behavior.
+- **Automatic Working Memory injection** via `system_prompt_block()`. No manual `read_working_memory` tool call needed.
+- **Per-turn proactive recall** via `prefetch()`. Relevant memories are searched and injected as context before every LLM call, without relying on SOUL.md guidance compliance.
+- **User profile mirroring** via `on_memory_write()`. When Hermes writes a user fact to its built-in USER.md, the fact is also saved to Nowledge Mem for cross-tool availability.
+- **Compression awareness** via `on_pre_compress()`. The context compressor is told that external knowledge exists and can be recovered via search.
+- **9 native tools** with clean `nmem_` prefix (e.g. `nmem_search` instead of `mcp_nowledge_mem_memory_search`).
+- **`hermes memory setup` integration** via `get_config_schema()` and `save_config()`.
+- **Dual-transport client** (`client.py`) using only stdlib (subprocess + urllib). Prefers `nmem` CLI when available; falls back to HTTP REST when CLI is not installed. Domain methods handle transport dispatch internally.
+
+### Changed
+
+- `setup.sh` now supports `--plugin` (default) and `--mcp` flags for choosing install mode.
+- README rewritten for dual install paths: plugin (recommended) vs MCP-only (alternative).
+
 ## [0.4.0] - 2026-04-02
 
 ### Fixed

--- a/nowledge-mem-hermes/CHANGELOG.md
+++ b/nowledge-mem-hermes/CHANGELOG.md
@@ -9,9 +9,9 @@
 - **Per-turn proactive recall** via `prefetch()`. Relevant memories are searched and injected as context before every LLM call, without relying on SOUL.md guidance compliance.
 - **User profile mirroring** via `on_memory_write()`. When Hermes writes a user fact to its built-in USER.md, the fact is also saved to Nowledge Mem for cross-tool availability.
 - **Compression awareness** via `on_pre_compress()`. The context compressor is told that external knowledge exists and can be recovered via search.
-- **9 native tools** with clean `nmem_` prefix (e.g. `nmem_search` instead of `mcp_nowledge_mem_memory_search`).
+- **6 native tools** with clean `nmem_` prefix (e.g. `nmem_search` instead of `mcp_nowledge_mem_memory_search`). Graph tools (neighbors, evolves, labels) deferred until `nmem` CLI adds those commands.
 - **`hermes memory setup` integration** via `get_config_schema()` and `save_config()`.
-- **Dual-transport client** (`client.py`) using only stdlib (subprocess + urllib). Prefers `nmem` CLI when available; falls back to HTTP REST when CLI is not installed. Domain methods handle transport dispatch internally.
+- **CLI-only client** (`client.py`) using only stdlib (subprocess + json). Shells out to `nmem` CLI, which handles server URL, API key, and remote access. No duplicate HTTP transport or config surface.
 
 ### Changed
 

--- a/nowledge-mem-hermes/README.md
+++ b/nowledge-mem-hermes/README.md
@@ -109,7 +109,7 @@ The only plugin-specific setting is request timeout, stored in `~/.hermes/nowled
 
 ```json
 {
-  "timeout": 60
+  "timeout": 30
 }
 ```
 

--- a/nowledge-mem-hermes/README.md
+++ b/nowledge-mem-hermes/README.md
@@ -52,6 +52,7 @@ This adds the MCP server to `config.yaml` and installs behavioral guidance in `~
 
 1. **Nowledge Mem desktop app** running (or the server accessible on port 14242)
 2. **Hermes Agent** installed and configured
+3. **`nmem` CLI** available on PATH. If the desktop app is on the same machine, `nmem` is already bundled. Otherwise: `pip install nmem-cli`
 
 ## What the plugin does
 
@@ -63,7 +64,7 @@ The plugin uses Hermes' memory provider lifecycle to replace manual tool calls a
 | `prefetch` | Relevant memories searched before each turn | "Search proactively" guidance in SOUL.md |
 | `on_memory_write` | User profile facts from Hermes mirrored to Nowledge Mem | Nothing (new capability) |
 | `on_pre_compress` | Compressor told about external knowledge | Nothing (new capability) |
-| `get_tool_schemas` | 9 native tools with clean names | MCP tools with `mcp_nowledge_mem_` prefix |
+| `get_tool_schemas` | 6 native tools with clean names | MCP tools with `mcp_nowledge_mem_` prefix |
 
 ## Tools
 
@@ -71,15 +72,14 @@ Plugin mode exposes tools directly (no prefix):
 
 | Tool | Purpose |
 |------|---------|
-| `nmem_search` | Search memories or list recent |
+| `nmem_search` | Search memories |
 | `nmem_save` | Save a decision, insight, or learning |
 | `nmem_update` | Refine an existing memory |
 | `nmem_delete` | Remove one or more memories |
-| `nmem_labels` | List labels with usage counts |
 | `nmem_thread_search` | Search past conversations |
 | `nmem_thread_messages` | Fetch messages from a thread |
-| `nmem_neighbors` | Discover related memories via graph |
-| `nmem_evolves` | Trace how a decision changed over time |
+
+Graph exploration tools (`neighbors`, `evolves`, `labels`) will be added when the `nmem` CLI supports them.
 
 ## Hermes memory vs Nowledge Mem
 
@@ -92,27 +92,26 @@ The plugin's `on_memory_write` hook automatically mirrors user profile facts fro
 
 ## Transport
 
-The plugin uses a dual-transport client: it prefers the `nmem` CLI when installed (handles auth, remote URL, API key), and falls back to direct HTTP REST when the CLI is not available. Most tools work through either transport. A few (labels listing, graph exploration) always use HTTP.
+The plugin shells out to the `nmem` CLI for all operations. The CLI handles server URL, API key, and remote access configuration. No duplicate config needed in the plugin.
+
+If `nmem` is not on PATH, the plugin disables gracefully. On machines running the Nowledge Mem desktop app, `nmem` is already bundled. For remote-only setups: `pip install nmem-cli`.
 
 ## Configuration
 
-The plugin reads configuration from (in priority order):
+**No plugin-level configuration needed.** The `nmem` CLI manages server URL and API key. Configure remote access via `nmem`:
 
-1. Environment variables: `NOWLEDGE_MEM_URL`, `NOWLEDGE_MEM_API_KEY`
-2. Config file: `$HERMES_HOME/nowledge-mem.json`
-3. Default: `http://127.0.0.1:14242`
+```bash
+nmem config set url https://your-server:14242
+nmem config set api_key your-key
+```
 
-For remote access:
+The only plugin-specific setting is request timeout, stored in `~/.hermes/nowledge-mem.json`:
 
 ```json
 {
-  "url": "https://your-server:14242",
-  "api_key": "your-api-key",
   "timeout": 60
 }
 ```
-
-Save to `~/.hermes/nowledge-mem.json`, or run `hermes memory setup` and enter the URL when prompted.
 
 ## Verify
 
@@ -124,7 +123,8 @@ Hermes should call `nmem_search` (plugin mode) or `mcp_nowledge_mem_memory_searc
 
 ## Troubleshooting
 
-- **"Nowledge Mem server not reachable"**: Verify the desktop app is running. Check with `curl http://127.0.0.1:14242/health`.
+- **"Nowledge Mem server not reachable"**: Verify the desktop app is running. Check with `nmem status`.
+- **"nmem CLI not found"**: Install with `pip install nmem-cli`, or enable CLI in the desktop app: Settings > Developer Tools.
 - **Tools not appearing (plugin)**: Confirm `memory.provider: "nowledge-mem"` in config.yaml and plugin files exist in `~/.hermes/plugins/memory/nowledge-mem/`. Restart Hermes.
 - **Tools not appearing (MCP)**: Confirm `mcp_servers.nowledge-mem` block in config.yaml. Restart Hermes.
 - **Hermes recalls but never saves**: In MCP mode, behavioral guidance may be missing from SOUL.md. In plugin mode, the guidance is built-in; check that the plugin loaded with `hermes memory status`.

--- a/nowledge-mem-hermes/README.md
+++ b/nowledge-mem-hermes/README.md
@@ -4,130 +4,135 @@
 
 Hermes has its own memory and learning system. Nowledge Mem complements it with knowledge that spans tools: insights from Claude Code, Cursor, Codex, Gemini, and every other environment you work in. One knowledge graph, available everywhere.
 
-## What you get
+## Install
 
-- **Start every session informed.** Hermes loads your Working Memory briefing: current priorities, recent decisions, open questions.
-- **The agent searches for you.** When past context would improve the answer, Hermes finds it through your knowledge graph without being asked.
-- **Insights stick around.** Key decisions and learnings are saved to Nowledge Mem, ready for any future session in any tool.
-- **Session handoff.** Save Hermes conversations as structured threads you can search later. What gets captured depends on Hermes' session context capabilities.
+### Plugin (recommended, Hermes v0.7.0+)
+
+The plugin integrates at the memory-provider level: Working Memory loads automatically, relevant memories are recalled before every turn, and tools use clean names without the `mcp_` prefix.
+
+```bash
+bash <(curl -sL https://raw.githubusercontent.com/nowledge-co/community/main/nowledge-mem-hermes/setup.sh)
+```
+
+Or with the interactive setup:
+
+```bash
+hermes memory setup
+# Select: nowledge-mem
+```
+
+Or manually:
+
+1. Copy plugin files to `~/.hermes/plugins/memory/nowledge-mem/`:
+   ```bash
+   mkdir -p ~/.hermes/plugins/memory/nowledge-mem
+   cd ~/.hermes/plugins/memory/nowledge-mem
+   for f in plugin.yaml __init__.py provider.py client.py; do
+     curl -sLO "https://raw.githubusercontent.com/nowledge-co/community/main/nowledge-mem-hermes/$f"
+   done
+   ```
+2. Set the provider in `~/.hermes/config.yaml`:
+   ```yaml
+   memory:
+     provider: "nowledge-mem"
+   ```
+3. Restart Hermes.
+
+### MCP only (any Hermes version)
+
+If you prefer the standard MCP connection or are on Hermes < v0.7.0:
+
+```bash
+bash <(curl -sL https://raw.githubusercontent.com/nowledge-co/community/main/nowledge-mem-hermes/setup.sh) --mcp
+```
+
+This adds the MCP server to `config.yaml` and installs behavioral guidance in `~/.hermes/SOUL.md`. Tools appear with the `mcp_nowledge_mem_` prefix.
 
 ## Prerequisites
 
 1. **Nowledge Mem desktop app** running (or the server accessible on port 14242)
 2. **Hermes Agent** installed and configured
 
-## Quick setup (one command)
+## What the plugin does
 
-```bash
-bash <(curl -sL https://raw.githubusercontent.com/nowledge-co/community/main/nowledge-mem-hermes/setup.sh)
-```
+The plugin uses Hermes' memory provider lifecycle to replace manual tool calls and behavioral guidance with deterministic hooks:
 
-This configures the MCP server and installs behavioral guidance. Safe to run multiple times. Restart Hermes after running.
+| Hook | What happens | Replaces |
+|------|-------------|----------|
+| `system_prompt_block` | Working Memory injected into every session automatically | Manual `read_working_memory` call |
+| `prefetch` | Relevant memories searched before each turn | "Search proactively" guidance in SOUL.md |
+| `on_memory_write` | User profile facts from Hermes mirrored to Nowledge Mem | Nothing (new capability) |
+| `on_pre_compress` | Compressor told about external knowledge | Nothing (new capability) |
+| `get_tool_schemas` | 9 native tools with clean names | MCP tools with `mcp_nowledge_mem_` prefix |
 
-If you have the repo cloned, run directly:
+## Tools
 
-```bash
-cd community/nowledge-mem-hermes && ./setup.sh
-```
+Plugin mode exposes tools directly (no prefix):
 
-## Manual setup
-
-### Step 1: MCP server
-
-Add the Nowledge Mem MCP server to your Hermes configuration:
-
-```yaml title="~/.hermes/config.yaml"
-mcp_servers:
-  nowledge-mem:
-    url: "http://127.0.0.1:14242/mcp"
-    timeout: 120
-```
-
-### Step 2: Behavioral guidance (required)
-
-Without this step, Hermes sees the tools but does not know when to save knowledge proactively.
-
-Append the guidance to `~/.hermes/SOUL.md` (Hermes loads this file on every session):
-
-```bash
-curl -sL https://raw.githubusercontent.com/nowledge-co/community/main/nowledge-mem-hermes/AGENTS.md >> ~/.hermes/SOUL.md
-```
-
-Restart Hermes after both steps.
-
-> **Why SOUL.md?** Hermes discovers `HERMES.md` by walking from the current directory to the git repository root. If you place guidance at `~/HERMES.md`, it is not found when working inside any git repository. `~/.hermes/SOUL.md` is the only file Hermes loads on every session regardless of working directory.
-
-### Project-level alternative
-
-For project-specific guidance that overrides or supplements the global file, add to your project's git root:
-
-```bash
-curl -sL https://raw.githubusercontent.com/nowledge-co/community/main/nowledge-mem-hermes/AGENTS.md >> HERMES.md
-```
-
-Hermes walks from the current directory to the git root looking for `HERMES.md` or `.hermes.md`. Project-level guidance is loaded in addition to SOUL.md.
-
-## Verify
-
-Start a new Hermes session and ask:
-
-> Search my memories for recent decisions.
-
-Hermes should call `mcp_nowledge_mem_memory_search` and return results from your knowledge graph. If Mem is not running, you will see a connection error.
-
-Then test proactive save by making a decision in conversation. Hermes should save it to Nowledge Mem without being asked. If it doesn't, confirm Step 2 is complete.
-
-## Update
-
-The MCP server runs inside Nowledge Mem. When you update the desktop app, all MCP tools update automatically. No changes to your Hermes config needed.
+| Tool | Purpose |
+|------|---------|
+| `nmem_search` | Search memories or list recent |
+| `nmem_save` | Save a decision, insight, or learning |
+| `nmem_update` | Refine an existing memory |
+| `nmem_delete` | Remove one or more memories |
+| `nmem_labels` | List labels with usage counts |
+| `nmem_thread_search` | Search past conversations |
+| `nmem_thread_messages` | Fetch messages from a thread |
+| `nmem_neighbors` | Discover related memories via graph |
+| `nmem_evolves` | Trace how a decision changed over time |
 
 ## Hermes memory vs Nowledge Mem
 
-Hermes has a built-in memory system for facts within Hermes sessions. Nowledge Mem is complementary: it stores knowledge that spans tools. Use both:
+Hermes has a built-in memory system for facts within Hermes sessions. Nowledge Mem is complementary:
 
 - **Hermes memory**: Hermes-specific preferences, tool quirks, environment details
 - **Nowledge Mem**: Decisions, procedures, and learnings that future sessions in any tool should know about
 
-The behavioral guidance in AGENTS.md teaches Hermes to distinguish between the two.
+The plugin's `on_memory_write` hook automatically mirrors user profile facts from Hermes to Nowledge Mem, so cross-tool knowledge stays in sync.
 
-## MCP tools
+## Transport
 
-These tools are available to Hermes once the MCP server is connected. Hermes prefixes them as `mcp_nowledge_mem_<tool>` (see [Hermes MCP naming convention](https://hermes-agent.ai/docs/user-guide/features/overview)):
+The plugin uses a dual-transport client: it prefers the `nmem` CLI when installed (handles auth, remote URL, API key), and falls back to direct HTTP REST when the CLI is not available. Most tools work through either transport. A few (labels listing, graph exploration) always use HTTP.
 
-| Tool | Purpose |
-|------|---------|
-| `read_working_memory` | Load your daily context briefing |
-| `memory_search` | Search memories and distilled knowledge |
-| `memory_add` | Save a new memory |
-| `memory_update` | Refine an existing memory |
-| `memory_delete` | Remove a memory |
-| `thread_search` | Search past conversations |
-| `thread_fetch_messages` | Read messages from a specific thread |
-| `thread_persist` | Save a conversation thread |
-| `list_memory_labels` | Browse memory categories |
+## Configuration
 
-Additional tools for graph exploration, source analysis, and knowledge processing are available depending on your server configuration.
+The plugin reads configuration from (in priority order):
 
-## Remote access
+1. Environment variables: `NOWLEDGE_MEM_URL`, `NOWLEDGE_MEM_API_KEY`
+2. Config file: `$HERMES_HOME/nowledge-mem.json`
+3. Default: `http://127.0.0.1:14242`
 
-If Nowledge Mem runs on another machine, update the MCP server URL:
+For remote access:
 
-```yaml title="~/.hermes/config.yaml"
-mcp_servers:
-  nowledge-mem:
-    url: "https://your-server:14242/mcp"
-    timeout: 120
+```json
+{
+  "url": "https://your-server:14242",
+  "api_key": "your-api-key",
+  "timeout": 60
+}
 ```
 
-Ensure the remote server has API access enabled. See [Remote Access](https://mem.nowledge.co/docs/remote-access) for setup details.
+Save to `~/.hermes/nowledge-mem.json`, or run `hermes memory setup` and enter the URL when prompted.
+
+## Verify
+
+Start a new Hermes session. You should see Working Memory loaded in the system prompt. Ask:
+
+> Search my memories for recent decisions.
+
+Hermes should call `nmem_search` (plugin mode) or `mcp_nowledge_mem_memory_search` (MCP mode) and return results.
 
 ## Troubleshooting
 
-- **"Cannot connect to MCP server"**: Verify the Nowledge Mem desktop app is running and the server is listening on port 14242. Check with `curl http://127.0.0.1:14242/health`.
-- **Tools not appearing**: Restart Hermes after editing `config.yaml`. Confirm the `mcp_servers` block is properly indented.
-- **Hermes recalls but never saves**: Behavioral guidance is missing from `~/.hermes/SOUL.md`. Run `bash <(curl -sL https://raw.githubusercontent.com/nowledge-co/community/main/nowledge-mem-hermes/setup.sh)` and restart. Note: `~/HERMES.md` is not found inside git repositories; use SOUL.md or a project-level HERMES.md.
-- **Slow responses**: The default timeout of 120 seconds covers deep search. If searches consistently time out, check server performance or network latency for remote setups.
-- **No results from search**: Nowledge Mem may be empty. Add a few memories first through the desktop app or another integration, then try again.
+- **"Nowledge Mem server not reachable"**: Verify the desktop app is running. Check with `curl http://127.0.0.1:14242/health`.
+- **Tools not appearing (plugin)**: Confirm `memory.provider: "nowledge-mem"` in config.yaml and plugin files exist in `~/.hermes/plugins/memory/nowledge-mem/`. Restart Hermes.
+- **Tools not appearing (MCP)**: Confirm `mcp_servers.nowledge-mem` block in config.yaml. Restart Hermes.
+- **Hermes recalls but never saves**: In MCP mode, behavioral guidance may be missing from SOUL.md. In plugin mode, the guidance is built-in; check that the plugin loaded with `hermes memory status`.
+- **Slow responses**: Default timeout is 30 seconds. Increase in `nowledge-mem.json` for remote setups.
+
+## Update
+
+The MCP tools are defined by the Nowledge Mem server. When you update the desktop app, tool capabilities update automatically. For plugin updates, re-run the setup command.
 
 ## Links
 

--- a/nowledge-mem-hermes/__init__.py
+++ b/nowledge-mem-hermes/__init__.py
@@ -1,0 +1,13 @@
+"""Nowledge Mem memory provider plugin for Hermes Agent.
+
+Registers as an external memory provider, replacing the generic MCP
+connection with native lifecycle hooks: automatic Working Memory
+injection, per-turn recall, user-profile mirroring, and native tools.
+"""
+
+from provider import NowledgeMemProvider
+
+
+def register(ctx) -> None:
+    """Plugin entry point called by Hermes plugin loader."""
+    ctx.register_memory_provider(NowledgeMemProvider())

--- a/nowledge-mem-hermes/client.py
+++ b/nowledge-mem-hermes/client.py
@@ -1,0 +1,346 @@
+"""Dual-transport client for Nowledge Mem.
+
+Prefers the ``nmem`` CLI when available (handles auth, remote URL, API key
+out of the box). Falls back to direct HTTP REST when the CLI is not
+installed, useful for Hermes built-in distribution where users may not
+have ``nmem`` separately.
+
+Domain methods (search, save, update, ...) handle transport dispatch
+internally. The caller never needs to know whether CLI or HTTP is used.
+
+No external dependencies: stdlib only (subprocess, urllib).
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import subprocess
+import urllib.error
+import urllib.parse
+import urllib.request
+from typing import Any, Dict, List, Optional
+
+logger = logging.getLogger(__name__)
+
+
+class NowledgeMemClient:
+    """Dual-transport client: nmem CLI (preferred) or HTTP REST (fallback).
+
+    The CLI transport shells out to ``nmem --json <args>``. The CLI already
+    handles server URL, API key, and remote access.
+
+    The HTTP transport calls the REST API directly, using a configurable
+    URL and optional API key header.
+
+    Domain methods try CLI first when available, falling back to HTTP for
+    operations the CLI does not support (labels listing, graph exploration)
+    or when CLI arguments are insufficient (empty search query).
+    """
+
+    def __init__(
+        self,
+        url: str = "http://127.0.0.1:14242",
+        api_key: str = "",
+        timeout: int = 30,
+    ) -> None:
+        self._url = url.rstrip("/")
+        self._api_key = api_key
+        self._timeout = timeout
+        self.use_cli = self._detect_cli()
+
+    @property
+    def transport(self) -> str:
+        return "cli" if self.use_cli else "http"
+
+    # ── Domain methods ───────────────────────────────────────────────────
+
+    def health(self) -> bool:
+        """Check that the server (or CLI) is reachable."""
+        if self.use_cli:
+            try:
+                r = subprocess.run(
+                    ["nmem", "--json", "status"],
+                    capture_output=True,
+                    text=True,
+                    timeout=5,
+                )
+                return r.returncode == 0
+            except Exception:
+                return False
+        try:
+            data = self._http_get("/health")
+            return data.get("status") in ("ok", "degraded")
+        except Exception:
+            return False
+
+    def working_memory(self) -> Dict[str, Any]:
+        """Fetch the user's Working Memory briefing."""
+        if self.use_cli:
+            return self._cli(["wm", "read"])
+        return self._http_get("/working-memory")
+
+    def search(
+        self,
+        query: str = "",
+        *,
+        limit: int = 10,
+        filter_labels: Optional[List[str]] = None,
+        mode: Optional[str] = None,
+    ) -> Any:
+        """Search memories. Omit query to list recent."""
+        # CLI requires a positional query; fall back to HTTP for empty query
+        if self.use_cli and query:
+            cmd = ["m", "search", query]
+            if limit != 10:
+                cmd.extend(["-n", str(limit)])
+            if filter_labels:
+                for lbl in filter_labels:
+                    cmd.extend(["-l", lbl])
+            if mode == "deep":
+                cmd.extend(["--mode", "deep"])
+            return self._cli(cmd)
+        body: dict = {"query": query, "limit": limit}
+        if filter_labels:
+            body["filter_labels"] = filter_labels
+        if mode:
+            body["mode"] = mode
+        return self._http_post("/memories/search", body)
+
+    def save(
+        self,
+        content: str,
+        *,
+        title: Optional[str] = None,
+        importance: Optional[float] = None,
+        labels: Optional[List[str]] = None,
+        unit_type: Optional[str] = None,
+        event_date: Optional[str] = None,
+    ) -> Any:
+        """Save a new memory."""
+        if self.use_cli:
+            cmd = ["m", "add", content]
+            if title:
+                cmd.extend(["-t", title])
+            if importance is not None:
+                cmd.extend(["-i", str(importance)])
+            if labels:
+                for lbl in labels:
+                    cmd.extend(["-l", lbl])
+            if unit_type:
+                cmd.extend(["--unit-type", unit_type])
+            if event_date:
+                cmd.extend(["--event-start", event_date])
+            return self._cli(cmd)
+        body: dict = {"content": content}
+        if title:
+            body["title"] = title
+        if importance is not None:
+            body["importance"] = importance
+        if labels:
+            body["labels"] = labels
+        if unit_type:
+            body["unit_type"] = unit_type
+        if event_date:
+            body["event_start"] = event_date
+        return self._http_post("/memories", body)
+
+    def update(
+        self,
+        memory_id: str,
+        *,
+        content: Optional[str] = None,
+        title: Optional[str] = None,
+        importance: Optional[float] = None,
+        add_labels: Optional[List[str]] = None,
+    ) -> Any:
+        """Update an existing memory.
+
+        Labels are additive (``add_labels``). The CLI ``nmem m update``
+        does not support label changes, so label updates always go
+        through HTTP.
+        """
+        if self.use_cli and not add_labels:
+            cmd = ["m", "update", memory_id]
+            if content:
+                cmd.extend(["-c", content])
+            if title:
+                cmd.extend(["-t", title])
+            if importance is not None:
+                cmd.extend(["-i", str(importance)])
+            return self._cli(cmd)
+        body: dict = {}
+        if content:
+            body["content"] = content
+        if title:
+            body["title"] = title
+        if importance is not None:
+            body["importance"] = importance
+        if add_labels:
+            body["add_labels"] = add_labels
+        return self._http_patch(f"/memories/{memory_id}", body)
+
+    def delete(self, memory_id: str) -> Any:
+        """Delete a single memory."""
+        if self.use_cli:
+            return self._cli(["m", "delete", memory_id, "-f"])
+        return self._http_delete(f"/memories/{memory_id}")
+
+    def delete_many(self, memory_ids: List[str]) -> Any:
+        """Delete multiple memories."""
+        if self.use_cli:
+            return self._cli(["m", "delete"] + memory_ids + ["-f"])
+        results = []
+        for mid in memory_ids:
+            results.append(self._http_delete(f"/memories/{mid}"))
+        return {"deleted": len(results)}
+
+    def list_labels(self) -> Any:
+        """List labels with usage counts. HTTP-only (no CLI command)."""
+        return self._http_get("/labels")
+
+    def thread_search(
+        self,
+        query: str = "",
+        *,
+        limit: int = 10,
+        source: Optional[str] = None,
+    ) -> Any:
+        """Search past conversations. Omit query to list recent."""
+        # CLI requires positional query; fall back to HTTP when empty
+        if self.use_cli and query:
+            cmd = ["t", "search", query]
+            if limit != 10:
+                cmd.extend(["-n", str(limit)])
+            if source:
+                cmd.extend(["--source", source])
+            return self._cli(cmd)
+        params: Dict[str, str] = {}
+        if query:
+            params["query"] = query
+        if limit != 10:
+            params["limit"] = str(limit)
+        if source:
+            params["source"] = source
+        return self._http_get("/threads/search", params)
+
+    def thread_messages(
+        self,
+        thread_id: str,
+        *,
+        limit: int = 50,
+        offset: int = 0,
+    ) -> Any:
+        """Fetch messages from a thread."""
+        if self.use_cli:
+            cmd = ["t", "show", thread_id]
+            if limit != 50:
+                cmd.extend(["-n", str(limit)])
+            if offset:
+                cmd.extend(["--offset", str(offset)])
+            return self._cli(cmd)
+        params: Dict[str, str] = {}
+        if limit != 50:
+            params["limit"] = str(limit)
+        if offset:
+            params["offset"] = str(offset)
+        return self._http_get(f"/threads/{thread_id}", params)
+
+    def neighbors(self, memory_id: str) -> Any:
+        """Discover related memories via graph. HTTP-only (no CLI command)."""
+        return self._http_get(f"/graph/expand/{memory_id}")
+
+    def evolves(self, memory_id: str) -> Any:
+        """Trace how a memory evolved over time. HTTP-only (no CLI command)."""
+        return self._http_get("/evolves", {"memory_id": memory_id})
+
+    # ── Transport internals ──────────────────────────────────────────────
+
+    @staticmethod
+    def _detect_cli() -> bool:
+        try:
+            r = subprocess.run(
+                ["nmem", "--version"],
+                capture_output=True,
+                text=True,
+                timeout=5,
+            )
+            return r.returncode == 0
+        except Exception:
+            return False
+
+    def _cli(self, args: List[str]) -> Any:
+        """Run ``nmem --json <args>`` and return parsed JSON."""
+        cmd = ["nmem", "--json"] + args
+        try:
+            r = subprocess.run(
+                cmd, capture_output=True, text=True, timeout=self._timeout
+            )
+        except FileNotFoundError:
+            raise RuntimeError(
+                "nmem CLI not found. Install from Nowledge Mem: "
+                "Settings > Developer Tools > Install CLI"
+            )
+        if r.returncode != 0:
+            stderr = r.stderr.strip()
+            raise RuntimeError(stderr or f"nmem exited with code {r.returncode}")
+        output = r.stdout.strip()
+        if not output:
+            return {}
+        try:
+            return json.loads(output)
+        except json.JSONDecodeError as e:
+            raise RuntimeError(
+                f"nmem returned non-JSON output: {output[:200]}"
+            ) from e
+
+    def _http_get(
+        self, path: str, params: Optional[Dict[str, str]] = None
+    ) -> Any:
+        url = f"{self._url}{path}"
+        if params:
+            qs = urllib.parse.urlencode(
+                {k: v for k, v in params.items() if v is not None}
+            )
+            url = f"{url}?{qs}"
+        req = urllib.request.Request(url, headers=self._headers())
+        try:
+            resp = urllib.request.urlopen(req, timeout=self._timeout)
+        except urllib.error.HTTPError as e:
+            body_text = e.read().decode("utf-8", errors="replace")
+            raise RuntimeError(
+                f"HTTP {e.code} GET {path}: {body_text[:300]}"
+            )
+        return json.loads(resp.read().decode("utf-8"))
+
+    def _http_post(self, path: str, body: Optional[dict] = None) -> Any:
+        return self._http_request("POST", path, body)
+
+    def _http_patch(self, path: str, body: Optional[dict] = None) -> Any:
+        return self._http_request("PATCH", path, body)
+
+    def _http_delete(self, path: str) -> Any:
+        return self._http_request("DELETE", path)
+
+    def _http_request(
+        self, method: str, path: str, body: Optional[dict] = None
+    ) -> Any:
+        url = f"{self._url}{path}"
+        data = json.dumps(body).encode("utf-8") if body else None
+        headers = {**self._headers(), "Content-Type": "application/json"}
+        req = urllib.request.Request(url, data, headers, method=method)
+        try:
+            resp = urllib.request.urlopen(req, timeout=self._timeout)
+        except urllib.error.HTTPError as e:
+            body_text = e.read().decode("utf-8", errors="replace")
+            raise RuntimeError(
+                f"HTTP {e.code} {method} {path}: {body_text[:300]}"
+            )
+        raw = resp.read().decode("utf-8")
+        return json.loads(raw) if raw.strip() else {}
+
+    def _headers(self) -> Dict[str, str]:
+        h: Dict[str, str] = {"Accept": "application/json"}
+        if self._api_key:
+            h["X-API-Key"] = self._api_key
+        return h

--- a/nowledge-mem-hermes/client.py
+++ b/nowledge-mem-hermes/client.py
@@ -141,7 +141,9 @@ class NowledgeMemClient:
 
     def delete_many(self, memory_ids: List[str]) -> Any:
         """Delete multiple memories."""
-        return self._cli(["m", "delete"] + memory_ids + ["-f"])
+        if not memory_ids:
+            raise ValueError("memory_ids must not be empty")
+        return self._cli(["m", "delete", *memory_ids, "-f"])
 
     def thread_search(
         self,

--- a/nowledge-mem-hermes/client.py
+++ b/nowledge-mem-hermes/client.py
@@ -1,14 +1,13 @@
-"""Dual-transport client for Nowledge Mem.
+"""CLI-only client for Nowledge Mem.
 
-Prefers the ``nmem`` CLI when available (handles auth, remote URL, API key
-out of the box). Falls back to direct HTTP REST when the CLI is not
-installed, useful for Hermes built-in distribution where users may not
-have ``nmem`` separately.
+Shells out to ``nmem --json <args>``. The CLI handles server URL, API key,
+and remote access configuration, so this client has zero config surface.
 
-Domain methods (search, save, update, ...) handle transport dispatch
-internally. The caller never needs to know whether CLI or HTTP is used.
+If ``nmem`` is not installed, ``is_available`` returns False and the
+provider gracefully disables tools. On machines running the Nowledge Mem
+desktop app, ``nmem`` is already bundled. Otherwise: ``pip install nmem-cli``.
 
-No external dependencies: stdlib only (subprocess, urllib).
+No external dependencies: stdlib only (subprocess, json).
 """
 
 from __future__ import annotations
@@ -16,69 +15,55 @@ from __future__ import annotations
 import json
 import logging
 import subprocess
-import urllib.error
-import urllib.parse
-import urllib.request
 from typing import Any, Dict, List, Optional
 
 logger = logging.getLogger(__name__)
 
 
 class NowledgeMemClient:
-    """Dual-transport client: nmem CLI (preferred) or HTTP REST (fallback).
+    """Thin wrapper around the ``nmem`` CLI.
 
-    The CLI transport shells out to ``nmem --json <args>``. The CLI already
-    handles server URL, API key, and remote access.
-
-    The HTTP transport calls the REST API directly, using a configurable
-    URL and optional API key header.
-
-    Domain methods try CLI first when available, falling back to HTTP for
-    operations the CLI does not support (labels listing, graph exploration)
-    or when CLI arguments are insufficient (empty search query).
+    Every domain method builds CLI args and calls ``nmem --json <args>``.
+    The CLI owns auth, server URL, and remote config.
     """
 
-    def __init__(
-        self,
-        url: str = "http://127.0.0.1:14242",
-        api_key: str = "",
-        timeout: int = 30,
-    ) -> None:
-        self._url = url.rstrip("/")
-        self._api_key = api_key
+    def __init__(self, timeout: int = 30) -> None:
         self._timeout = timeout
-        self.use_cli = self._detect_cli()
 
-    @property
-    def transport(self) -> str:
-        return "cli" if self.use_cli else "http"
+    # -- Detection -----------------------------------------------------------
 
-    # ── Domain methods ───────────────────────────────────────────────────
+    @staticmethod
+    def is_available() -> bool:
+        """Return True if ``nmem`` CLI is on PATH and responds."""
+        try:
+            r = subprocess.run(
+                ["nmem", "--version"],
+                capture_output=True,
+                text=True,
+                timeout=5,
+            )
+            return r.returncode == 0
+        except Exception:
+            return False
+
+    # -- Domain methods ------------------------------------------------------
 
     def health(self) -> bool:
-        """Check that the server (or CLI) is reachable."""
-        if self.use_cli:
-            try:
-                r = subprocess.run(
-                    ["nmem", "--json", "status"],
-                    capture_output=True,
-                    text=True,
-                    timeout=5,
-                )
-                return r.returncode == 0
-            except Exception:
-                return False
+        """Check that Nowledge Mem is reachable."""
         try:
-            data = self._http_get("/health")
-            return data.get("status") in ("ok", "degraded")
+            r = subprocess.run(
+                ["nmem", "--json", "status"],
+                capture_output=True,
+                text=True,
+                timeout=5,
+            )
+            return r.returncode == 0
         except Exception:
             return False
 
     def working_memory(self) -> Dict[str, Any]:
         """Fetch the user's Working Memory briefing."""
-        if self.use_cli:
-            return self._cli(["wm", "read"])
-        return self._http_get("/working-memory")
+        return self._cli(["wm", "read"])
 
     def search(
         self,
@@ -88,24 +73,18 @@ class NowledgeMemClient:
         filter_labels: Optional[List[str]] = None,
         mode: Optional[str] = None,
     ) -> Any:
-        """Search memories. Omit query to list recent."""
-        # CLI requires a positional query; fall back to HTTP for empty query
-        if self.use_cli and query:
-            cmd = ["m", "search", query]
-            if limit != 10:
-                cmd.extend(["-n", str(limit)])
-            if filter_labels:
-                for lbl in filter_labels:
-                    cmd.extend(["-l", lbl])
-            if mode == "deep":
-                cmd.extend(["--mode", "deep"])
-            return self._cli(cmd)
-        body: dict = {"query": query, "limit": limit}
+        """Search memories. CLI requires a query string."""
+        if not query:
+            return {"memories": []}
+        cmd = ["m", "search", query]
+        if limit != 10:
+            cmd.extend(["-n", str(limit)])
         if filter_labels:
-            body["filter_labels"] = filter_labels
-        if mode:
-            body["mode"] = mode
-        return self._http_post("/memories/search", body)
+            for lbl in filter_labels:
+                cmd.extend(["-l", lbl])
+        if mode == "deep":
+            cmd.extend(["--mode", "deep"])
+        return self._cli(cmd)
 
     def save(
         self,
@@ -118,32 +97,19 @@ class NowledgeMemClient:
         event_date: Optional[str] = None,
     ) -> Any:
         """Save a new memory."""
-        if self.use_cli:
-            cmd = ["m", "add", content]
-            if title:
-                cmd.extend(["-t", title])
-            if importance is not None:
-                cmd.extend(["-i", str(importance)])
-            if labels:
-                for lbl in labels:
-                    cmd.extend(["-l", lbl])
-            if unit_type:
-                cmd.extend(["--unit-type", unit_type])
-            if event_date:
-                cmd.extend(["--event-start", event_date])
-            return self._cli(cmd)
-        body: dict = {"content": content}
+        cmd = ["m", "add", content]
         if title:
-            body["title"] = title
+            cmd.extend(["-t", title])
         if importance is not None:
-            body["importance"] = importance
+            cmd.extend(["-i", str(importance)])
         if labels:
-            body["labels"] = labels
+            for lbl in labels:
+                cmd.extend(["-l", lbl])
         if unit_type:
-            body["unit_type"] = unit_type
+            cmd.extend(["--unit-type", unit_type])
         if event_date:
-            body["event_start"] = event_date
-        return self._http_post("/memories", body)
+            cmd.extend(["--event-start", event_date])
+        return self._cli(cmd)
 
     def update(
         self,
@@ -152,52 +118,27 @@ class NowledgeMemClient:
         content: Optional[str] = None,
         title: Optional[str] = None,
         importance: Optional[float] = None,
-        add_labels: Optional[List[str]] = None,
     ) -> Any:
-        """Update an existing memory.
+        """Update an existing memory (content, title, importance).
 
-        Labels are additive (``add_labels``). The CLI ``nmem m update``
-        does not support label changes, so label updates always go
-        through HTTP.
+        Label changes are not supported by ``nmem m update`` yet.
         """
-        if self.use_cli and not add_labels:
-            cmd = ["m", "update", memory_id]
-            if content:
-                cmd.extend(["-c", content])
-            if title:
-                cmd.extend(["-t", title])
-            if importance is not None:
-                cmd.extend(["-i", str(importance)])
-            return self._cli(cmd)
-        body: dict = {}
+        cmd = ["m", "update", memory_id]
         if content:
-            body["content"] = content
+            cmd.extend(["-c", content])
         if title:
-            body["title"] = title
+            cmd.extend(["-t", title])
         if importance is not None:
-            body["importance"] = importance
-        if add_labels:
-            body["add_labels"] = add_labels
-        return self._http_patch(f"/memories/{memory_id}", body)
+            cmd.extend(["-i", str(importance)])
+        return self._cli(cmd)
 
     def delete(self, memory_id: str) -> Any:
         """Delete a single memory."""
-        if self.use_cli:
-            return self._cli(["m", "delete", memory_id, "-f"])
-        return self._http_delete(f"/memories/{memory_id}")
+        return self._cli(["m", "delete", memory_id, "-f"])
 
     def delete_many(self, memory_ids: List[str]) -> Any:
         """Delete multiple memories."""
-        if self.use_cli:
-            return self._cli(["m", "delete"] + memory_ids + ["-f"])
-        results = []
-        for mid in memory_ids:
-            results.append(self._http_delete(f"/memories/{mid}"))
-        return {"deleted": len(results)}
-
-    def list_labels(self) -> Any:
-        """List labels with usage counts. HTTP-only (no CLI command)."""
-        return self._http_get("/labels")
+        return self._cli(["m", "delete"] + memory_ids + ["-f"])
 
     def thread_search(
         self,
@@ -206,23 +147,15 @@ class NowledgeMemClient:
         limit: int = 10,
         source: Optional[str] = None,
     ) -> Any:
-        """Search past conversations. Omit query to list recent."""
-        # CLI requires positional query; fall back to HTTP when empty
-        if self.use_cli and query:
-            cmd = ["t", "search", query]
-            if limit != 10:
-                cmd.extend(["-n", str(limit)])
-            if source:
-                cmd.extend(["--source", source])
-            return self._cli(cmd)
-        params: Dict[str, str] = {}
-        if query:
-            params["query"] = query
+        """Search past conversations. CLI requires a query string."""
+        if not query:
+            return {"threads": []}
+        cmd = ["t", "search", query]
         if limit != 10:
-            params["limit"] = str(limit)
+            cmd.extend(["-n", str(limit)])
         if source:
-            params["source"] = source
-        return self._http_get("/threads/search", params)
+            cmd.extend(["--source", source])
+        return self._cli(cmd)
 
     def thread_messages(
         self,
@@ -232,42 +165,14 @@ class NowledgeMemClient:
         offset: int = 0,
     ) -> Any:
         """Fetch messages from a thread."""
-        if self.use_cli:
-            cmd = ["t", "show", thread_id]
-            if limit != 50:
-                cmd.extend(["-n", str(limit)])
-            if offset:
-                cmd.extend(["--offset", str(offset)])
-            return self._cli(cmd)
-        params: Dict[str, str] = {}
+        cmd = ["t", "show", thread_id]
         if limit != 50:
-            params["limit"] = str(limit)
+            cmd.extend(["-n", str(limit)])
         if offset:
-            params["offset"] = str(offset)
-        return self._http_get(f"/threads/{thread_id}", params)
+            cmd.extend(["--offset", str(offset)])
+        return self._cli(cmd)
 
-    def neighbors(self, memory_id: str) -> Any:
-        """Discover related memories via graph. HTTP-only (no CLI command)."""
-        return self._http_get(f"/graph/expand/{memory_id}")
-
-    def evolves(self, memory_id: str) -> Any:
-        """Trace how a memory evolved over time. HTTP-only (no CLI command)."""
-        return self._http_get("/evolves", {"memory_id": memory_id})
-
-    # ── Transport internals ──────────────────────────────────────────────
-
-    @staticmethod
-    def _detect_cli() -> bool:
-        try:
-            r = subprocess.run(
-                ["nmem", "--version"],
-                capture_output=True,
-                text=True,
-                timeout=5,
-            )
-            return r.returncode == 0
-        except Exception:
-            return False
+    # -- Transport -----------------------------------------------------------
 
     def _cli(self, args: List[str]) -> Any:
         """Run ``nmem --json <args>`` and return parsed JSON."""
@@ -278,8 +183,8 @@ class NowledgeMemClient:
             )
         except FileNotFoundError:
             raise RuntimeError(
-                "nmem CLI not found. Install from Nowledge Mem: "
-                "Settings > Developer Tools > Install CLI"
+                "nmem CLI not found. Install: pip install nmem-cli, "
+                "or enable CLI in Nowledge Mem: Settings > Developer Tools"
             )
         if r.returncode != 0:
             stderr = r.stderr.strip()
@@ -293,54 +198,3 @@ class NowledgeMemClient:
             raise RuntimeError(
                 f"nmem returned non-JSON output: {output[:200]}"
             ) from e
-
-    def _http_get(
-        self, path: str, params: Optional[Dict[str, str]] = None
-    ) -> Any:
-        url = f"{self._url}{path}"
-        if params:
-            qs = urllib.parse.urlencode(
-                {k: v for k, v in params.items() if v is not None}
-            )
-            url = f"{url}?{qs}"
-        req = urllib.request.Request(url, headers=self._headers())
-        try:
-            resp = urllib.request.urlopen(req, timeout=self._timeout)
-        except urllib.error.HTTPError as e:
-            body_text = e.read().decode("utf-8", errors="replace")
-            raise RuntimeError(
-                f"HTTP {e.code} GET {path}: {body_text[:300]}"
-            )
-        return json.loads(resp.read().decode("utf-8"))
-
-    def _http_post(self, path: str, body: Optional[dict] = None) -> Any:
-        return self._http_request("POST", path, body)
-
-    def _http_patch(self, path: str, body: Optional[dict] = None) -> Any:
-        return self._http_request("PATCH", path, body)
-
-    def _http_delete(self, path: str) -> Any:
-        return self._http_request("DELETE", path)
-
-    def _http_request(
-        self, method: str, path: str, body: Optional[dict] = None
-    ) -> Any:
-        url = f"{self._url}{path}"
-        data = json.dumps(body).encode("utf-8") if body else None
-        headers = {**self._headers(), "Content-Type": "application/json"}
-        req = urllib.request.Request(url, data, headers, method=method)
-        try:
-            resp = urllib.request.urlopen(req, timeout=self._timeout)
-        except urllib.error.HTTPError as e:
-            body_text = e.read().decode("utf-8", errors="replace")
-            raise RuntimeError(
-                f"HTTP {e.code} {method} {path}: {body_text[:300]}"
-            )
-        raw = resp.read().decode("utf-8")
-        return json.loads(raw) if raw.strip() else {}
-
-    def _headers(self) -> Dict[str, str]:
-        h: Dict[str, str] = {"Accept": "application/json"}
-        if self._api_key:
-            h["X-API-Key"] = self._api_key
-        return h

--- a/nowledge-mem-hermes/client.py
+++ b/nowledge-mem-hermes/client.py
@@ -90,14 +90,17 @@ class NowledgeMemClient:
         self,
         content: str,
         *,
+        memory_id: Optional[str] = None,
         title: Optional[str] = None,
         importance: Optional[float] = None,
         labels: Optional[List[str]] = None,
         unit_type: Optional[str] = None,
         event_date: Optional[str] = None,
     ) -> Any:
-        """Save a new memory."""
+        """Save a new memory, or upsert by memory_id."""
         cmd = ["m", "add", content]
+        if memory_id:
+            cmd.extend(["--id", memory_id])
         if title:
             cmd.extend(["-t", title])
         if importance is not None:

--- a/nowledge-mem-hermes/plugin.yaml
+++ b/nowledge-mem-hermes/plugin.yaml
@@ -1,0 +1,4 @@
+name: nowledge-mem
+version: 0.5.0
+description: "Cross-tool personal knowledge graph with semantic search, Working Memory, and proactive recall."
+author: Nowledge Labs

--- a/nowledge-mem-hermes/provider.py
+++ b/nowledge-mem-hermes/provider.py
@@ -5,8 +5,9 @@ user's cross-tool knowledge graph. Replaces the generic MCP connection
 with lifecycle hooks: automatic Working Memory injection, per-turn
 recall, user-profile mirroring, and native tool names.
 
-Transport: the client handles CLI vs HTTP dispatch internally.
-The provider is transport-agnostic.
+Transport: ``nmem`` CLI only. The CLI handles server URL, API key, and
+remote access. If ``nmem`` is not installed, the provider disables
+gracefully.
 
 Requires Hermes v0.7.0+ (MemoryProvider support).
 """
@@ -44,13 +45,7 @@ Claude Code, Cursor, or Codex session?" If yes, save to Nowledge Mem.
 Save proactively when the conversation produces a decision, procedure, \
 learning, or important context. Search first (nmem_search); if existing \
 knowledge covers the topic, use nmem_update rather than create a duplicate. \
-One strong memory is better than three weak ones.
-
-Graph exploration: nmem_neighbors discovers related memories and entities. \
-nmem_evolves traces how a decision changed over time.
-
-Labels: check existing with nmem_labels before creating new ones. \
-Use 1-3 per memory, prefer broad categories."""
+One strong memory is better than three weak ones."""
 
 
 # ---------------------------------------------------------------------------
@@ -60,16 +55,15 @@ Use 1-3 per memory, prefer broad categories."""
 _SEARCH = {
     "name": "nmem_search",
     "description": (
-        "Search stored memories or list recent. "
-        "Omit query to list. Supports label filtering, temporal filtering, "
-        "and deep search mode."
+        "Search stored memories. "
+        "Supports label filtering and deep search mode."
     ),
     "parameters": {
         "type": "object",
         "properties": {
             "query": {
                 "type": "string",
-                "description": "Search query. Omit to list recent memories.",
+                "description": "Search query.",
             },
             "limit": {
                 "type": "integer",
@@ -84,7 +78,7 @@ _SEARCH = {
                 "description": "'normal' (fast, default) or 'deep' (graph-enhanced).",
             },
         },
-        "required": [],
+        "required": ["query"],
     },
 }
 
@@ -147,10 +141,6 @@ _UPDATE = {
                 "type": "number",
                 "description": "Updated importance (omit to keep current).",
             },
-            "add_labels": {
-                "type": "string",
-                "description": "Labels to add, comma-separated (omit to keep current).",
-            },
         },
         "required": ["memory_id"],
     },
@@ -179,16 +169,10 @@ _DELETE = {
     },
 }
 
-_LABELS = {
-    "name": "nmem_labels",
-    "description": "List labels with usage counts.",
-    "parameters": {"type": "object", "properties": {}, "required": []},
-}
-
 _THREAD_SEARCH = {
     "name": "nmem_thread_search",
     "description": (
-        "Search past conversations or list recent. "
+        "Search past conversations. "
         "Returns threads with matched message snippets."
     ),
     "parameters": {
@@ -196,7 +180,7 @@ _THREAD_SEARCH = {
         "properties": {
             "query": {
                 "type": "string",
-                "description": "Search query. Omit to list recent threads.",
+                "description": "Search query.",
             },
             "limit": {
                 "type": "integer",
@@ -207,7 +191,7 @@ _THREAD_SEARCH = {
                 "description": "Filter by source (e.g. 'claude-code', 'hermes').",
             },
         },
-        "required": [],
+        "required": ["query"],
     },
 }
 
@@ -231,48 +215,13 @@ _THREAD_MESSAGES = {
     },
 }
 
-_NEIGHBORS = {
-    "name": "nmem_neighbors",
-    "description": (
-        "Discover related memories and entities via knowledge graph connections."
-    ),
-    "parameters": {
-        "type": "object",
-        "properties": {
-            "memory_id": {
-                "type": "string",
-                "description": "Memory ID to explore from.",
-            },
-        },
-        "required": ["memory_id"],
-    },
-}
-
-_EVOLVES = {
-    "name": "nmem_evolves",
-    "description": "Trace how a decision or understanding changed over time.",
-    "parameters": {
-        "type": "object",
-        "properties": {
-            "memory_id": {
-                "type": "string",
-                "description": "Memory ID to trace.",
-            },
-        },
-        "required": ["memory_id"],
-    },
-}
-
 ALL_TOOL_SCHEMAS = [
     _SEARCH,
     _SAVE,
     _UPDATE,
     _DELETE,
-    _LABELS,
     _THREAD_SEARCH,
     _THREAD_MESSAGES,
-    _NEIGHBORS,
-    _EVOLVES,
 ]
 
 
@@ -304,10 +253,8 @@ class NowledgeMemProvider(MemoryProvider):
     # -- Core lifecycle ------------------------------------------------------
 
     def is_available(self) -> bool:
-        """Check if nmem CLI is installed or HTTP URL is configured."""
-        if NowledgeMemClient._detect_cli():
-            return True
-        return bool(os.environ.get("NOWLEDGE_MEM_URL"))
+        """Check if nmem CLI is installed."""
+        return NowledgeMemClient.is_available()
 
     def initialize(self, session_id: str, **kwargs: Any) -> None:
         agent_context = kwargs.get("agent_context", "")
@@ -323,17 +270,11 @@ class NowledgeMemProvider(MemoryProvider):
             self._cron_skipped = True
             return
 
-        hermes_home = kwargs.get("hermes_home", "")
-        url, api_key, timeout = self._load_config(hermes_home)
-
-        self._client = NowledgeMemClient(url=url, api_key=api_key, timeout=timeout)
+        timeout = self._load_timeout(kwargs.get("hermes_home", ""))
+        self._client = NowledgeMemClient(timeout=timeout)
 
         if not self._client.health():
-            logger.warning(
-                "Nowledge Mem not reachable (transport=%s, url=%s)",
-                self._client.transport,
-                url,
-            )
+            logger.warning("Nowledge Mem not reachable via nmem CLI")
             self._client = None
             return
 
@@ -345,11 +286,7 @@ class NowledgeMemProvider(MemoryProvider):
             logger.debug("Working memory fetch failed: %s", e)
             self._working_memory = ""
 
-        logger.info(
-            "Nowledge Mem provider initialized (transport=%s, url=%s)",
-            self._client.transport,
-            url,
-        )
+        logger.info("Nowledge Mem provider initialized (CLI transport)")
 
     def system_prompt_block(self) -> str:
         if self._cron_skipped:
@@ -471,7 +408,6 @@ class NowledgeMemProvider(MemoryProvider):
                 content=args.get("content"),
                 title=args.get("title"),
                 importance=args.get("importance"),
-                add_labels=self._parse_csv(args.get("add_labels")),
             )
 
         if tool_name == "nmem_delete":
@@ -480,9 +416,6 @@ class NowledgeMemProvider(MemoryProvider):
             if args.get("memory_id"):
                 return c.delete(args["memory_id"])
             raise ValueError("nmem_delete requires memory_id or memory_ids")
-
-        if tool_name == "nmem_labels":
-            return c.list_labels()
 
         if tool_name == "nmem_thread_search":
             return c.thread_search(
@@ -498,29 +431,12 @@ class NowledgeMemProvider(MemoryProvider):
                 offset=args.get("offset", 0),
             )
 
-        if tool_name == "nmem_neighbors":
-            return c.neighbors(args["memory_id"])
-
-        if tool_name == "nmem_evolves":
-            return c.evolves(args["memory_id"])
-
         raise ValueError(f"Unknown tool: {tool_name}")
 
     # -- Config --------------------------------------------------------------
 
     def get_config_schema(self) -> List[Dict[str, Any]]:
         return [
-            {
-                "key": "url",
-                "description": "Nowledge Mem server URL",
-                "default": "http://127.0.0.1:14242",
-            },
-            {
-                "key": "api_key",
-                "description": "API key for remote access",
-                "secret": True,
-                "env_var": "NOWLEDGE_MEM_API_KEY",
-            },
             {
                 "key": "timeout",
                 "description": "Request timeout in seconds",
@@ -558,25 +474,17 @@ class NowledgeMemProvider(MemoryProvider):
         return [s.strip() for s in value.split(",") if s.strip()]
 
     @staticmethod
-    def _load_config(hermes_home: str) -> tuple:
-        """Resolve URL, API key, and timeout from env / config / defaults."""
-        url = os.environ.get("NOWLEDGE_MEM_URL", "")
-        api_key = os.environ.get("NOWLEDGE_MEM_API_KEY", "")
-        timeout = 30
-
+    def _load_timeout(hermes_home: str) -> int:
+        """Resolve timeout from config file or default."""
         if hermes_home:
             config_path = Path(hermes_home) / "nowledge-mem.json"
             if config_path.exists():
                 try:
                     cfg = json.loads(config_path.read_text())
-                    url = url or cfg.get("url", "")
-                    api_key = api_key or cfg.get("api_key", "")
-                    timeout = int(cfg.get("timeout", 30))
+                    return int(cfg.get("timeout", 30))
                 except Exception:
                     pass
-
-        url = url or "http://127.0.0.1:14242"
-        return url, api_key, timeout
+        return 30
 
     @staticmethod
     def _format_working_memory(wm: Any) -> str:

--- a/nowledge-mem-hermes/provider.py
+++ b/nowledge-mem-hermes/provider.py
@@ -1,0 +1,617 @@
+"""Nowledge Mem memory provider for Hermes Agent.
+
+Implements the MemoryProvider ABC to give Hermes native access to the
+user's cross-tool knowledge graph. Replaces the generic MCP connection
+with lifecycle hooks: automatic Working Memory injection, per-turn
+recall, user-profile mirroring, and native tool names.
+
+Transport: the client handles CLI vs HTTP dispatch internally.
+The provider is transport-agnostic.
+
+Requires Hermes v0.7.0+ (MemoryProvider support).
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import threading
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+from agent.memory_provider import MemoryProvider
+
+from client import NowledgeMemClient
+
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Behavioral guidance (injected via system_prompt_block)
+# ---------------------------------------------------------------------------
+
+GUIDANCE = """\
+# Nowledge Mem
+Cross-tool personal knowledge graph. Knowledge saved here persists across \
+all tools and sessions.
+
+**Nowledge Mem vs Hermes memory:** Hermes memory stores Hermes-specific \
+facts (env details, tool quirks). Nowledge Mem stores cross-tool knowledge: \
+decisions, procedures, and learnings. Ask yourself: "Would this matter in a \
+Claude Code, Cursor, or Codex session?" If yes, save to Nowledge Mem.
+
+Save proactively when the conversation produces a decision, procedure, \
+learning, or important context. Search first (nmem_search); if existing \
+knowledge covers the topic, use nmem_update rather than create a duplicate. \
+One strong memory is better than three weak ones.
+
+Graph exploration: nmem_neighbors discovers related memories and entities. \
+nmem_evolves traces how a decision changed over time.
+
+Labels: check existing with nmem_labels before creating new ones. \
+Use 1-3 per memory, prefer broad categories."""
+
+
+# ---------------------------------------------------------------------------
+# Tool schemas (OpenAI function-calling format)
+# ---------------------------------------------------------------------------
+
+_SEARCH = {
+    "name": "nmem_search",
+    "description": (
+        "Search stored memories or list recent. "
+        "Omit query to list. Supports label filtering, temporal filtering, "
+        "and deep search mode."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "query": {
+                "type": "string",
+                "description": "Search query. Omit to list recent memories.",
+            },
+            "limit": {
+                "type": "integer",
+                "description": "Max results, 1-20 (default 10).",
+            },
+            "filter_labels": {
+                "type": "string",
+                "description": "Comma-separated labels to filter by.",
+            },
+            "mode": {
+                "type": "string",
+                "description": "'normal' (fast, default) or 'deep' (graph-enhanced).",
+            },
+        },
+        "required": [],
+    },
+}
+
+_SAVE = {
+    "name": "nmem_save",
+    "description": (
+        "Save a decision, insight, procedure, or learning. "
+        "Search first to avoid duplicates; use nmem_update if it exists."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "content": {"type": "string", "description": "Memory content."},
+            "title": {"type": "string", "description": "Descriptive title."},
+            "importance": {
+                "type": "number",
+                "description": (
+                    "0.0-1.0. 0.8+ major, 0.5-0.7 useful, 0.3-0.4 minor."
+                ),
+            },
+            "labels": {
+                "type": "string",
+                "description": "Comma-separated labels.",
+            },
+            "unit_type": {
+                "type": "string",
+                "description": (
+                    "fact, preference, decision, plan, procedure, "
+                    "learning, context, or event."
+                ),
+            },
+            "event_date": {
+                "type": "string",
+                "description": "When it happened (YYYY, YYYY-MM, or YYYY-MM-DD).",
+            },
+        },
+        "required": ["content"],
+    },
+}
+
+_UPDATE = {
+    "name": "nmem_update",
+    "description": "Refine an existing memory. Search first to find the memory_id.",
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "memory_id": {
+                "type": "string",
+                "description": "Memory ID from search results.",
+            },
+            "content": {
+                "type": "string",
+                "description": "Updated content (omit to keep current).",
+            },
+            "title": {
+                "type": "string",
+                "description": "Updated title (omit to keep current).",
+            },
+            "importance": {
+                "type": "number",
+                "description": "Updated importance (omit to keep current).",
+            },
+            "add_labels": {
+                "type": "string",
+                "description": "Labels to add, comma-separated (omit to keep current).",
+            },
+        },
+        "required": ["memory_id"],
+    },
+}
+
+_DELETE = {
+    "name": "nmem_delete",
+    "description": (
+        "Delete one or more memories. "
+        "Also removes associated relationships and entity links."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "memory_id": {
+                "type": "string",
+                "description": "Single memory ID to delete.",
+            },
+            "memory_ids": {
+                "type": "array",
+                "items": {"type": "string"},
+                "description": "Multiple memory IDs for bulk delete.",
+            },
+        },
+        "required": [],
+    },
+}
+
+_LABELS = {
+    "name": "nmem_labels",
+    "description": "List labels with usage counts.",
+    "parameters": {"type": "object", "properties": {}, "required": []},
+}
+
+_THREAD_SEARCH = {
+    "name": "nmem_thread_search",
+    "description": (
+        "Search past conversations or list recent. "
+        "Returns threads with matched message snippets."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "query": {
+                "type": "string",
+                "description": "Search query. Omit to list recent threads.",
+            },
+            "limit": {
+                "type": "integer",
+                "description": "Max threads, 1-50 (default 10).",
+            },
+            "source": {
+                "type": "string",
+                "description": "Filter by source (e.g. 'claude-code', 'hermes').",
+            },
+        },
+        "required": [],
+    },
+}
+
+_THREAD_MESSAGES = {
+    "name": "nmem_thread_messages",
+    "description": "Fetch messages from a thread. Use after nmem_thread_search.",
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "thread_id": {"type": "string", "description": "Thread ID."},
+            "offset": {
+                "type": "integer",
+                "description": "Messages to skip (default 0).",
+            },
+            "limit": {
+                "type": "integer",
+                "description": "Max messages, 1-100 (default 50).",
+            },
+        },
+        "required": ["thread_id"],
+    },
+}
+
+_NEIGHBORS = {
+    "name": "nmem_neighbors",
+    "description": (
+        "Discover related memories and entities via knowledge graph connections."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "memory_id": {
+                "type": "string",
+                "description": "Memory ID to explore from.",
+            },
+        },
+        "required": ["memory_id"],
+    },
+}
+
+_EVOLVES = {
+    "name": "nmem_evolves",
+    "description": "Trace how a decision or understanding changed over time.",
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "memory_id": {
+                "type": "string",
+                "description": "Memory ID to trace.",
+            },
+        },
+        "required": ["memory_id"],
+    },
+}
+
+ALL_TOOL_SCHEMAS = [
+    _SEARCH,
+    _SAVE,
+    _UPDATE,
+    _DELETE,
+    _LABELS,
+    _THREAD_SEARCH,
+    _THREAD_MESSAGES,
+    _NEIGHBORS,
+    _EVOLVES,
+]
+
+
+# ---------------------------------------------------------------------------
+# Provider implementation
+# ---------------------------------------------------------------------------
+
+
+class NowledgeMemProvider(MemoryProvider):
+    """Nowledge Mem as a native Hermes memory provider.
+
+    Lifecycle hooks replace behavioral guidance with deterministic behavior:
+    - system_prompt_block: Working Memory injected automatically
+    - prefetch: relevant memories recalled before every turn
+    - on_memory_write: user profile facts mirrored to Nowledge Mem
+    - on_pre_compress: hints about external knowledge for the compressor
+    """
+
+    def __init__(self) -> None:
+        self._client: Optional[NowledgeMemClient] = None
+        self._working_memory = ""
+        self._cron_skipped = False
+        self._bg_threads: List[threading.Thread] = []
+
+    @property
+    def name(self) -> str:
+        return "nowledge-mem"
+
+    # -- Core lifecycle ------------------------------------------------------
+
+    def is_available(self) -> bool:
+        """Check if nmem CLI is installed or HTTP URL is configured."""
+        if NowledgeMemClient._detect_cli():
+            return True
+        return bool(os.environ.get("NOWLEDGE_MEM_URL"))
+
+    def initialize(self, session_id: str, **kwargs: Any) -> None:
+        agent_context = kwargs.get("agent_context", "")
+        platform = kwargs.get("platform", "cli")
+
+        if agent_context in ("cron", "flush") or platform == "cron":
+            logger.debug(
+                "Nowledge Mem skipped: cron/flush context "
+                "(agent_context=%s, platform=%s)",
+                agent_context,
+                platform,
+            )
+            self._cron_skipped = True
+            return
+
+        hermes_home = kwargs.get("hermes_home", "")
+        url, api_key, timeout = self._load_config(hermes_home)
+
+        self._client = NowledgeMemClient(url=url, api_key=api_key, timeout=timeout)
+
+        if not self._client.health():
+            logger.warning(
+                "Nowledge Mem not reachable (transport=%s, url=%s)",
+                self._client.transport,
+                url,
+            )
+            self._client = None
+            return
+
+        # Fetch Working Memory for system prompt injection
+        try:
+            wm = self._client.working_memory()
+            self._working_memory = self._format_working_memory(wm)
+        except Exception as e:
+            logger.debug("Working memory fetch failed: %s", e)
+            self._working_memory = ""
+
+        logger.info(
+            "Nowledge Mem provider initialized (transport=%s, url=%s)",
+            self._client.transport,
+            url,
+        )
+
+    def system_prompt_block(self) -> str:
+        if self._cron_skipped:
+            return ""
+
+        parts = [GUIDANCE]
+
+        if self._working_memory:
+            parts.append(f"## Working Memory\n\n{self._working_memory}")
+        elif self._client:
+            parts.append(
+                "## Working Memory\n\n"
+                "No briefing available yet. The knowledge graph is connected."
+            )
+        else:
+            parts.append(
+                "## Working Memory\n\n"
+                "Nowledge Mem server is not reachable. "
+                "Tools are unavailable until the server is running."
+            )
+
+        return "\n\n".join(parts)
+
+    def prefetch(self, query: str, *, session_id: str = "") -> str:
+        """Search Nowledge Mem for context relevant to the current turn."""
+        if self._cron_skipped or not self._client:
+            return ""
+        if not query or len(query.strip()) < 10:
+            return ""
+
+        try:
+            result = self._client.search(query.strip()[:200], limit=5)
+            return self._format_prefetch(result)
+        except Exception as e:
+            logger.debug("Nowledge Mem prefetch failed: %s", e)
+            return ""
+
+    def on_memory_write(self, action: str, target: str, content: str) -> None:
+        """Mirror Hermes user-profile writes to Nowledge Mem."""
+        if self._cron_skipped or not self._client:
+            return
+        if action != "add" or target != "user" or not content:
+            return
+
+        client = self._client  # capture for thread
+
+        def _mirror() -> None:
+            try:
+                client.save(
+                    content,
+                    title="User profile (synced from Hermes)",
+                    labels=["hermes-profile"],
+                    importance=0.5,
+                )
+                logger.debug("Mirrored user-profile write to Nowledge Mem")
+            except Exception as e:
+                logger.debug("Mirror write failed (non-fatal): %s", e)
+
+        t = threading.Thread(target=_mirror, daemon=True, name="nmem-mirror")
+        t.start()
+        self._bg_threads.append(t)
+
+    def on_pre_compress(self, messages: List[Dict[str, Any]]) -> str:
+        if self._cron_skipped or not self._client:
+            return ""
+        return (
+            "Cross-session knowledge is stored in Nowledge Mem. "
+            "Decisions and insights from compressed messages can be "
+            "recovered via nmem_search. Preserve references to memory IDs "
+            "if any were mentioned."
+        )
+
+    # -- Tools ---------------------------------------------------------------
+
+    def get_tool_schemas(self) -> List[Dict[str, Any]]:
+        if self._cron_skipped or not self._client:
+            return []
+        return list(ALL_TOOL_SCHEMAS)
+
+    def handle_tool_call(
+        self, tool_name: str, args: Dict[str, Any], **kwargs: Any
+    ) -> str:
+        if not self._client:
+            return json.dumps({"error": "Nowledge Mem is not connected."})
+
+        try:
+            result = self._dispatch(tool_name, args)
+            return json.dumps(result, ensure_ascii=False, default=str)
+        except Exception as e:
+            logger.error("Tool %s failed: %s", tool_name, e)
+            return json.dumps({"error": f"{tool_name} failed: {e}"})
+
+    def _dispatch(self, tool_name: str, args: Dict[str, Any]) -> Any:
+        """Route a tool call to the appropriate client method."""
+        assert self._client is not None
+        c = self._client
+
+        if tool_name == "nmem_search":
+            return c.search(
+                args.get("query", ""),
+                limit=args.get("limit", 10),
+                filter_labels=self._parse_csv(args.get("filter_labels")),
+                mode=args.get("mode"),
+            )
+
+        if tool_name == "nmem_save":
+            return c.save(
+                args["content"],
+                title=args.get("title"),
+                importance=args.get("importance"),
+                labels=self._parse_csv(args.get("labels")),
+                unit_type=args.get("unit_type"),
+                event_date=args.get("event_date"),
+            )
+
+        if tool_name == "nmem_update":
+            return c.update(
+                args["memory_id"],
+                content=args.get("content"),
+                title=args.get("title"),
+                importance=args.get("importance"),
+                add_labels=self._parse_csv(args.get("add_labels")),
+            )
+
+        if tool_name == "nmem_delete":
+            if args.get("memory_ids"):
+                return c.delete_many(args["memory_ids"])
+            if args.get("memory_id"):
+                return c.delete(args["memory_id"])
+            raise ValueError("nmem_delete requires memory_id or memory_ids")
+
+        if tool_name == "nmem_labels":
+            return c.list_labels()
+
+        if tool_name == "nmem_thread_search":
+            return c.thread_search(
+                args.get("query", ""),
+                limit=args.get("limit", 10),
+                source=args.get("source"),
+            )
+
+        if tool_name == "nmem_thread_messages":
+            return c.thread_messages(
+                args["thread_id"],
+                limit=args.get("limit", 50),
+                offset=args.get("offset", 0),
+            )
+
+        if tool_name == "nmem_neighbors":
+            return c.neighbors(args["memory_id"])
+
+        if tool_name == "nmem_evolves":
+            return c.evolves(args["memory_id"])
+
+        raise ValueError(f"Unknown tool: {tool_name}")
+
+    # -- Config --------------------------------------------------------------
+
+    def get_config_schema(self) -> List[Dict[str, Any]]:
+        return [
+            {
+                "key": "url",
+                "description": "Nowledge Mem server URL",
+                "default": "http://127.0.0.1:14242",
+            },
+            {
+                "key": "api_key",
+                "description": "API key for remote access",
+                "secret": True,
+                "env_var": "NOWLEDGE_MEM_API_KEY",
+            },
+            {
+                "key": "timeout",
+                "description": "Request timeout in seconds",
+                "default": "30",
+            },
+        ]
+
+    def save_config(self, values: Dict[str, Any], hermes_home: str) -> None:
+        config_path = Path(hermes_home) / "nowledge-mem.json"
+        existing: dict = {}
+        if config_path.exists():
+            try:
+                existing = json.loads(config_path.read_text())
+            except Exception:
+                pass
+        existing.update(values)
+        config_path.write_text(json.dumps(existing, indent=2))
+        logger.info("Nowledge Mem config saved to %s", config_path)
+
+    # -- Shutdown ------------------------------------------------------------
+
+    def shutdown(self) -> None:
+        for t in self._bg_threads:
+            if t.is_alive():
+                t.join(timeout=3.0)
+        self._bg_threads.clear()
+
+    # -- Helpers -------------------------------------------------------------
+
+    @staticmethod
+    def _parse_csv(value: Optional[str]) -> Optional[List[str]]:
+        """Parse a comma-separated string into a list of trimmed strings."""
+        if not value:
+            return None
+        return [s.strip() for s in value.split(",") if s.strip()]
+
+    @staticmethod
+    def _load_config(hermes_home: str) -> tuple:
+        """Resolve URL, API key, and timeout from env / config / defaults."""
+        url = os.environ.get("NOWLEDGE_MEM_URL", "")
+        api_key = os.environ.get("NOWLEDGE_MEM_API_KEY", "")
+        timeout = 30
+
+        if hermes_home:
+            config_path = Path(hermes_home) / "nowledge-mem.json"
+            if config_path.exists():
+                try:
+                    cfg = json.loads(config_path.read_text())
+                    url = url or cfg.get("url", "")
+                    api_key = api_key or cfg.get("api_key", "")
+                    timeout = int(cfg.get("timeout", 30))
+                except Exception:
+                    pass
+
+        url = url or "http://127.0.0.1:14242"
+        return url, api_key, timeout
+
+    @staticmethod
+    def _format_working_memory(wm: Any) -> str:
+        """Format working memory response for system prompt."""
+        if not wm:
+            return ""
+        if isinstance(wm, dict):
+            content = wm.get("content", "") or wm.get("briefing", "")
+            if isinstance(content, str) and content.strip():
+                return content.strip()
+            return json.dumps(wm, indent=2, ensure_ascii=False)
+        if isinstance(wm, str):
+            return wm.strip()
+        return str(wm)
+
+    @staticmethod
+    def _format_prefetch(result: Any) -> str:
+        """Format search results as injected recall context."""
+        if not result or not isinstance(result, dict):
+            return ""
+        memories = result.get("memories", result.get("results", []))
+        if not memories:
+            return ""
+
+        lines: List[str] = []
+        for m in memories[:5]:
+            score = m.get("score", m.get("relevance_score", 0))
+            if score < 0.3:
+                continue
+            title = m.get("title", "Untitled")
+            content = (m.get("content", "") or "")[:300]
+            labels = m.get("labels", [])
+            label_str = f" [{', '.join(labels)}]" if labels else ""
+            lines.append(f"- **{title}**{label_str}: {content}")
+
+        if not lines:
+            return ""
+        return "## Recalled from Nowledge Mem\n" + "\n".join(lines)

--- a/nowledge-mem-hermes/provider.py
+++ b/nowledge-mem-hermes/provider.py
@@ -43,9 +43,16 @@ decisions, procedures, and learnings. Ask yourself: "Would this matter in a \
 Claude Code, Cursor, or Codex session?" If yes, save to Nowledge Mem.
 
 Save proactively when the conversation produces a decision, procedure, \
-learning, or important context. Search first (nmem_search); if existing \
-knowledge covers the topic, use nmem_update rather than create a duplicate. \
-One strong memory is better than three weak ones."""
+learning, or important context. One strong memory is better than three \
+weak ones.
+
+**Upsert by ID:** pass a stable id to nmem_save to create-or-update in one \
+call. If a memory with that ID already exists it is updated; otherwise a new \
+one is created. Use this when you have a natural key (e.g. topic or decision \
+name) instead of the search-then-update dance.
+
+Without an id, search first (nmem_search); if existing knowledge covers the \
+topic, use nmem_update rather than create a duplicate."""
 
 
 # ---------------------------------------------------------------------------

--- a/nowledge-mem-hermes/provider.py
+++ b/nowledge-mem-hermes/provider.py
@@ -86,12 +86,21 @@ _SAVE = {
     "name": "nmem_save",
     "description": (
         "Save a decision, insight, procedure, or learning. "
-        "Search first to avoid duplicates; use nmem_update if it exists."
+        "Pass id to upsert: update if that ID exists, create if not. "
+        "Without id, search first to avoid duplicates."
     ),
     "parameters": {
         "type": "object",
         "properties": {
             "content": {"type": "string", "description": "Memory content."},
+            "id": {
+                "type": "string",
+                "description": (
+                    "Stable ID for upsert. If a memory with this ID exists "
+                    "it is updated; otherwise created with this ID. Omit to "
+                    "auto-generate."
+                ),
+            },
             "title": {"type": "string", "description": "Descriptive title."},
             "importance": {
                 "type": "number",
@@ -395,6 +404,7 @@ class NowledgeMemProvider(MemoryProvider):
         if tool_name == "nmem_save":
             return c.save(
                 args["content"],
+                memory_id=args.get("id"),
                 title=args.get("title"),
                 importance=args.get("importance"),
                 labels=self._parse_csv(args.get("labels")),

--- a/nowledge-mem-hermes/setup.sh
+++ b/nowledge-mem-hermes/setup.sh
@@ -1,21 +1,117 @@
 #!/usr/bin/env bash
 # Nowledge Mem for Hermes Agent — one-command setup
-# Configures MCP server and installs behavioral guidance.
-# Safe to run multiple times (idempotent).
 #
-# Usage (no repo clone needed):
+# Plugin install (recommended, Hermes v0.7.0+):
 #   bash <(curl -sL https://raw.githubusercontent.com/nowledge-co/community/main/nowledge-mem-hermes/setup.sh)
+#
+# MCP-only install (any Hermes version):
+#   bash <(curl -sL https://raw.githubusercontent.com/nowledge-co/community/main/nowledge-mem-hermes/setup.sh) --mcp
+#
+# Safe to run multiple times (idempotent).
 
 set -euo pipefail
 
 HERMES_HOME="${HERMES_HOME:-$HOME/.hermes}"
-SOUL_MD="$HERMES_HOME/SOUL.md"
 CONFIG="$HERMES_HOME/config.yaml"
-MARKER="# Nowledge Mem for Hermes"
-AGENTS_URL="https://raw.githubusercontent.com/nowledge-co/community/main/nowledge-mem-hermes/AGENTS.md"
+BASE_URL="https://raw.githubusercontent.com/nowledge-co/community/main/nowledge-mem-hermes"
+
+# Detect local repo directory (for users who cloned the repo)
+SCRIPT_DIR=""
+if [[ -n "${BASH_SOURCE[0]:-}" && "${BASH_SOURCE[0]}" != /dev/* && "${BASH_SOURCE[0]}" != /proc/* ]]; then
+  SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || SCRIPT_DIR=""
+fi
+
+# --- Mode selection ---
+MODE="plugin"
+for arg in "$@"; do
+  case "$arg" in
+    --mcp) MODE="mcp" ;;
+    --plugin) MODE="plugin" ;;
+  esac
+done
 
 mkdir -p "$HERMES_HOME"
 
+# --- Helper: download or read local file ---
+get_file() {
+  local filename="$1"
+  if [ -n "$SCRIPT_DIR" ] && [ -f "$SCRIPT_DIR/$filename" ]; then
+    cat "$SCRIPT_DIR/$filename"
+  else
+    curl -sfL "$BASE_URL/$filename" || true
+  fi
+}
+
+# =========================================================================
+# Plugin install
+# =========================================================================
+if [ "$MODE" = "plugin" ]; then
+  PLUGIN_DIR="$HERMES_HOME/plugins/memory/nowledge-mem"
+  mkdir -p "$PLUGIN_DIR"
+
+  echo "[*] Installing Nowledge Mem memory provider plugin..."
+
+  PLUGIN_FILES="plugin.yaml __init__.py provider.py client.py"
+  ALL_OK=true
+
+  for f in $PLUGIN_FILES; do
+    CONTENT="$(get_file "$f")"
+    if [ -z "$CONTENT" ]; then
+      echo "[error] Could not download $f"
+      ALL_OK=false
+      continue
+    fi
+    printf '%s\n' "$CONTENT" > "$PLUGIN_DIR/$f"
+    echo "  [ok] $f"
+  done
+
+  if ! $ALL_OK; then
+    echo "[error] Some files failed to download. Check your network."
+    exit 1
+  fi
+
+  # Set memory.provider in config.yaml
+  if [ -f "$CONFIG" ] && grep -qF "provider:" "$CONFIG" && grep -qF "nowledge-mem" "$CONFIG"; then
+    echo "[ok] memory.provider already set in $CONFIG"
+  elif [ ! -f "$CONFIG" ]; then
+    cat > "$CONFIG" << 'YAML'
+memory:
+  provider: "nowledge-mem"
+YAML
+    echo "[ok] Created $CONFIG with memory.provider: nowledge-mem"
+  elif grep -qF "memory:" "$CONFIG"; then
+    # memory section exists but provider not set — inform user
+    echo ""
+    echo "[action needed] $CONFIG has a memory: section but provider is not set."
+    echo "Add the following under your memory: block:"
+    echo ""
+    echo '  provider: "nowledge-mem"'
+    echo ""
+  else
+    # No memory section — append it
+    printf '\nmemory:\n  provider: "nowledge-mem"\n' >> "$CONFIG"
+    echo "[ok] Added memory.provider to $CONFIG"
+  fi
+
+  # Remove MCP server config if present (plugin replaces it)
+  if [ -f "$CONFIG" ] && grep -qF "nowledge-mem:" "$CONFIG" && grep -qF "url:" "$CONFIG" && grep -qF "/mcp" "$CONFIG"; then
+    echo "[note] You can remove the nowledge-mem entry from mcp_servers: in $CONFIG"
+    echo "       The plugin connects directly; MCP server config is no longer needed."
+  fi
+
+  echo ""
+  echo "Plugin installed to $PLUGIN_DIR"
+  echo "Restart Hermes, then test:"
+  echo '  "Search my memories for recent decisions"'
+  exit 0
+fi
+
+# =========================================================================
+# MCP-only install
+# =========================================================================
+
+SOUL_MD="$HERMES_HOME/SOUL.md"
+MARKER="# Nowledge Mem for Hermes"
 MCP_OK=false
 GUIDANCE_OK=false
 
@@ -45,39 +141,20 @@ else
 fi
 
 # --- Step 2: Behavioral guidance ---
-#
-# Hermes loads ~/.hermes/SOUL.md on every session regardless of working
-# directory.  HERMES.md is only discovered by walking from the current
-# directory to the git root, so ~/HERMES.md is NOT found when working
-# inside a git repository.  SOUL.md is the only reliable global path.
 
 if [ -f "$SOUL_MD" ] && grep -qF "$MARKER" "$SOUL_MD"; then
   echo "[ok] Behavioral guidance already in $SOUL_MD"
   GUIDANCE_OK=true
 else
-  # Prefer local AGENTS.md (for repo-cloned users); fall back to GitHub
-  SCRIPT_DIR=""
-  if [[ -n "${BASH_SOURCE[0]:-}" && "${BASH_SOURCE[0]}" != /dev/* && "${BASH_SOURCE[0]}" != /proc/* ]]; then
-    SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || SCRIPT_DIR=""
-  fi
-
-  GUIDANCE=""
-  if [ -n "$SCRIPT_DIR" ] && [ -f "$SCRIPT_DIR/AGENTS.md" ]; then
-    GUIDANCE="$(cat "$SCRIPT_DIR/AGENTS.md")"
-  else
-    GUIDANCE="$(curl -sfL "$AGENTS_URL")" || true
-  fi
+  GUIDANCE="$(get_file "AGENTS.md")"
 
   if [ -z "$GUIDANCE" ]; then
     echo "[error] Could not download guidance. Check your network and try again."
-    echo "  Manual alternative: curl -sL $AGENTS_URL >> $SOUL_MD"
     exit 1
   fi
 
-  # Validate that we got the expected content, not an error page
   if ! printf '%s' "$GUIDANCE" | grep -qF "$MARKER"; then
     echo "[error] Downloaded content does not look like Nowledge Mem guidance."
-    echo "  Manual alternative: curl -sL $AGENTS_URL >> $SOUL_MD"
     exit 1
   fi
 

--- a/nowledge-mem-hermes/setup.sh
+++ b/nowledge-mem-hermes/setup.sh
@@ -71,7 +71,9 @@ if [ "$MODE" = "plugin" ]; then
   fi
 
   # Set memory.provider in config.yaml
-  if [ -f "$CONFIG" ] && grep -qF "provider:" "$CONFIG" && grep -qF "nowledge-mem" "$CONFIG"; then
+  # Use a single grep to avoid false positives when "provider:" and "nowledge-mem"
+  # appear in unrelated sections (e.g. mcp_servers).
+  if [ -f "$CONFIG" ] && grep -qE 'provider:.*nowledge-mem' "$CONFIG"; then
     echo "[ok] memory.provider already set in $CONFIG"
   elif [ ! -f "$CONFIG" ]; then
     cat > "$CONFIG" << 'YAML'
@@ -87,6 +89,8 @@ YAML
     echo ""
     echo '  provider: "nowledge-mem"'
     echo ""
+    echo "Plugin installed to $PLUGIN_DIR but config is incomplete."
+    exit 1
   else
     # No memory section — append it
     printf '\nmemory:\n  provider: "nowledge-mem"\n' >> "$CONFIG"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Hermes native memory-provider plugin with automatic working-memory injection, deterministic lifecycle hooks, CLI-backed transport, native nmem tools, and a stdlib CLI client.

* **Bug Fixes**
  * Fixed plugin install/update paths and added required feature gate; cleaned manifest metadata and adjusted integration metadata for CLI/plugin transport.

* **Documentation**
  * Updated install/setup/troubleshooting for plugin vs MCP modes, tool naming, and changelogs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new Hermes memory-provider plugin with per-turn recall and write mirroring via the `nmem` CLI, plus an updated installer script; behavior changes could affect Hermes session prompting and memory writes. Codex changes are mostly install/docs fixes, but incorrect paths/config could still break plugin discovery.
> 
> **Overview**
> Introduces a **native Hermes memory provider plugin** (v0.5.0) that integrates via Hermes v0.7.0+ lifecycle hooks: automatic Working Memory injection, per-turn prefetch recall, tool schema/dispatch for `nmem_*` commands, and mirroring Hermes user-profile writes into Nowledge Mem via a background save.
> 
> Updates Hermes installation to support **two modes** in `setup.sh` (default `--plugin` vs `--mcp`), and rewrites docs/guidance to reflect plugin mode vs MCP-only mode and the new `nmem_` tool naming.
> 
> Fixes the Codex CLI plugin packaging/install flow (v0.1.1): corrects the Codex plugin store path and required `~/.codex/config.toml` feature gate, adjusts repo-level install to use `marketplace.json`, and simplifies `.codex-plugin/plugin.json` to only fields Codex parses. Also updates `integrations.json` entries and `.gitignore` to exclude `__pycache__`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bd379b70f5734f2e5739aa89ea537ad77761243e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->