### PR TITLE
feat(alma): Persist thread ID's in the local storage for 7 days

### DIFF
--- a/nowledge-mem-alma-plugin/main.js
+++ b/nowledge-mem-alma-plugin/main.js
@@ -1347,6 +1347,7 @@ export async function activate(context) {
 			logger.warn?.(`nowledge-mem: failed to load thread mapping: ${err instanceof Error ? err.message : String(err)}`);
 		}
 	};
+	await loadThreadMapping();
 
 	/** Persist thread mapping to storage. */
 	const persistThreadMapping = async () => {
@@ -1357,7 +1358,6 @@ export async function activate(context) {
 			logger.warn?.(`nowledge-mem: failed to persist thread mapping: ${err instanceof Error ? err.message : String(err)}`);
 		}
 	};
-	loadThreadMapping();
 
 	/** Resolve the best possible thread title via Alma APIs, falling back to first user message. */
 	const resolveTitle = async (threadId, buf) => {


### PR DESCRIPTION
This PR fixes #165 

- Add MAX_MAPPING_AGE_MS constant (7 days in milliseconds)
- Update loadThreadMapping() to filter expired entries and legacy string-format values
- Update thread mapping storage format from string to { id, ts } object
- Persist immediately after pruning to keep storage clean
- Update flushThread write site to include timestamp
- Update ensureBuffer read site to access .id field from stored object
- Legacy string-format entries are automatically dropped on load for smooth migration

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Thread conversations now persist across sessions so appended content continues on reopened threads without needing to recreate them.
  * Previously created external-thread IDs are remembered, enabling seamless cross-session appends to those threads.

* **Chores**
  * Automatic cleanup prunes stale thread mappings after about one week and keeps persisted mappings consistent.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->