### PR TITLE
dev branch 0.6.18

### DIFF
--- a/integrations.json
+++ b/integrations.json
@@ -80,6 +80,7 @@
       "type": "plugin",
       "version": "0.1.2",
       "directory": "nowledge-mem-codex-plugin",
+
       "legacyDirectory": "nowledge-mem-codex-prompts",
       "transport": "cli",
       "capabilities": {
@@ -184,7 +185,7 @@
       "name": "OpenClaw",
       "category": "coding",
       "type": "plugin",
-      "version": "0.7.3",
+      "version": "0.8.0",
       "directory": "nowledge-mem-openclaw-plugin",
       "transport": "cli",
       "capabilities": {
@@ -195,7 +196,8 @@
         "autoCapture": true,
         "graphExploration": true,
         "status": true,
-        "contextEngine": true
+        "contextEngine": true,
+        "corpusSupplement": true
       },
       "threadSave": {
         "method": "plugin-capture",

--- a/integrations.json
+++ b/integrations.json
@@ -185,7 +185,7 @@
       "name": "OpenClaw",
       "category": "coding",
       "type": "plugin",
-      "version": "0.8.0",
+      "version": "0.8.1",
       "directory": "nowledge-mem-openclaw-plugin",
       "transport": "cli",
       "capabilities": {
@@ -223,9 +223,9 @@
       "name": "Alma",
       "category": "coding",
       "type": "plugin",
-      "version": "0.6.13",
+      "version": "0.6.15",
       "directory": "nowledge-mem-alma-plugin",
-      "transport": "cli",
+      "transport": "http",
       "capabilities": {
         "workingMemory": true,
         "search": true,
@@ -328,7 +328,7 @@
       "name": "Hermes Agent",
       "category": "coding",
       "type": "plugin",
-      "version": "0.5.0",
+      "version": "0.5.2",
       "directory": "nowledge-mem-hermes",
       "transport": "cli",
       "capabilities": {

--- a/integrations.json
+++ b/integrations.json
@@ -201,7 +201,7 @@
       },
       "threadSave": {
         "method": "plugin-capture",
-        "note": "Plugin captures interactive sessions via hooks (agent_end, after_compaction, before_reset) and Context Engine afterTurn; persists threads via Nowledge Mem HTTP API with incremental tail sync. Isolated cron/session keys excluded (OpenClaw isCronSessionKey via plugin-sdk). Memory tools still use nmem CLI."
+        "note": "Plugin captures interactive sessions via hooks (agent_end, after_compaction, before_reset) and Context Engine afterTurn; persists threads via Nowledge Mem HTTP API with incremental tail sync. Cron sessions (agent:<id>:cron:... and bare cron:*) excluded automatically. Memory tools still use nmem CLI."
       },
       "install": {
         "command": "openclaw plugins install @nowledge/openclaw-nowledge-mem",

--- a/integrations.json
+++ b/integrations.json
@@ -201,7 +201,7 @@
       },
       "threadSave": {
         "method": "plugin-capture",
-        "note": "Plugin captures sessions via lifecycle hooks (agent_end, after_compaction) and Context Engine afterTurn; sends via nmem CLI"
+        "note": "Plugin captures interactive sessions via hooks (agent_end, after_compaction, before_reset) and Context Engine afterTurn; persists threads via Nowledge Mem HTTP API with incremental tail sync. Isolated cron/session keys excluded (OpenClaw isCronSessionKey via plugin-sdk). Memory tools still use nmem CLI."
       },
       "install": {
         "command": "openclaw plugins install @nowledge/openclaw-nowledge-mem",
@@ -223,9 +223,9 @@
       "name": "Alma",
       "category": "coding",
       "type": "plugin",
-      "version": "0.6.14",
+      "version": "0.6.13",
       "directory": "nowledge-mem-alma-plugin",
-      "transport": "http",
+      "transport": "cli",
       "capabilities": {
         "workingMemory": true,
         "search": true,
@@ -328,7 +328,7 @@
       "name": "Hermes Agent",
       "category": "coding",
       "type": "plugin",
-      "version": "0.5.1",
+      "version": "0.5.0",
       "directory": "nowledge-mem-hermes",
       "transport": "cli",
       "capabilities": {

--- a/integrations.json
+++ b/integrations.json
@@ -225,7 +225,7 @@
       "type": "plugin",
       "version": "0.6.14",
       "directory": "nowledge-mem-alma-plugin",
-      "transport": "cli",
+      "transport": "http",
       "capabilities": {
         "workingMemory": true,
         "search": true,

--- a/integrations.json
+++ b/integrations.json
@@ -201,7 +201,7 @@
       },
       "threadSave": {
         "method": "plugin-capture",
-        "note": "Plugin captures interactive sessions via hooks (agent_end, after_compaction, before_reset) and Context Engine afterTurn; persists threads via Nowledge Mem HTTP API with incremental tail sync. Cron sessions (agent:<id>:cron:... and bare cron:*) excluded automatically. Memory tools still use nmem CLI."
+        "note": "Plugin captures interactive sessions via hooks (agent_end, after_compaction, before_reset) and Context Engine afterTurn; persists threads via Nowledge Mem HTTP API with incremental tail sync. Isolated cron/session keys excluded (OpenClaw isCronSessionKey via plugin-sdk/routing). Memory tools still use nmem CLI."
       },
       "install": {
         "command": "openclaw plugins install @nowledge/openclaw-nowledge-mem",

--- a/integrations.json
+++ b/integrations.json
@@ -223,7 +223,7 @@
       "name": "Alma",
       "category": "coding",
       "type": "plugin",
-      "version": "0.6.13",
+      "version": "0.6.14",
       "directory": "nowledge-mem-alma-plugin",
       "transport": "cli",
       "capabilities": {

--- a/integrations.json
+++ b/integrations.json
@@ -328,7 +328,7 @@
       "name": "Hermes Agent",
       "category": "coding",
       "type": "plugin",
-      "version": "0.5.0",
+      "version": "0.5.1",
       "directory": "nowledge-mem-hermes",
       "transport": "cli",
       "capabilities": {

--- a/nowledge-mem-alma-plugin/CHANGELOG.md
+++ b/nowledge-mem-alma-plugin/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## 0.6.15
+
+### Fix async flush race condition, error handling, and search mode
+
+- Thread sync could permanently lose messages when new turns arrived during an in-flight flush. The message count is now snapshotted before async work begins, so messages pushed by hooks during the network call are correctly saved on the next flush.
+- `dispose()` now awaits all pending flushes before tearing down, preventing data loss on plugin disable or reload.
+- Recall injection in `willSend` is now wrapped in a try/catch so a server-unreachable or search failure does not break message sending.
+- Search mode sent `"normal"` to the backend, which only accepts `"fast"` or `"deep"`. The unrecognized value silently fell through to deep mode (slower, more expensive). Now correctly sends `"fast"` as default. Tool schema updated to match.
+- Store tool response fields (`title`, `labels`, `unit_type`, `importance`) were read from the raw API response instead of the unwrapped memory object, causing them to resolve to `undefined` when the API wraps the response in `{ memory: {...} }`.
+- Error classification (`cliErrorResult`) used a cascade of `if` statements where later matches could overwrite more specific codes (e.g., "model not found" classified as `model_unavailable` instead of `not_found`). Refactored to an `else if` chain with most-specific patterns first.
+- Removed phantom `force` parameter from delete tool schemas (the API does not support forced deletion).
+- Removed phantom `input.messages` fallback in thread show tool (not in schema, never sent by LLM).
+
 ## 0.6.14
 
 ### Async HTTP transport (fixes Alma freeze on Windows)

--- a/nowledge-mem-alma-plugin/CHANGELOG.md
+++ b/nowledge-mem-alma-plugin/CHANGELOG.md
@@ -1,12 +1,19 @@
 # Changelog
 
+## 0.6.14
+
+### Fix thread duplication on plugin restart or buffer eviction
+- Conversations now use a stable thread ID derived from Alma's internal thread ID (SHA-1 hash). Previously, each plugin restart, LRU eviction, or Alma relaunch caused the same conversation to be saved as a new thread instead of appending to the existing one.
+- First flush for a buffer now tries to append to the existing thread before falling back to create. This handles the case where the thread already exists in Nowledge Mem from a prior session.
+- `createThread()` now accepts an optional `id` parameter, passed through to `nmem t create --id`.
+
 ## 0.6.13
 
 ### Reliable live thread sync (complete rewrite)
 - Conversations sync during normal use — no need to quit Alma. Three hooks work together: `willSend` buffers the user message, `didReceive` buffers the AI response and starts a 7-second idle timer, `thread.activated` flushes the previous thread on switch. Quit hooks flush all buffered threads as a safety net.
 - All message data comes from hook payloads (`input.content`, `input.response.content`), never from `context.chat.getMessages()` which returns empty in `willSend` timing.
 - Thread titles resolved at flush time via `context.chat.getThread()` with 4-strategy fallback — Alma generates titles asynchronously after the first AI response, so early capture misses them.
-- Incremental sync: first flush creates a new thread; subsequent flushes append only new messages to the existing thread (no duplicate thread creation).
+- Incremental sync: first flush creates a new thread; subsequent flushes append only new messages to the existing thread. (Note: thread identity was session-scoped; cross-session dedup fixed in 0.6.14.)
 - Per-thread idle timers: multiple concurrent conversations are tracked independently.
 - Content-safe: AI responses in array-of-blocks format (Anthropic API style) are properly extracted.
 - Thread buffer LRU eviction at 20 entries with best-effort flush before eviction.

--- a/nowledge-mem-alma-plugin/CHANGELOG.md
+++ b/nowledge-mem-alma-plugin/CHANGELOG.md
@@ -2,10 +2,14 @@
 
 ## 0.6.14
 
+### Async HTTP transport (fixes Alma freeze on Windows)
+- All data operations now use direct HTTP `fetch()` to the Nowledge Mem API instead of shelling out to the `nmem` CLI via `spawnSync`. This eliminates the event-loop blocking that caused Alma to freeze for seconds during recall injection and thread sync, especially on Windows where Python process startup is slow.
+- The `nmem` CLI is no longer required for normal operation. The plugin connects directly to `http://127.0.0.1:14242` (or the configured remote URL). CLI availability is still checked in the status tool for diagnostic purposes.
+- API key is passed via `Authorization: Bearer` header, never as a CLI argument or environment variable.
+
 ### Fix thread duplication on plugin restart or buffer eviction
 - Conversations now use a stable thread ID derived from Alma's internal thread ID (SHA-1 hash). Previously, each plugin restart, LRU eviction, or Alma relaunch caused the same conversation to be saved as a new thread instead of appending to the existing one.
 - First flush for a buffer now tries to append to the existing thread before falling back to create. This handles the case where the thread already exists in Nowledge Mem from a prior session.
-- `createThread()` now accepts an optional `id` parameter, passed through to `nmem t create --id`.
 
 ## 0.6.13
 

--- a/nowledge-mem-alma-plugin/CHANGELOG.md
+++ b/nowledge-mem-alma-plugin/CHANGELOG.md
@@ -7,9 +7,20 @@
 - The `nmem` CLI is no longer required for normal operation. The plugin connects directly to `http://127.0.0.1:14242` (or the configured remote URL). CLI availability is still checked in the status tool for diagnostic purposes.
 - API key is passed via `Authorization: Bearer` header, never as a CLI argument or environment variable.
 
+### Fix memory search, recall injection, and dedup check
+- Memory search query parameter was `query` but the HTTP API expects `q`. All memory searches silently returned recent/browse-mode results instead of semantically relevant ones. This broke recall injection (random memories instead of relevant), dedup check in store (compared against wrong memories), and the search/query tools.
+- Label filter parameter was `filter_labels` but the API expects `labels`. Label-based filtering was silently ignored.
+- Time filter sent enum values (`today`, `week`) to the `event_date_from` field which expects date strings. Corrected to use the `time_range` parameter.
+
 ### Fix thread duplication on plugin restart or buffer eviction
 - Conversations now use a stable thread ID derived from Alma's internal thread ID (SHA-1 hash). Previously, each plugin restart, LRU eviction, or Alma relaunch caused the same conversation to be saved as a new thread instead of appending to the existing one.
 - First flush for a buffer now tries to append to the existing thread before falling back to create. This handles the case where the thread already exists in Nowledge Mem from a prior session.
+
+### Remove dead code and phantom parameters
+- Remove unused `saveActiveThread()`, `normalizeThreadMessages()`, `stringifyMessage()`, and `addMemory()` functions (superseded by hook-based live sync and direct HTTP calls).
+- Remove `contentLimit` parameter from show/thread_show tools (the HTTP API returns full content; truncation was a CLI-only concept). Remove misleading `truncatedContent` response field.
+- Remove unused `force` parameter from deleteMemory/deleteThread client methods (the HTTP API does not support forced deletion).
+- Fix `createThread` fallback ID prefix from `cli-` to `alma-`.
 
 ## 0.6.13
 

--- a/nowledge-mem-alma-plugin/CLAUDE.md
+++ b/nowledge-mem-alma-plugin/CLAUDE.md
@@ -9,7 +9,7 @@ This file is a practical continuation guide for future agent sessions working on
 - Runtime: plain ESM (`main.js`), no build step
 - Memory backend: direct HTTP to Nowledge Mem API (default `http://127.0.0.1:14242`). CLI (`nmem`) is only used for diagnostic in the status tool.
 
-## Current Status (as of v0.6.14)
+## Current Status (as of v0.6.15)
 
 - Plugin is installed/activated and registers 12 tools successfully in Alma logs.
 - Live thread sync works via three hooks: `willSend` (user msg + recall), `didReceive` (AI response + idle timer), `thread.activated` (flush on switch).

--- a/nowledge-mem-alma-plugin/CLAUDE.md
+++ b/nowledge-mem-alma-plugin/CLAUDE.md
@@ -66,7 +66,7 @@ Registered IDs (plugin-qualified at runtime as `nowledge-mem.<id>`):
 - `nowledgeMem.autoCapture` (default `true`) — enables live thread sync via willSend/didReceive/thread.activated hooks
 - `nowledgeMem.maxRecallResults` (default `5`, clamp 1-20)
 - `nowledgeMem.apiUrl` (default `""`, empty = local `http://127.0.0.1:14242`)
-- `nowledgeMem.apiKey` (default `""`, passed via env var only, never logged)
+- `nowledgeMem.apiKey` (default `""`, sent via `Authorization: Bearer` header, never logged)
 
 ## Ground Truth Debug Checklist
 

--- a/nowledge-mem-alma-plugin/CLAUDE.md
+++ b/nowledge-mem-alma-plugin/CLAUDE.md
@@ -7,7 +7,7 @@ This file is a practical continuation guide for future agent sessions working on
 
 - Plugin target: Alma local plugin system
 - Runtime: plain ESM (`main.js`), no build step
-- Memory backend: `nmem` CLI (fallback: `uvx --from nmem-cli nmem`)
+- Memory backend: direct HTTP to Nowledge Mem API (default `http://127.0.0.1:14242`). CLI (`nmem`) is only used for diagnostic in the status tool.
 
 ## Current Status (as of v0.6.14)
 
@@ -89,9 +89,8 @@ Do not assume registration failed if ToolSearch can discover names.
 ```bash
 node --check main.js
 node -e "JSON.parse(require('fs').readFileSync('manifest.json','utf8'));console.log('manifest ok')"
-nmem --version || uvx --from nmem-cli nmem --version
-nmem --json m search "alma" -n 3
-nmem --json t search "alma" -n 3
+curl -s http://127.0.0.1:14242/health | head -c 200   # Verify API is reachable
+curl -s http://127.0.0.1:14242/memories/search?query=alma&limit=3   # Test search
 ```
 
 ## Reinstall / Reload in Alma

--- a/nowledge-mem-alma-plugin/CLAUDE.md
+++ b/nowledge-mem-alma-plugin/CLAUDE.md
@@ -24,7 +24,7 @@ This file is a practical continuation guide for future agent sessions working on
   - search-style: `{ ok, type, query, total, items, raw }` — items may include `sourceThreadId`
   - singleton-style: `{ ok, item, ... }` — show includes `sourceThreadId` when available
   - store: `{ ok, item, summary }` or `{ ok, skipped, reason, existingId, similarity }`
-  - delete-style: `{ ok, id, force, [cascade], notFound, item? }`
+  - delete-style: `{ ok, id, [cascade], notFound, item? }`
   - status: `{ ok, status:{ connectionMode, apiUrl, apiKeyConfigured, cliAvailable, cliCommand, serverConnected, serverError, settings } }`
   - errors: `{ ok:false, error:{ code, operation, message } }`
 

--- a/nowledge-mem-alma-plugin/CLAUDE.md
+++ b/nowledge-mem-alma-plugin/CLAUDE.md
@@ -9,10 +9,11 @@ This file is a practical continuation guide for future agent sessions working on
 - Runtime: plain ESM (`main.js`), no build step
 - Memory backend: `nmem` CLI (fallback: `uvx --from nmem-cli nmem`)
 
-## Current Status (as of v0.6.13)
+## Current Status (as of v0.6.14)
 
 - Plugin is installed/activated and registers 12 tools successfully in Alma logs.
 - Live thread sync works via three hooks: `willSend` (user msg + recall), `didReceive` (AI response + idle timer), `thread.activated` (flush on switch).
+- Thread IDs are deterministic: `alma-{sha1(almaThreadId)[:12]}`. Survives plugin restarts, LRU eviction, and Alma relaunches. First flush tries append (thread may exist from prior session), falls back to create.
 - All message data from hook payloads, never `context.chat.getMessages()`.
 - Titles resolved at flush time via `context.chat.getThread()` with 4-strategy fallback.
 - Hook registration: `context.events ?? context.hooks` (canonical API first).
@@ -123,7 +124,7 @@ open -a Alma
 
 ## Alma Hook Availability
 
-All three hooks used by live sync are confirmed working in Alma (verified v0.6.13):
+All three hooks used by live sync are confirmed working in Alma (verified v0.6.14):
 - `chat.message.willSend` — fires before user message is sent. Input: `{threadId, content, model, providerId}`.
 - `chat.message.didReceive` — fires after AI response. Input: `{threadId, response: {content, usage?}, pricing?}`.
 - `thread.activated` — fires on thread switch. Input: `{threadId, title?}`.

--- a/nowledge-mem-alma-plugin/CLAUDE.md
+++ b/nowledge-mem-alma-plugin/CLAUDE.md
@@ -59,7 +59,6 @@ Registered IDs (plugin-qualified at runtime as `nowledge-mem.<id>`):
 - `chat.message.didReceive`: buffer AI response (from `input.response.content`) + start 7s idle timer
 - `thread.activated`: flush previous thread immediately on switch
 - Quit hooks (`app.willQuit`, `app.will-quit`, `app.beforeQuit`, `app.before-quit`): safety net flush
-- `deactivate()`: fallback if quit hooks do not fire
 
 ## Settings (manifest + `context.settings`)
 
@@ -90,7 +89,7 @@ Do not assume registration failed if ToolSearch can discover names.
 node --check main.js
 node -e "JSON.parse(require('fs').readFileSync('manifest.json','utf8'));console.log('manifest ok')"
 curl -s http://127.0.0.1:14242/health | head -c 200   # Verify API is reachable
-curl -s http://127.0.0.1:14242/memories/search?query=alma&limit=3   # Test search
+curl -s 'http://127.0.0.1:14242/memories/search?q=alma&limit=3'   # Test search (param is `q`, not `query`)
 ```
 
 ## Reinstall / Reload in Alma
@@ -142,6 +141,20 @@ Only implement if needed; verify with runtime evidence first.
 1. Add test fixture script to validate response shape per tool automatically.
 2. Add explicit telemetry fields for hook outcomes (`recallUsed`, `captureSavedThreadId`) in logs.
 3. Fix live `recallPolicy` reload by moving hook registration logic into a function that can be torn down and re-created on settings change.
+
+## HTTP API Parameter Mapping
+
+The plugin talks directly to the Nowledge Mem HTTP API. Parameter names must match exactly (FastAPI silently ignores unknown query params). Key mappings:
+
+| Operation | Plugin param | HTTP API param | Notes |
+|-----------|-------------|---------------|-------|
+| Memory search | `q` | `q` | NOT `query` (thread search uses `query`) |
+| Memory search | `labels` | `labels` | NOT `filter_labels` |
+| Memory search | `time_range` | `time_range` | Accepts `today/week/month/year`. NOT `event_date_from` (which expects `YYYY-MM-DD`) |
+| Thread search | `query` | `query` | Thread search DOES use `query` |
+| Thread append | path `{thread_id}` | `thread_id` | Human-readable ID, not UUID |
+
+When modifying API calls, always verify parameter names against the backend endpoint signatures in `nowledge-graph-py/src/nowledge_graph_server/api/routers/`.
 
 ## Cache Safety
 

--- a/nowledge-mem-alma-plugin/main.js
+++ b/nowledge-mem-alma-plugin/main.js
@@ -253,6 +253,10 @@ class NowledgeMemClient {
 		return this._fetch("DELETE", `/threads/${encodeURIComponent(id)}`, { params });
 	}
 
+	async createMemory(body) {
+		return this._fetch("POST", "/memories", { body });
+	}
+
 	// --- Server health (async, for status tool) ---
 
 	async checkServerHealth() {
@@ -310,9 +314,10 @@ function validationErrorResult(operation, message) {
 function cliErrorResult(err, operation) {
 	const message = err instanceof Error ? err.message : String(err);
 	const normalized = message.toLowerCase();
+	const status = err && typeof err === "object" ? err.status : undefined;
 	let code = "cli_error";
-	if (normalized.includes("not found")) code = "not_found";
-	if (normalized.includes("permission")) code = "permission_denied";
+	if (status === 404 || normalized.includes("not found")) code = "not_found";
+	if (status === 403 || normalized.includes("permission")) code = "permission_denied";
 	if (normalized.includes("invalid json")) code = "invalid_json";
 	if (normalized.includes("nmem cli not found")) code = "nmem_not_found";
 	if (
@@ -786,7 +791,7 @@ export async function activate(context) {
 				if (eventEnd) body.event_end = eventEnd;
 				if (temporalContext) body.temporal_context = temporalContext;
 
-				const result = await client._fetch("POST", "/memories", { body });
+				const result = await client.createMemory(body);
 				const mem = result?.memory ?? result ?? {};
 				const id = String(mem.id ?? result?.memory_id ?? "");
 

--- a/nowledge-mem-alma-plugin/main.js
+++ b/nowledge-mem-alma-plugin/main.js
@@ -317,11 +317,12 @@ function cliErrorResult(err, operation) {
 	const status = err && typeof err === "object" ? err.status : undefined;
 	let code = "cli_error";
 	// Order matters: most specific first, broader patterns last.
+	// "model not found" should be model_unavailable, not not_found.
 	if (normalized.includes("nmem cli not found")) code = "nmem_not_found";
 	else if (normalized.includes("invalid json")) code = "invalid_json";
 	else if (status === 403 || normalized.includes("permission")) code = "permission_denied";
-	else if (status === 404 || normalized.includes("not found")) code = "not_found";
 	else if (normalized.includes("model") || normalized.includes("embedding") || normalized.includes("download")) code = "model_unavailable";
+	else if (status === 404 || normalized.includes("not found")) code = "not_found";
 	return { ok: false, error: { code, operation, message } };
 }
 
@@ -798,7 +799,7 @@ export async function activate(context) {
 						title: title ?? String(mem.title ?? ""),
 						content: text,
 						unitType: mem.unit_type || unitType,
-						labels: mem.labels || labels,
+						labels: result?.assigned_labels || labels,
 						importance: importance ?? Number(mem.importance ?? 0.5),
 						eventStart,
 						eventEnd,

--- a/nowledge-mem-alma-plugin/main.js
+++ b/nowledge-mem-alma-plugin/main.js
@@ -97,7 +97,9 @@ class NowledgeMemClient {
 			});
 			if (!resp.ok) {
 				const text = await resp.text().catch(() => "");
-				throw new Error(`HTTP ${resp.status}: ${text.slice(0, 200)}`);
+				const err = new Error(`HTTP ${resp.status}: ${text.slice(0, 200)}`);
+				err.status = resp.status;
+				throw err;
 			}
 			const ct = resp.headers.get("content-type") || "";
 			return ct.includes("application/json") ? resp.json() : resp.text();
@@ -211,9 +213,6 @@ class NowledgeMemClient {
 	async createThread(title, content, messages, source = "alma", id = null) {
 		const body = { title, source };
 		if (id) body.thread_id = id;
-		if (typeof content === "string" && content.trim()) {
-			// content goes into summary-like field; messages carry the actual data
-		}
 		if (Array.isArray(messages) && messages.length > 0) {
 			body.messages = messages;
 		} else if (typeof content === "string" && content.trim()) {
@@ -1283,8 +1282,13 @@ export async function activate(context) {
 					logger.info?.(`nowledge-mem: appending ${buf.messages.length} msgs to ${buf.nowledgeThreadId} (reconnect)`);
 					await client.appendThread(buf.nowledgeThreadId, buf.messages);
 				} catch (appendErr) {
-					// Thread does not exist yet: create with stable ID
-					logger.debug?.(`nowledge-mem: append-first failed (${appendErr instanceof Error ? appendErr.message : String(appendErr)}), creating new thread`);
+					// Only fall back to create when the thread genuinely doesn't exist (404).
+					// Rethrow transient errors (5xx, timeouts) so the outer catch handles them.
+					const isNotFound =
+						appendErr?.status === 404 ||
+						/not.found/i.test(appendErr instanceof Error ? appendErr.message : "");
+					if (!isNotFound) throw appendErr;
+					logger.debug?.(`nowledge-mem: thread not found, creating ${buf.nowledgeThreadId}`);
 					const summary = buf.messages
 						.slice(-8)
 						.map((msg) => `[${msg.role}] ${escapeForInline(msg.content, 280)}`)

--- a/nowledge-mem-alma-plugin/main.js
+++ b/nowledge-mem-alma-plugin/main.js
@@ -909,7 +909,6 @@ export async function activate(context) {
 			type: "object",
 			properties: {
 				id: { type: "string", minLength: 1 },
-				force: { type: "boolean", default: false },
 			},
 			required: ["id"],
 		},
@@ -917,20 +916,18 @@ export async function activate(context) {
 			type: "object",
 			properties: {
 				id: { type: "string", minLength: 1 },
-				force: { type: "boolean", default: false },
 			},
 			required: ["id"],
 		},
 		async execute(input) {
 			const id = String(input?.id ?? "").trim();
 			if (!id) return validationErrorResult("memory_delete", "id is required");
-			const force = input?.force === true;
 			try {
 				const result = await client.deleteMemory(id);
-				return { ok: true, id, force, notFound: false, item: result };
+				return { ok: true, id, notFound: false, item: result };
 			} catch (err) {
 				const info = cliErrorResult(err, "memory_delete");
-				if (info.error.code === "not_found") return { ok: true, id, force, notFound: true };
+				if (info.error.code === "not_found") return { ok: true, id, notFound: true };
 				return info;
 			}
 		},
@@ -1180,7 +1177,6 @@ export async function activate(context) {
 			type: "object",
 			properties: {
 				id: { type: "string", minLength: 1 },
-				force: { type: "boolean", default: false },
 				cascade: { type: "boolean", default: false },
 			},
 			required: ["id"],
@@ -1189,7 +1185,6 @@ export async function activate(context) {
 			type: "object",
 			properties: {
 				id: { type: "string", minLength: 1 },
-				force: { type: "boolean", default: false },
 				cascade: { type: "boolean", default: false },
 			},
 			required: ["id"],
@@ -1197,14 +1192,13 @@ export async function activate(context) {
 		async execute(input) {
 			const id = String(input?.id ?? "").trim();
 			if (!id) return validationErrorResult("thread_delete", "id is required");
-			const force = input?.force === true;
 			const cascade = input?.cascade === true;
 			try {
 				const result = await client.deleteThread(id, cascade);
-				return { ok: true, id, force, cascade, notFound: false, item: result };
+				return { ok: true, id, cascade, notFound: false, item: result };
 			} catch (err) {
 				const info = cliErrorResult(err, "thread_delete");
-				if (info.error.code === "not_found") return { ok: true, id, force, cascade, notFound: true };
+				if (info.error.code === "not_found") return { ok: true, id, cascade, notFound: true };
 				return info;
 			}
 		},
@@ -1276,16 +1270,22 @@ export async function activate(context) {
 			const resolved = await resolveTitle(threadId, buf);
 			if (resolved) buf.title = escapeForInline(resolved, 120);
 
+			// Snapshot message count before async work. New messages may arrive
+			// via willSend/didReceive during the awaits; snapshotting prevents
+			// counting those as already saved.
+			const snapshotCount = buf.messages.length;
+
 			if (buf.savedCount > 0) {
 				// Already synced before in this session: append new messages
-				const newMessages = buf.messages.slice(buf.savedCount);
+				const newMessages = buf.messages.slice(buf.savedCount, snapshotCount);
 				logger.info?.(`nowledge-mem: appending ${newMessages.length} msgs to ${buf.nowledgeThreadId}`);
 				await client.appendThread(buf.nowledgeThreadId, newMessages);
 			} else {
 				// First flush for this buffer: try append (thread may exist from prior session), fall back to create
+				const msgsToSend = buf.messages.slice(0, snapshotCount);
 				try {
-					logger.info?.(`nowledge-mem: appending ${buf.messages.length} msgs to ${buf.nowledgeThreadId} (reconnect)`);
-					await client.appendThread(buf.nowledgeThreadId, buf.messages);
+					logger.info?.(`nowledge-mem: appending ${msgsToSend.length} msgs to ${buf.nowledgeThreadId} (reconnect)`);
+					await client.appendThread(buf.nowledgeThreadId, msgsToSend);
 				} catch (appendErr) {
 					// Only fall back to create when the thread genuinely doesn't exist (404).
 					// Rethrow transient errors (5xx, timeouts) so the outer catch handles them.
@@ -1294,21 +1294,21 @@ export async function activate(context) {
 						/not.found/i.test(appendErr instanceof Error ? appendErr.message : "");
 					if (!isNotFound) throw appendErr;
 					logger.debug?.(`nowledge-mem: thread not found, creating ${buf.nowledgeThreadId}`);
-					const summary = buf.messages
+					const summary = msgsToSend
 						.slice(-8)
 						.map((msg) => `[${msg.role}] ${escapeForInline(msg.content, 280)}`)
 						.join("\n");
-					logger.info?.(`nowledge-mem: creating thread ${buf.nowledgeThreadId} for ${threadId} (${buf.messages.length} msgs, title="${buf.title}")`);
+					logger.info?.(`nowledge-mem: creating thread ${buf.nowledgeThreadId} for ${threadId} (${msgsToSend.length} msgs, title="${buf.title}")`);
 					await client.createThread(
 						buf.title,
 						escapeForInline(summary, 1200),
-						buf.messages,
+						msgsToSend,
 						"alma",
 						buf.nowledgeThreadId,
 					);
 				}
 			}
-			buf.savedCount = buf.messages.length;
+			buf.savedCount = snapshotCount;
 			logger.info?.(`nowledge-mem: thread synced (${threadId}, ${buf.messages.length} msgs)`);
 		} catch (err) {
 			logger.error?.(`nowledge-mem: thread sync failed: ${err instanceof Error ? err.message : String(err)}`);
@@ -1460,6 +1460,15 @@ export async function activate(context) {
 
 	return {
 		dispose() {
+			// Flush any unsynced thread buffers before tearing down.
+			// This covers plugin disable/reload paths where quit hooks may not fire.
+			for (const [threadId, buf] of threadBuffers) {
+				if (buf.messages.length > buf.savedCount && !buf.flushing) {
+					flushThread(threadId).catch((err) =>
+						logger.error?.(`nowledge-mem: dispose flush failed for ${threadId}: ${err}`),
+					);
+				}
+			}
 			for (const d of disposables) {
 				try { d.dispose(); } catch { /* best effort */ }
 			}
@@ -1471,7 +1480,7 @@ export async function activate(context) {
 
 export async function deactivate(context) {
 	const logger = context?.logger ?? console;
-	// Thread buffers are flushed by quit hooks registered in activate().
-	// deactivate() cannot access those buffers (they're scoped to activate's closure).
+	// Thread buffers are flushed by dispose() (scoped to activate's closure).
+	// deactivate() is called externally and cannot access those buffers directly.
 	logger.info?.("nowledge-mem deactivated");
 }

--- a/nowledge-mem-alma-plugin/main.js
+++ b/nowledge-mem-alma-plugin/main.js
@@ -1,4 +1,5 @@
 import { spawnSync } from "node:child_process";
+import { createHash } from "node:crypto";
 import { readFileSync, statSync } from "node:fs";
 import { homedir } from "node:os";
 
@@ -265,8 +266,9 @@ class NowledgeMemClient {
 		return this.run(args, true);
 	}
 
-	async createThread(title, content, messages, source = "alma") {
+	async createThread(title, content, messages, source = "alma", id = null) {
 		const args = ["--json", "t", "create", "-t", title];
+		if (id) args.push("--id", id);
 		if (typeof content === "string" && content.trim()) args.push("-c", content.trim());
 		if (Array.isArray(messages) && messages.length > 0) {
 			args.push("-m", JSON.stringify(messages));
@@ -1317,47 +1319,8 @@ export async function activate(context) {
 	// Buffer schema: { title, messages: [{role,content}], savedCount: number,
 	//   nowledgeThreadId: string|null, flushing: boolean, timer: number|null }
 	const MAX_THREAD_BUFFERS = 20;
-	const MAX_MAPPING_AGE_MS = 7 * 24 * 60 * 60 * 1000; // 1 week
 	const threadBuffers = new Map();
-	const nowledgeMemThreadIds = new Map(); // almaThreadId → { id: nowledgeMemThreadId, ts: epoch_ms } (persisted)
 	let activeThreadId = null;
-
-	/** Load thread mapping from persistent storage, pruning entries older than 1 week. */
-	const loadThreadMapping = async () => {
-		try {
-			const data = await context.storage?.local?.get('nowledgeMem.threadMapping', {});
-			if (data && typeof data === 'object') {
-				const now = Date.now();
-				let pruned = 0;
-				for (const [k, v] of Object.entries(data)) {
-					if (v && typeof v === 'object' && typeof v.id === 'string' && typeof v.ts === 'number') {
-						if (now - v.ts > MAX_MAPPING_AGE_MS) {
-							pruned++;
-						} else {
-							nowledgeMemThreadIds.set(k, v);
-						}
-					} else {
-						pruned++; // legacy string format — drop
-					}
-				}
-				logger.info?.(`nowledge-mem: loaded ${nowledgeMemThreadIds.size} thread mappings from storage (pruned ${pruned})`);
-				if (pruned > 0) await persistThreadMapping();
-			}
-		} catch (err) {
-			logger.warn?.(`nowledge-mem: failed to load thread mapping: ${err instanceof Error ? err.message : String(err)}`);
-		}
-	};
-	await loadThreadMapping();
-
-	/** Persist thread mapping to storage. */
-	const persistThreadMapping = async () => {
-		try {
-			const obj = Object.fromEntries(nowledgeMemThreadIds);
-			await context.storage?.local?.set('nowledgeMem.threadMapping', obj);
-		} catch (err) {
-			logger.warn?.(`nowledge-mem: failed to persist thread mapping: ${err instanceof Error ? err.message : String(err)}`);
-		}
-	};
 
 	/** Resolve the best possible thread title via Alma APIs, falling back to first user message. */
 	const resolveTitle = async (threadId, buf) => {
@@ -1391,6 +1354,10 @@ export async function activate(context) {
 		return null;
 	};
 
+	/** Derive a stable Nowledge Mem thread ID from an Alma thread ID. */
+	const stableThreadId = (almaThreadId) =>
+		`alma-${createHash("sha1").update(String(almaThreadId)).digest("hex").slice(0, 12)}`;
+
 	/** Flush a thread buffer to Nowledge Mem if it has new messages. */
 	const flushThread = async (threadId) => {
 		const buf = threadBuffers.get(threadId);
@@ -1402,39 +1369,39 @@ export async function activate(context) {
 		// Cancel this buffer's idle timer
 		if (buf.timer) { clearTimeout(buf.timer); buf.timer = null; }
 
+		// Ensure stable thread ID (survives plugin restarts and LRU eviction)
+		if (!buf.nowledgeThreadId) buf.nowledgeThreadId = stableThreadId(threadId);
+
 		try {
 			// Resolve title right before saving (Alma generates titles asynchronously)
 			const resolved = await resolveTitle(threadId, buf);
 			if (resolved) buf.title = escapeForInline(resolved, 120);
 
-			if (buf.nowledgeThreadId) {
-				// Append only new messages to existing thread
+			if (buf.savedCount > 0) {
+				// Already synced before in this session: append new messages
 				const newMessages = buf.messages.slice(buf.savedCount);
 				logger.info?.(`nowledge-mem: appending ${newMessages.length} msgs to ${buf.nowledgeThreadId}`);
 				await client.appendThread(buf.nowledgeThreadId, newMessages);
 			} else {
-				// First flush — create the thread
-				const summary = buf.messages
-					.slice(-8)
-					.map((msg) => `[${msg.role}] ${escapeForInline(msg.content, 280)}`)
-					.join("\n");
-				logger.info?.(`nowledge-mem: creating thread for ${threadId} (${buf.messages.length} msgs, title="${buf.title}")`);
-				const result = await client.createThread(
-					buf.title,
-					escapeForInline(summary, 1200),
-					buf.messages,
-					"alma",
-				);
-				// Extract the created thread ID from the result
-				const createdId =
-					(result && typeof result === "object")
-						? String(result.id ?? result.thread_id ?? result.thread?.thread_id ?? "")
-						: String(result ?? "");
-				if (createdId) {
-					buf.nowledgeThreadId = createdId;
-					// Persist the mapping for cross-session continuity
-					nowledgeMemThreadIds.set(threadId, { id: createdId, ts: Date.now() });
-					await persistThreadMapping();
+				// First flush for this buffer: try append (thread may exist from prior session), fall back to create
+				try {
+					logger.info?.(`nowledge-mem: appending ${buf.messages.length} msgs to ${buf.nowledgeThreadId} (reconnect)`);
+					await client.appendThread(buf.nowledgeThreadId, buf.messages);
+				} catch (appendErr) {
+					// Thread does not exist yet: create with stable ID
+					logger.debug?.(`nowledge-mem: append-first failed (${appendErr instanceof Error ? appendErr.message : String(appendErr)}), creating new thread`);
+					const summary = buf.messages
+						.slice(-8)
+						.map((msg) => `[${msg.role}] ${escapeForInline(msg.content, 280)}`)
+						.join("\n");
+					logger.info?.(`nowledge-mem: creating thread ${buf.nowledgeThreadId} for ${threadId} (${buf.messages.length} msgs, title="${buf.title}")`);
+					await client.createThread(
+						buf.title,
+						escapeForInline(summary, 1200),
+						buf.messages,
+						"alma",
+						buf.nowledgeThreadId,
+					);
 				}
 			}
 			buf.savedCount = buf.messages.length;
@@ -1469,13 +1436,11 @@ export async function activate(context) {
 				if (evicted?.timer) clearTimeout(evicted.timer);
 				threadBuffers.delete(oldest);
 			}
-			// Check if we have a persisted mapping for this thread
-			const persistedNmId = nowledgeMemThreadIds.get(threadId)?.id || null;
 			threadBuffers.set(threadId, {
 				title: escapeForInline(`Alma Thread ${new Date().toISOString().slice(0, 10)}`, 120),
 				messages: [],
 				savedCount: 0,
-				nowledgeThreadId: persistedNmId,
+				nowledgeThreadId: null,
 				flushing: false,
 				timer: null,
 			});

--- a/nowledge-mem-alma-plugin/main.js
+++ b/nowledge-mem-alma-plugin/main.js
@@ -71,89 +71,71 @@ class NowledgeMemClient {
 		this._apiKey = (credentials.apiKey || "").trim();
 	}
 
+	// --- HTTP transport (async, non-blocking) ---
+
+	/** Build common headers. API key is passed via Authorization header, never logged. */
+	_headers() {
+		const h = { "Content-Type": "application/json", Accept: "application/json" };
+		if (this._apiKey) h.Authorization = `Bearer ${this._apiKey}`;
+		return h;
+	}
+
+	/** Core async fetch with timeout. All data operations route through this. */
+	async _fetch(method, path, { body, params, timeout = 15_000 } = {}) {
+		const url = new URL(path, this._apiUrl);
+		if (params) {
+			for (const [k, v] of Object.entries(params)) {
+				if (v !== undefined && v !== null) url.searchParams.set(k, String(v));
+			}
+		}
+		const controller = new AbortController();
+		const timer = setTimeout(() => controller.abort(), timeout);
+		try {
+			const resp = await fetch(url.href, {
+				method,
+				headers: this._headers(),
+				body: body !== undefined ? JSON.stringify(body) : undefined,
+				signal: controller.signal,
+			});
+			if (!resp.ok) {
+				const text = await resp.text().catch(() => "");
+				throw new Error(`HTTP ${resp.status}: ${text.slice(0, 200)}`);
+			}
+			const ct = resp.headers.get("content-type") || "";
+			return ct.includes("application/json") ? resp.json() : resp.text();
+		} finally {
+			clearTimeout(timer);
+		}
+	}
+
+	// --- CLI diagnostic (sync, used only for status tool) ---
+
 	resolveCommand() {
 		if (this.command) return this.command;
-
-		const candidates = [
+		for (const candidate of [
 			{ cmd: "nmem", prefix: [] },
 			{ cmd: "uvx", prefix: ["--from", "nmem-cli", "nmem"] },
-		];
-
-		for (const candidate of candidates) {
-			const result = spawnSync(
-				candidate.cmd,
-				[...candidate.prefix, "--version"],
-				{
-					encoding: "utf-8",
-					timeout: 10_000,
-				},
-			);
+		]) {
+			const result = spawnSync(candidate.cmd, [...candidate.prefix, "--version"], {
+				encoding: "utf-8",
+				timeout: 10_000,
+			});
 			if (result.status === 0) {
 				this.command = candidate;
-				this.logger.info?.(
-					`nmem resolved via: ${candidate.cmd} ${candidate.prefix.join(" ")}`.trim(),
-				);
+				this.logger.info?.(`nmem resolved via: ${candidate.cmd} ${candidate.prefix.join(" ")}`.trim());
 				return candidate;
 			}
 		}
-
-		throw new Error(
-			"nmem CLI not found. Install with `pip install nmem` or use `uvx --from nmem-cli nmem`.",
-		);
+		throw new Error("nmem CLI not found. Install with `pip install nmem` or use `uvx --from nmem-cli nmem`.");
 	}
 
-	/**
-	 * Build env for child process. API key is injected here — NEVER via CLI args.
-	 */
-	_spawnEnv() {
-		const env = { ...process.env };
-		if (this._apiUrl !== "http://127.0.0.1:14242") {
-			env.NMEM_API_URL = this._apiUrl;
-		}
-		if (this._apiKey) {
-			env.NMEM_API_KEY = this._apiKey;
-		}
-		return env;
-	}
-
-	/**
-	 * Build base CLI args for remote access. --api-url is safe (not a secret).
-	 */
-	_apiUrlArgs() {
-		return this._apiUrl !== "http://127.0.0.1:14242"
-			? ["--api-url", this._apiUrl]
-			: [];
-	}
-
-	run(args, expectJson = false) {
-		const { cmd, prefix } = this.resolveCommand();
-		const finalArgs = [...prefix, ...this._apiUrlArgs(), ...args];
-		const result = spawnSync(cmd, finalArgs, {
-			encoding: "utf-8",
-			timeout: 30_000,
-			env: this._spawnEnv(),
-		});
-
-		if (result.status !== 0) {
-			const stderr = result.stderr?.trim() || "unknown error";
-			throw new Error(
-				`nmem command failed: ${cmd} ${finalArgs.join(" ")}\n${stderr}`,
-			);
-		}
-
-		const stdout = result.stdout?.trim() ?? "";
-		if (!expectJson) return stdout;
-
-		try {
-			return JSON.parse(stdout);
-		} catch {
-			throw new Error("nmem returned invalid JSON output");
-		}
-	}
+	// --- Memory operations ---
 
 	async search(query, limit = 5) {
 		const safeLimit = clamp(Number(limit) || 5, 1, 20);
-		const data = this.run(["--json", "m", "search", query, "-n", String(safeLimit)], true);
+		const data = await this._fetch("GET", "/memories/search", {
+			params: { query, limit: safeLimit },
+		});
 		const memories = data.memories ?? data.results ?? [];
 		return memories.map((memory) => ({
 			id: String(memory.id ?? ""),
@@ -171,56 +153,43 @@ class NowledgeMemClient {
 	}
 
 	async searchMemory(query, options = {}) {
-		const args = ["--json", "m", "search", query];
-		if (options.limit !== undefined) {
-			args.push("-n", String(clamp(Number(options.limit) || 5, 1, 20)));
-		}
-		if (typeof options.label === "string" && options.label.trim()) {
-			args.push("-l", options.label.trim());
-		}
-		if (typeof options.time === "string" && options.time.trim()) {
-			args.push("-t", options.time.trim());
-		}
+		const params = { query };
+		if (options.limit !== undefined) params.limit = clamp(Number(options.limit) || 5, 1, 20);
+		if (typeof options.label === "string" && options.label.trim()) params.filter_labels = options.label.trim();
+		if (typeof options.time === "string" && options.time.trim()) params.event_date_from = options.time.trim();
 		if (typeof options.importance === "number" && Number.isFinite(options.importance)) {
-			args.push("--importance", String(clamp(options.importance, 0.1, 1.0)));
+			params.importance_min = clamp(options.importance, 0.1, 1.0);
 		}
-		if (options.mode === "deep") args.push("--mode", "deep");
-		return this.run(args, true);
+		if (options.mode === "deep") params.mode = "deep";
+		return this._fetch("GET", "/memories/search", { params });
 	}
 
-	async showMemory(id, contentLimit = 1200) {
-		return this.run(
-			["--json", "m", "show", String(id), "--content-limit", String(Math.max(100, Math.floor(contentLimit)))],
-			true,
-		);
+	async showMemory(id, _contentLimit = 1200) {
+		return this._fetch("GET", `/memories/${encodeURIComponent(id)}`);
 	}
 
 	async addMemory(content, title, importance, labels = [], source) {
-		const args = ["--json", "m", "add", content];
-		if (title) args.push("-t", title);
+		const body = { content, source: source || "alma" };
+		if (title) body.title = title;
 		if (typeof importance === "number" && Number.isFinite(importance)) {
-			args.push("-i", String(clamp(importance, 0.1, 1.0)));
+			body.importance = clamp(importance, 0.1, 1.0);
 		}
-		for (const label of labels) args.push("-l", label);
-		if (source) args.push("-s", source);
-		const data = this.run(args, true);
-		return data;
+		if (labels.length > 0) body.labels = labels;
+		return this._fetch("POST", "/memories", { body });
 	}
 
 	async updateMemory(id, content, title, importance) {
-		const args = ["--json", "m", "update", String(id)];
-		if (typeof content === "string" && content.trim()) args.push("-c", content.trim());
-		if (typeof title === "string" && title.trim()) args.push("-t", title.trim());
+		const body = {};
+		if (typeof content === "string" && content.trim()) body.content = content.trim();
+		if (typeof title === "string" && title.trim()) body.title = title.trim();
 		if (typeof importance === "number" && Number.isFinite(importance)) {
-			args.push("-i", String(clamp(importance, 0.1, 1.0)));
+			body.importance = clamp(importance, 0.1, 1.0);
 		}
-		return this.run(args, true);
+		return this._fetch("PATCH", `/memories/${encodeURIComponent(id)}`, { body });
 	}
 
-	async deleteMemory(id, force = false) {
-		const args = ["--json", "m", "delete", String(id)];
-		if (force) args.push("-f");
-		return this.run(args, true);
+	async deleteMemory(id, _force = false) {
+		return this._fetch("DELETE", `/memories/${encodeURIComponent(id)}`);
 	}
 
 	async readWorkingMemory() {
@@ -239,56 +208,78 @@ class NowledgeMemClient {
 		}
 	}
 
-	async saveThread(summary) {
-		const args = ["t", "save", "--from", "alma", "--truncate"];
-		if (summary) args.push("-s", summary);
-		return this.run(args, false);
-	}
+	// --- Thread operations ---
 
 	async searchThreads(query, limit = 5, source) {
-		const args = ["--json", "t", "search", query, "-n", String(clamp(Number(limit) || 5, 1, 50))];
-		if (source) args.push("--source", String(source));
-		return this.run(args, true);
+		const params = { query, limit: clamp(Number(limit) || 5, 1, 50) };
+		if (source) params.source = String(source);
+		return this._fetch("GET", "/threads/search", { params });
 	}
 
 	async showThread(id, messages = 30, contentLimit = 1200, offset = 0) {
-		const args = [
-			"--json",
-			"t",
-			"show",
-			String(id),
-			"-n",
-			String(Math.max(1, Math.floor(messages))),
-			"--content-limit",
-			String(Math.max(100, Math.floor(contentLimit))),
-		];
-		if (offset > 0) args.push("--offset", String(Math.max(0, Math.floor(offset))));
-		return this.run(args, true);
+		const params = {
+			limit: Math.max(1, Math.floor(messages)),
+			offset: Math.max(0, Math.floor(offset)),
+		};
+		return this._fetch("GET", `/threads/${encodeURIComponent(id)}`, { params });
 	}
 
 	async createThread(title, content, messages, source = "alma", id = null) {
-		const args = ["--json", "t", "create", "-t", title];
-		if (id) args.push("--id", id);
-		if (typeof content === "string" && content.trim()) args.push("-c", content.trim());
-		if (Array.isArray(messages) && messages.length > 0) {
-			args.push("-m", JSON.stringify(messages));
+		const body = { title, source };
+		if (id) body.thread_id = id;
+		if (typeof content === "string" && content.trim()) {
+			// content goes into summary-like field; messages carry the actual data
 		}
-		if (source) args.push("-s", source);
-		return this.run(args, true);
+		if (Array.isArray(messages) && messages.length > 0) {
+			body.messages = messages;
+		} else if (typeof content === "string" && content.trim()) {
+			body.messages = [{ role: "user", content: content.trim() }];
+		}
+		// Generate thread_id if not provided (match CLI behavior)
+		if (!body.thread_id) {
+			const ts = new Date().toISOString().replace(/\D/g, "").slice(0, 14);
+			const titleHash = createHash("md5").update(title || "").digest("hex").slice(0, 6);
+			body.thread_id = `cli-${ts}-${titleHash}`;
+		}
+		const data = await this._fetch("POST", "/threads", { body, timeout: 30_000 });
+		const threadData = data.thread ?? {};
+		return {
+			success: true,
+			id: threadData.thread_id ?? body.thread_id,
+			title: threadData.title ?? title,
+			messages: (data.messages ?? []).length,
+		};
 	}
 
 	async appendThread(threadId, messages) {
-		const args = ["--json", "t", "append", String(threadId), "-m", JSON.stringify(messages)];
-		return this.run(args, true);
+		const data = await this._fetch("POST", `/threads/${encodeURIComponent(threadId)}/append`, {
+			body: { messages, deduplicate: true },
+			timeout: 30_000,
+		});
+		return {
+			success: data.success ?? true,
+			id: threadId,
+			messages_added: data.messages_added ?? 0,
+			total_messages: data.total_messages ?? 0,
+		};
 	}
 
 	async deleteThread(id, force = false, cascade = false) {
-		const args = ["--json", "t", "delete", String(id)];
-		if (force) args.push("-f");
-		if (cascade) args.push("--cascade");
-		return this.run(args, true);
+		const params = {};
+		if (cascade) params.cascade_delete_memories = true;
+		return this._fetch("DELETE", `/threads/${encodeURIComponent(id)}`, { params });
 	}
 
+	// --- Server health (async, for status tool) ---
+
+	async checkServerHealth() {
+		try {
+			await this._fetch("GET", "/health", { timeout: 5_000 });
+			return { connected: true, error: null };
+		} catch (err) {
+			return { connected: false, error: err instanceof Error ? err.message : String(err) };
+		}
+	}
 }
 
 function normalizeWillSendPayload(first, second) {
@@ -860,19 +851,18 @@ export async function activate(context) {
 			}
 
 			try {
-				const args = ["--json", "m", "add", text];
-				if (title) args.push("-t", title);
-				if (importance !== undefined && Number.isFinite(importance)) {
-					args.push("-i", String(importance));
-				}
-				if (unitType) args.push("--unit-type", unitType);
-				for (const label of labels) args.push("-l", label);
-				if (eventStart) args.push("--event-start", eventStart);
-				if (eventEnd) args.push("--event-end", eventEnd);
-				if (temporalContext) args.push("--when", temporalContext);
+				const body = { content: text, source: source || "alma" };
+				if (title) body.title = title;
+				if (importance !== undefined && Number.isFinite(importance)) body.importance = importance;
+				if (unitType) body.unit_type = unitType;
+				if (labels.length > 0) body.labels = labels;
+				if (eventStart) body.event_start = eventStart;
+				if (eventEnd) body.event_end = eventEnd;
+				if (temporalContext) body.temporal_context = temporalContext;
 
-				const result = client.run(args, true);
-				const id = String(result?.id ?? result?.memory?.id ?? result?.memory_id ?? "");
+				const result = await client._fetch("POST", "/memories", { body });
+				const mem = result?.memory ?? result ?? {};
+				const id = String(mem.id ?? result?.memory_id ?? "");
 
 				const typeLabel = unitType ? ` [${unitType}]` : "";
 				return {
@@ -1057,7 +1047,7 @@ export async function activate(context) {
 		async execute() {
 			const remoteMode = client._apiUrl !== "http://127.0.0.1:14242";
 
-			// Check CLI availability
+			// Check CLI availability (diagnostic only, not used for data operations)
 			let cliAvailable = false;
 			let cliCommand = null;
 			try {
@@ -1065,22 +1055,13 @@ export async function activate(context) {
 				cliAvailable = true;
 				cliCommand = `${resolved.cmd}${resolved.prefix.length ? ` ${resolved.prefix.join(" ")}` : ""}`;
 			} catch {
-				// CLI not found
+				// CLI not found (not required for HTTP transport)
 			}
 
-			// Check server connectivity
-			let serverConnected = false;
-			let serverError = null;
-			if (cliAvailable) {
-				try {
-					client.run(["status"], false);
-					serverConnected = true;
-				} catch (err) {
-					serverError = err instanceof Error ? err.message : String(err);
-				}
-			} else {
-				serverError = "nmem CLI not available";
-			}
+			// Check server connectivity via HTTP
+			const health = await client.checkServerHealth();
+			const serverConnected = health.connected;
+			const serverError = health.error;
 
 			return {
 				ok: true,

--- a/nowledge-mem-alma-plugin/main.js
+++ b/nowledge-mem-alma-plugin/main.js
@@ -316,17 +316,12 @@ function cliErrorResult(err, operation) {
 	const normalized = message.toLowerCase();
 	const status = err && typeof err === "object" ? err.status : undefined;
 	let code = "cli_error";
-	if (status === 404 || normalized.includes("not found")) code = "not_found";
-	if (status === 403 || normalized.includes("permission")) code = "permission_denied";
-	if (normalized.includes("invalid json")) code = "invalid_json";
+	// Order matters: most specific first, broader patterns last.
 	if (normalized.includes("nmem cli not found")) code = "nmem_not_found";
-	if (
-		normalized.includes("model") ||
-		normalized.includes("embedding") ||
-		normalized.includes("download")
-	) {
-		code = "model_unavailable";
-	}
+	else if (normalized.includes("invalid json")) code = "invalid_json";
+	else if (status === 403 || normalized.includes("permission")) code = "permission_denied";
+	else if (status === 404 || normalized.includes("not found")) code = "not_found";
+	else if (normalized.includes("model") || normalized.includes("embedding") || normalized.includes("download")) code = "model_unavailable";
 	return { ok: false, error: { code, operation, message } };
 }
 
@@ -567,7 +562,7 @@ export async function activate(context) {
 				label: { type: "string" },
 				time: { type: "string", enum: ["today", "week", "month", "year"] },
 				importance: { type: "number", minimum: 0.1, maximum: 1.0 },
-				mode: { type: "string", enum: ["normal", "deep"] },
+				mode: { type: "string", enum: ["fast", "deep"], default: "fast" },
 			},
 			required: ["query"],
 		},
@@ -579,7 +574,7 @@ export async function activate(context) {
 				label: { type: "string" },
 				time: { type: "string", enum: ["today", "week", "month", "year"] },
 				importance: { type: "number", minimum: 0.1, maximum: 1.0 },
-				mode: { type: "string", enum: ["normal", "deep"] },
+				mode: { type: "string", enum: ["fast", "deep"], default: "fast" },
 			},
 			required: ["query"],
 		},
@@ -598,7 +593,7 @@ export async function activate(context) {
 					time: input.time,
 					importance:
 						typeof input.importance === "number" ? clamp(input.importance, 0.1, 1.0) : undefined,
-					mode: input.mode === "deep" ? "deep" : "normal",
+					mode: input.mode === "deep" ? "deep" : "fast",
 				});
 				const result = normalizeSearchResponse(data, query, "memory");
 				// Enrich items with sourceThreadId for thread provenance
@@ -641,7 +636,7 @@ export async function activate(context) {
 			const limit = clamp(Number(input?.limit ?? 8) || 8, 1, 20);
 
 			try {
-				const memoryResult = await client.searchMemory(query, { limit, mode: "normal" });
+				const memoryResult = await client.searchMemory(query, { limit, mode: "fast" });
 				const memoryItems = normalizeItems(memoryResult, ["memories", "results"]);
 				if (memoryItems.length > 0) {
 					// Enrich items with sourceThreadId for thread provenance
@@ -800,11 +795,11 @@ export async function activate(context) {
 					ok: true,
 					item: {
 						id,
-						title: title ?? String(result?.title ?? ""),
+						title: title ?? String(mem.title ?? ""),
 						content: text,
-						unitType: result?.unit_type || unitType,
-						labels: result?.labels || labels,
-						importance: importance ?? Number(result?.importance ?? 0.5),
+						unitType: mem.unit_type || unitType,
+						labels: mem.labels || labels,
+						importance: importance ?? Number(mem.importance ?? 0.5),
 						eventStart,
 						eventEnd,
 						temporalContext,
@@ -1080,7 +1075,7 @@ export async function activate(context) {
 			const id = String(input?.id ?? "").trim();
 			if (!id) return validationErrorResult("thread_show", "id is required");
 			try {
-				const limit = clamp(Number(input?.limit ?? input?.messages ?? 30) || 30, 1, 200);
+				const limit = clamp(Number(input?.limit ?? 30) || 30, 1, 200);
 				const offset = Math.max(0, Math.floor(Number(input?.offset ?? 0) || 0));
 				const result = await client.showThread(id, limit, offset);
 				const threadMessages = Array.isArray(result?.messages) ? result.messages : [];
@@ -1374,16 +1369,19 @@ export async function activate(context) {
 			!(recallFrequency === "thread_once" && recalledThreads.has(threadId));
 
 		if (allowAutoRecall) {
-			const wm = await client.readWorkingMemory();
-			const results = await client.search(currentContent, maxRecallResults);
-			const contextBlock = buildMemoryContextBlock(wm, results, {
-				includeCliPlaybook: injectCliPlaybook,
-			});
-			if (!contextBlock) return;
-			if (payload.setContent(`${contextBlock}\n\n${currentContent}`)) {
-				if (allowAutoRecall && recallFrequency === "thread_once") {
-					recalledThreads.add(threadId);
+			try {
+				const wm = await client.readWorkingMemory();
+				const results = await client.search(currentContent, maxRecallResults);
+				const contextBlock = buildMemoryContextBlock(wm, results, {
+					includeCliPlaybook: injectCliPlaybook,
+				});
+				if (contextBlock && payload.setContent(`${contextBlock}\n\n${currentContent}`)) {
+					if (recallFrequency === "thread_once") {
+						recalledThreads.add(threadId);
+					}
 				}
+			} catch (recallErr) {
+				logger.error?.(`nowledge-mem: recall injection failed: ${recallErr instanceof Error ? recallErr.message : String(recallErr)}`);
 			}
 		}
 	});
@@ -1459,15 +1457,21 @@ export async function activate(context) {
 	);
 
 	return {
-		dispose() {
+		async dispose() {
 			// Flush any unsynced thread buffers before tearing down.
 			// This covers plugin disable/reload paths where quit hooks may not fire.
+			const flushPromises = [];
 			for (const [threadId, buf] of threadBuffers) {
 				if (buf.messages.length > buf.savedCount && !buf.flushing) {
-					flushThread(threadId).catch((err) =>
-						logger.error?.(`nowledge-mem: dispose flush failed for ${threadId}: ${err}`),
+					flushPromises.push(
+						flushThread(threadId).catch((err) =>
+							logger.error?.(`nowledge-mem: dispose flush failed for ${threadId}: ${err}`),
+						),
 					);
 				}
+			}
+			if (flushPromises.length > 0) {
+				await Promise.allSettled(flushPromises);
 			}
 			for (const d of disposables) {
 				try { d.dispose(); } catch { /* best effort */ }

--- a/nowledge-mem-alma-plugin/main.js
+++ b/nowledge-mem-alma-plugin/main.js
@@ -49,6 +49,14 @@ function extractText(content) {
 	return "";
 }
 
+/** Extract thread ID from a memory object, handling both string and {id, title} shapes. */
+function extractThreadId(mem) {
+	const st = mem?.source_thread;
+	if (typeof st === "string") return st;
+	if (st && typeof st === "object" && st.id) return String(st.id);
+	return mem?.source_thread_id ?? mem?.metadata?.source_thread_id ?? null;
+}
+
 class NowledgeMemClient {
 	/**
 	 * @param {object} logger
@@ -131,14 +139,10 @@ class NowledgeMemClient {
 			id: String(memory.id ?? ""),
 			title: String(memory.title ?? ""),
 			content: String(memory.content ?? ""),
-			score: Number(memory.score ?? 0),
+			score: Number(memory.relevance_score ?? memory.score ?? 0),
 			labels: Array.isArray(memory.labels) ? memory.labels : [],
 			importance: Number(memory.importance ?? memory.rating ?? 0.5),
-			sourceThreadId:
-				memory.source_thread ??
-				memory.source_thread_id ??
-				memory.metadata?.source_thread_id ??
-				null,
+			sourceThreadId: extractThreadId(memory),
 		}));
 	}
 
@@ -596,7 +600,7 @@ export async function activate(context) {
 				// Enrich items with sourceThreadId for thread provenance
 				if (result.ok && Array.isArray(result.items)) {
 					for (const item of result.items) {
-						const tid = item.source_thread ?? item.source_thread_id ?? item.metadata?.source_thread_id;
+						const tid = extractThreadId(item);
 						if (tid) item.sourceThreadId = tid;
 					}
 				}
@@ -638,7 +642,7 @@ export async function activate(context) {
 				if (memoryItems.length > 0) {
 					// Enrich items with sourceThreadId for thread provenance
 					for (const item of memoryItems) {
-						const tid = item.source_thread ?? item.source_thread_id ?? item.metadata?.source_thread_id;
+						const tid = extractThreadId(item);
 						if (tid) item.sourceThreadId = tid;
 					}
 					return {
@@ -834,8 +838,7 @@ export async function activate(context) {
 			if (!id) return validationErrorResult("memory_show", "id is required");
 			try {
 				const result = await client.showMemory(id);
-				const sourceThreadId =
-					result?.source_thread ?? result?.source_thread_id ?? result?.metadata?.source_thread_id ?? null;
+				const sourceThreadId = extractThreadId(result);
 				const response = {
 					ok: true,
 					item: result,

--- a/nowledge-mem-alma-plugin/main.js
+++ b/nowledge-mem-alma-plugin/main.js
@@ -3,8 +3,6 @@ import { createHash } from "node:crypto";
 import { readFileSync, statSync } from "node:fs";
 import { homedir } from "node:os";
 
-let quitCaptureAttempted = false;
-
 function clamp(value, min, max) {
 	return Math.min(max, Math.max(min, value));
 }
@@ -49,14 +47,6 @@ function extractText(content) {
 		if (typeof content.content === "string") return content.content;
 	}
 	return "";
-}
-
-function stringifyMessage(message) {
-	if (!message || typeof message !== "object") return "";
-	const role = typeof message.role === "string" ? message.role : "unknown";
-	const text = extractText(message.content);
-	if (!text) return "";
-	return `[${role}] ${escapeForInline(text, 400)}`;
 }
 
 class NowledgeMemClient {
@@ -134,7 +124,7 @@ class NowledgeMemClient {
 	async search(query, limit = 5) {
 		const safeLimit = clamp(Number(limit) || 5, 1, 20);
 		const data = await this._fetch("GET", "/memories/search", {
-			params: { query, limit: safeLimit },
+			params: { q: query, limit: safeLimit },
 		});
 		const memories = data.memories ?? data.results ?? [];
 		return memories.map((memory) => ({
@@ -153,10 +143,10 @@ class NowledgeMemClient {
 	}
 
 	async searchMemory(query, options = {}) {
-		const params = { query };
+		const params = { q: query };
 		if (options.limit !== undefined) params.limit = clamp(Number(options.limit) || 5, 1, 20);
-		if (typeof options.label === "string" && options.label.trim()) params.filter_labels = options.label.trim();
-		if (typeof options.time === "string" && options.time.trim()) params.event_date_from = options.time.trim();
+		if (typeof options.label === "string" && options.label.trim()) params.labels = options.label.trim();
+		if (typeof options.time === "string" && options.time.trim()) params.time_range = options.time.trim();
 		if (typeof options.importance === "number" && Number.isFinite(options.importance)) {
 			params.importance_min = clamp(options.importance, 0.1, 1.0);
 		}
@@ -164,18 +154,8 @@ class NowledgeMemClient {
 		return this._fetch("GET", "/memories/search", { params });
 	}
 
-	async showMemory(id, _contentLimit = 1200) {
+	async showMemory(id) {
 		return this._fetch("GET", `/memories/${encodeURIComponent(id)}`);
-	}
-
-	async addMemory(content, title, importance, labels = [], source) {
-		const body = { content, source: source || "alma" };
-		if (title) body.title = title;
-		if (typeof importance === "number" && Number.isFinite(importance)) {
-			body.importance = clamp(importance, 0.1, 1.0);
-		}
-		if (labels.length > 0) body.labels = labels;
-		return this._fetch("POST", "/memories", { body });
 	}
 
 	async updateMemory(id, content, title, importance) {
@@ -188,7 +168,7 @@ class NowledgeMemClient {
 		return this._fetch("PATCH", `/memories/${encodeURIComponent(id)}`, { body });
 	}
 
-	async deleteMemory(id, _force = false) {
+	async deleteMemory(id) {
 		return this._fetch("DELETE", `/memories/${encodeURIComponent(id)}`);
 	}
 
@@ -216,9 +196,9 @@ class NowledgeMemClient {
 		return this._fetch("GET", "/threads/search", { params });
 	}
 
-	async showThread(id, messages = 30, contentLimit = 1200, offset = 0) {
+	async showThread(id, limit = 30, offset = 0) {
 		const params = {
-			limit: Math.max(1, Math.floor(messages)),
+			limit: Math.max(1, Math.floor(limit)),
 			offset: Math.max(0, Math.floor(offset)),
 		};
 		return this._fetch("GET", `/threads/${encodeURIComponent(id)}`, { params });
@@ -239,7 +219,7 @@ class NowledgeMemClient {
 		if (!body.thread_id) {
 			const ts = new Date().toISOString().replace(/\D/g, "").slice(0, 14);
 			const titleHash = createHash("md5").update(title || "").digest("hex").slice(0, 6);
-			body.thread_id = `cli-${ts}-${titleHash}`;
+			body.thread_id = `alma-${ts}-${titleHash}`;
 		}
 		const data = await this._fetch("POST", "/threads", { body, timeout: 30_000 });
 		const threadData = data.thread ?? {};
@@ -264,7 +244,7 @@ class NowledgeMemClient {
 		};
 	}
 
-	async deleteThread(id, force = false, cascade = false) {
+	async deleteThread(id, cascade = false) {
 		const params = {};
 		if (cascade) params.cascade_delete_memories = true;
 		return this._fetch("DELETE", `/threads/${encodeURIComponent(id)}`, { params });
@@ -460,63 +440,6 @@ function buildMemoryContextBlock(workingMemory, results, options = {}) {
 
 	lines.push("", "</nowledge-mem-central-context>");
 	return lines.join("\n");
-}
-
-function normalizeThreadMessages(messages) {
-	return messages
-		.map((message) => {
-			const role =
-				typeof message?.role === "string" &&
-				["user", "assistant", "system"].includes(message.role)
-					? message.role
-					: "user";
-			const content = extractText(message?.content);
-			if (!content) return null;
-			return { role, content };
-		})
-		.filter(Boolean);
-}
-
-async function saveActiveThread(context, client) {
-	const chat = context.chat;
-	if (!chat?.getActiveThread || !chat?.getMessages) {
-		return "Skipped auto-capture: chat API unavailable.";
-	}
-
-	const activeThread = await chat.getActiveThread();
-	if (!activeThread?.id) {
-		return "Skipped auto-capture: no active thread.";
-	}
-
-	const messages = await chat.getMessages(activeThread.id);
-	if (!Array.isArray(messages) || messages.length === 0) {
-		return "Skipped auto-capture: no messages.";
-	}
-
-	const normalizedMessages = normalizeThreadMessages(messages);
-	if (!normalizedMessages.length) {
-		return "Skipped auto-capture: messages had no textual content.";
-	}
-
-	const title = escapeForInline(
-		typeof activeThread.title === "string" && activeThread.title.trim()
-			? activeThread.title
-			: `Alma Thread ${new Date().toISOString().slice(0, 10)}`,
-		120,
-	);
-	const summary = normalizedMessages
-		.slice(-8)
-		.map((msg) => `[${msg.role}] ${escapeForInline(msg.content, 280)}`)
-		.join("\n");
-
-	const created = await client.createThread(
-		title,
-		escapeForInline(summary, 1200),
-		normalizedMessages,
-		"alma",
-	);
-	const threadId = created?.id || created?.thread_id || "unknown";
-	return `Saved active thread (${normalizedMessages.length} messages, id=${threadId}).`;
 }
 
 export async function activate(context) {
@@ -896,7 +819,6 @@ export async function activate(context) {
 			type: "object",
 			properties: {
 				id: { type: "string", minLength: 1 },
-				contentLimit: { type: "number", minimum: 100, maximum: 10000, default: 1200 },
 			},
 			required: ["id"],
 		},
@@ -904,23 +826,19 @@ export async function activate(context) {
 			type: "object",
 			properties: {
 				id: { type: "string", minLength: 1 },
-				contentLimit: { type: "number", minimum: 100, maximum: 10000, default: 1200 },
 			},
 			required: ["id"],
 		},
 		async execute(input) {
 			const id = String(input?.id ?? "").trim();
 			if (!id) return validationErrorResult("memory_show", "id is required");
-			const contentLimit = clamp(Number(input?.contentLimit ?? 1200) || 1200, 100, 10000);
 			try {
-				const result = await client.showMemory(id, contentLimit);
-				const content = String(result?.content ?? "");
+				const result = await client.showMemory(id);
 				const sourceThreadId =
 					result?.source_thread ?? result?.source_thread_id ?? result?.metadata?.source_thread_id ?? null;
 				const response = {
 					ok: true,
 					item: result,
-					truncated: content.length >= contentLimit,
 				};
 				if (sourceThreadId) response.sourceThreadId = sourceThreadId;
 				return response;
@@ -1001,7 +919,7 @@ export async function activate(context) {
 			if (!id) return validationErrorResult("memory_delete", "id is required");
 			const force = input?.force === true;
 			try {
-				const result = await client.deleteMemory(id, force);
+				const result = await client.deleteMemory(id);
 				return { ok: true, id, force, notFound: false, item: result };
 			} catch (err) {
 				const info = cliErrorResult(err, "memory_delete");
@@ -1136,7 +1054,6 @@ export async function activate(context) {
 				id: { type: "string", minLength: 1 },
 				limit: { type: "number", minimum: 1, maximum: 200, default: 30 },
 				offset: { type: "number", minimum: 0, default: 0 },
-				contentLimit: { type: "number", minimum: 100, maximum: 20000, default: 1200 },
 			},
 			required: ["id"],
 		},
@@ -1152,7 +1069,6 @@ export async function activate(context) {
 					type: "number", minimum: 0, default: 0,
 					description: "Skip first N messages for pagination (default 0)",
 				},
-				contentLimit: { type: "number", minimum: 100, maximum: 20000, default: 1200 },
 			},
 			required: ["id"],
 		},
@@ -1162,8 +1078,7 @@ export async function activate(context) {
 			try {
 				const limit = clamp(Number(input?.limit ?? input?.messages ?? 30) || 30, 1, 200);
 				const offset = Math.max(0, Math.floor(Number(input?.offset ?? 0) || 0));
-				const contentLimit = clamp(Number(input?.contentLimit ?? 1200) || 1200, 100, 20000);
-				const result = await client.showThread(id, limit, contentLimit, offset);
+				const result = await client.showThread(id, limit, offset);
 				const threadMessages = Array.isArray(result?.messages) ? result.messages : [];
 				const totalMessages = Number(result?.total_messages ?? result?.message_count ?? threadMessages.length);
 				const hasMore = totalMessages > 0 && offset + threadMessages.length < totalMessages;
@@ -1174,10 +1089,6 @@ export async function activate(context) {
 					offset,
 					returnedMessages: threadMessages.length,
 					hasMore,
-					truncatedContent: threadMessages.some((m) => {
-						const txt = extractText(m?.content ?? m?.text ?? "");
-						return txt.length >= contentLimit;
-					}),
 				};
 			} catch (err) {
 				const info = cliErrorResult(err, "thread_show");
@@ -1282,7 +1193,7 @@ export async function activate(context) {
 			const force = input?.force === true;
 			const cascade = input?.cascade === true;
 			try {
-				const result = await client.deleteThread(id, force, cascade);
+				const result = await client.deleteThread(id, cascade);
 				return { ok: true, id, force, cascade, notFound: false, item: result };
 			} catch (err) {
 				const info = cliErrorResult(err, "thread_delete");
@@ -1494,7 +1405,6 @@ export async function activate(context) {
 
 		// --- Quit hooks as safety net ---
 		const handleAutoCapture = async (_input, output) => {
-			quitCaptureAttempted = true;
 			try {
 				// Flush all buffers with unsaved messages
 				const flushPromises = [];
@@ -1549,24 +1459,7 @@ export async function activate(context) {
 
 export async function deactivate(context) {
 	const logger = context?.logger ?? console;
-	const autoCapture = Boolean(
-		getSetting(context?.settings, "nowledgeMem.autoCapture", true),
-	);
-	if (!autoCapture || quitCaptureAttempted) {
-		logger.info?.("nowledge-mem deactivated");
-		return;
-	}
-	try {
-		quitCaptureAttempted = true;
-		const apiUrl = getSetting(context?.settings, "nowledgeMem.apiUrl", "") || "";
-		const apiKey = getSetting(context?.settings, "nowledgeMem.apiKey", "") || "";
-		const client = new NowledgeMemClient(logger, { apiUrl, apiKey });
-		const message = await saveActiveThread(context, client);
-		logger.info?.(`nowledge-mem: auto-capture on deactivate (${message})`);
-	} catch (err) {
-		logger.error?.(
-			`nowledge-mem auto-capture on deactivate failed: ${err instanceof Error ? err.message : String(err)}`,
-		);
-	}
+	// Thread buffers are flushed by quit hooks registered in activate().
+	// deactivate() cannot access those buffers (they're scoped to activate's closure).
 	logger.info?.("nowledge-mem deactivated");
 }

--- a/nowledge-mem-alma-plugin/manifest.json
+++ b/nowledge-mem-alma-plugin/manifest.json
@@ -2,7 +2,7 @@
   "id": "nowledge-mem",
   "name": "Nowledge Mem",
   "version": "0.6.14",
-  "description": "Local-first personal memory for Alma, powered by Nowledge Mem CLI",
+  "description": "Local-first personal memory for Alma, powered by Nowledge Mem",
   "author": {
     "name": "Nowledge Labs",
     "url": "https://github.com/nowledge-co"

--- a/nowledge-mem-alma-plugin/manifest.json
+++ b/nowledge-mem-alma-plugin/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "nowledge-mem",
   "name": "Nowledge Mem",
-  "version": "0.6.13",
+  "version": "0.6.14",
   "description": "Local-first personal memory for Alma, powered by Nowledge Mem CLI",
   "author": {
     "name": "Nowledge Labs",

--- a/nowledge-mem-alma-plugin/package.json
+++ b/nowledge-mem-alma-plugin/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@nowledge/alma-nowledge-mem",
-	"version": "0.6.14",
+	"version": "0.6.15",
 	"type": "module",
 	"description": "Nowledge Mem plugin for Alma, local-first personal knowledge base",
 	"author": {

--- a/nowledge-mem-alma-plugin/package.json
+++ b/nowledge-mem-alma-plugin/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@nowledge/alma-nowledge-mem",
-	"version": "0.6.13",
+	"version": "0.6.14",
 	"type": "module",
 	"description": "Nowledge Mem plugin for Alma, local-first personal knowledge base",
 	"author": {

--- a/nowledge-mem-codex-plugin/CHANGELOG.md
+++ b/nowledge-mem-codex-plugin/CHANGELOG.md
@@ -21,7 +21,7 @@
 
 ### Added
 
-- Five composable skills: `working-memory`, `search-memory`, `save-thread`, `distill-memory`, `status`.
+- Five composable skills: `read-working-memory`, `search-memory`, `save-thread`, `distill-memory`, `status`.
 - Plugin manifest with marketplace metadata.
 - Project-level `AGENTS.md` for stronger memory behavior in repos.
 - Migration path from `nowledge-mem-codex-prompts`.

--- a/nowledge-mem-hermes/CHANGELOG.md
+++ b/nowledge-mem-hermes/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [0.5.2] - 2026-04-07
+
+### Fixed
+
+- **Thread message limit was silently capped at 10.** The plugin default limit of 50 was only sent to the CLI when explicitly overridden. Since the CLI's own default is 10, all default `thread_messages` calls returned 10 messages while the plugin told the LLM it was requesting 50. The `-n` flag is now always passed.
+
 ## [0.5.1] - 2026-04-07
 
 ### Fixed

--- a/nowledge-mem-hermes/CHANGELOG.md
+++ b/nowledge-mem-hermes/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [0.5.1] - 2026-04-07
+
+### Fixed
+
+- **Install path**: `setup.sh` now installs to `~/.hermes/plugins/nowledge-mem/` instead of `~/.hermes/plugins/memory/nowledge-mem/`. Hermes scans direct children of `plugins/`, so the nested `memory/` directory was invisible to the plugin loader.
+- **Python imports**: changed bare imports (`from provider import ...`, `from client import ...`) to relative imports (`from .provider`, `from .client`). Hermes loads plugins via `importlib` with namespaced modules, which requires relative imports within the package.
+
 ## [0.5.0] - 2026-04-04
 
 ### Added

--- a/nowledge-mem-hermes/README.md
+++ b/nowledge-mem-hermes/README.md
@@ -23,10 +23,10 @@ hermes memory setup
 
 Or manually:
 
-1. Copy plugin files to `~/.hermes/plugins/memory/nowledge-mem/`:
+1. Copy plugin files to `~/.hermes/plugins/nowledge-mem/`:
    ```bash
-   mkdir -p ~/.hermes/plugins/memory/nowledge-mem
-   cd ~/.hermes/plugins/memory/nowledge-mem
+   mkdir -p ~/.hermes/plugins/nowledge-mem
+   cd ~/.hermes/plugins/nowledge-mem
    for f in plugin.yaml __init__.py provider.py client.py; do
      curl -sLO "https://raw.githubusercontent.com/nowledge-co/community/main/nowledge-mem-hermes/$f"
    done
@@ -125,7 +125,7 @@ Hermes should call `nmem_search` (plugin mode) or `mcp_nowledge_mem_memory_searc
 
 - **"Nowledge Mem server not reachable"**: Verify the desktop app is running. Check with `nmem status`.
 - **"nmem CLI not found"**: Install with `pip install nmem-cli`, or enable CLI in the desktop app: Settings > Developer Tools.
-- **Tools not appearing (plugin)**: Confirm `memory.provider: "nowledge-mem"` in config.yaml and plugin files exist in `~/.hermes/plugins/memory/nowledge-mem/`. Restart Hermes.
+- **Tools not appearing (plugin)**: Confirm `memory.provider: "nowledge-mem"` in config.yaml and plugin files exist in `~/.hermes/plugins/nowledge-mem/`. Restart Hermes.
 - **Tools not appearing (MCP)**: Confirm `mcp_servers.nowledge-mem` block in config.yaml. Restart Hermes.
 - **Hermes recalls but never saves**: In MCP mode, behavioral guidance may be missing from SOUL.md. In plugin mode, the guidance is built-in; check that the plugin loaded with `hermes memory status`.
 - **Slow responses**: Default timeout is 30 seconds. Increase in `nowledge-mem.json` for remote setups.

--- a/nowledge-mem-hermes/__init__.py
+++ b/nowledge-mem-hermes/__init__.py
@@ -5,7 +5,7 @@ connection with native lifecycle hooks: automatic Working Memory
 injection, per-turn recall, user-profile mirroring, and native tools.
 """
 
-from provider import NowledgeMemProvider
+from .provider import NowledgeMemProvider
 
 
 def register(ctx) -> None:

--- a/nowledge-mem-hermes/client.py
+++ b/nowledge-mem-hermes/client.py
@@ -171,8 +171,7 @@ class NowledgeMemClient:
     ) -> Any:
         """Fetch messages from a thread."""
         cmd = ["t", "show", thread_id]
-        if limit != 50:
-            cmd.extend(["-n", str(limit)])
+        cmd.extend(["-n", str(limit)])
         if offset:
             cmd.extend(["--offset", str(offset)])
         return self._cli(cmd)

--- a/nowledge-mem-hermes/plugin.yaml
+++ b/nowledge-mem-hermes/plugin.yaml
@@ -1,4 +1,4 @@
 name: nowledge-mem
-version: 0.5.1
+version: 0.5.2
 description: "Cross-tool personal knowledge graph with semantic search, Working Memory, and proactive recall."
 author: Nowledge Labs

--- a/nowledge-mem-hermes/plugin.yaml
+++ b/nowledge-mem-hermes/plugin.yaml
@@ -1,4 +1,4 @@
 name: nowledge-mem
-version: 0.5.0
+version: 0.5.1
 description: "Cross-tool personal knowledge graph with semantic search, Working Memory, and proactive recall."
 author: Nowledge Labs

--- a/nowledge-mem-hermes/provider.py
+++ b/nowledge-mem-hermes/provider.py
@@ -23,7 +23,7 @@ from typing import Any, Dict, List, Optional
 
 from agent.memory_provider import MemoryProvider
 
-from client import NowledgeMemClient
+from .client import NowledgeMemClient
 
 logger = logging.getLogger(__name__)
 

--- a/nowledge-mem-hermes/setup.sh
+++ b/nowledge-mem-hermes/setup.sh
@@ -46,7 +46,17 @@ get_file() {
 # Plugin install
 # =========================================================================
 if [ "$MODE" = "plugin" ]; then
-  PLUGIN_DIR="$HERMES_HOME/plugins/memory/nowledge-mem"
+  PLUGIN_DIR="$HERMES_HOME/plugins/nowledge-mem"
+
+  # Migrate from old incorrect path (v0.5.0 installed to plugins/memory/nowledge-mem)
+  OLD_PLUGIN_DIR="$HERMES_HOME/plugins/memory/nowledge-mem"
+  if [ -d "$OLD_PLUGIN_DIR" ] && [ -f "$OLD_PLUGIN_DIR/plugin.yaml" ]; then
+    echo "[*] Migrating from old install path..."
+    rm -rf "$OLD_PLUGIN_DIR"
+    rmdir "$HERMES_HOME/plugins/memory" 2>/dev/null || true
+    echo "  [ok] Removed $OLD_PLUGIN_DIR"
+  fi
+
   mkdir -p "$PLUGIN_DIR"
 
   echo "[*] Installing Nowledge Mem memory provider plugin..."

--- a/nowledge-mem-hermes/setup.sh
+++ b/nowledge-mem-hermes/setup.sh
@@ -48,13 +48,12 @@ get_file() {
 if [ "$MODE" = "plugin" ]; then
   PLUGIN_DIR="$HERMES_HOME/plugins/nowledge-mem"
 
-  # Migrate from old incorrect path (v0.5.0 installed to plugins/memory/nowledge-mem)
+  # Detect old incorrect path (v0.5.0 installed to plugins/memory/nowledge-mem)
   OLD_PLUGIN_DIR="$HERMES_HOME/plugins/memory/nowledge-mem"
+  MIGRATE_OLD=false
   if [ -d "$OLD_PLUGIN_DIR" ] && [ -f "$OLD_PLUGIN_DIR/plugin.yaml" ]; then
-    echo "[*] Migrating from old install path..."
-    rm -rf "$OLD_PLUGIN_DIR"
-    rmdir "$HERMES_HOME/plugins/memory" 2>/dev/null || true
-    echo "  [ok] Removed $OLD_PLUGIN_DIR"
+    echo "[*] Found old install path; will remove after successful install..."
+    MIGRATE_OLD=true
   fi
 
   mkdir -p "$PLUGIN_DIR"
@@ -78,6 +77,13 @@ if [ "$MODE" = "plugin" ]; then
   if ! $ALL_OK; then
     echo "[error] Some files failed to download. Check your network."
     exit 1
+  fi
+
+  # Now safe to remove old install path (download succeeded)
+  if $MIGRATE_OLD; then
+    rm -rf "$OLD_PLUGIN_DIR"
+    rmdir "$HERMES_HOME/plugins/memory" 2>/dev/null || true
+    echo "  [ok] Removed old install path $OLD_PLUGIN_DIR"
   fi
 
   # Set memory.provider in config.yaml

--- a/nowledge-mem-openclaw-plugin/CHANGELOG.md
+++ b/nowledge-mem-openclaw-plugin/CHANGELOG.md
@@ -2,6 +2,25 @@
 
 All notable changes to the Nowledge Mem OpenClaw plugin will be documented in this file.
 
+## [0.8.0] - 2026-04-07
+
+### Added
+
+- **Corpus supplement for OpenClaw dreaming.** Nowledge Mem's knowledge graph now participates in memory-core's recall pipeline and dreaming promotion. When `corpusSupplement: true` is set, memories stored in Nowledge Mem are searchable through memory-core's native `memory_search` tool and its three-phase dreaming system (light, deep, REM). Recalled Nowledge Mem content accumulates frequency, relevance, and diversity scores that feed into deep-phase promotion decisions. Cross-tool knowledge organically strengthens OpenClaw's local workspace memory.
+
+  Enable in your OpenClaw config:
+  ```json
+  { "corpusSupplement": true }
+  ```
+
+  Three new config keys control the supplement: `corpusSupplement` (boolean, default false), `corpusMaxResults` (1-20, default 5), `corpusMinScore` (0-100%, default 0).
+
+- **Duplicate recall prevention.** When the corpus supplement is active, the plugin's own search-based recall (in the hook and Context Engine) is automatically disabled. Working Memory injection continues as before. This prevents the same memories from appearing twice in the agent's context.
+
+### Changed
+
+- **Minimum OpenClaw version bumped to `>=2026.4.5`** for `registerMemoryCorpusSupplement` API support. Graceful fallback for older versions (registration silently skipped).
+
 ## [0.7.3] - 2026-03-30
 
 ### Added

--- a/nowledge-mem-openclaw-plugin/CHANGELOG.md
+++ b/nowledge-mem-openclaw-plugin/CHANGELOG.md
@@ -6,7 +6,7 @@ All notable changes to the Nowledge Mem OpenClaw plugin will be documented in th
 
 ### Fixed
 
-- **Cron and isolated-agent runs no longer sync into Mem threads by default.** OpenClaw schedules these as `agent:<agentId>:cron:...` (for example the `cron-worker` agent). They were previously captured like normal chat because `captureExclude` defaulted to empty and glob examples only match fixed segment counts. The plugin now detects the same session-key shape as OpenClaw's `isCronSessionKey`, plus bare `cron:*` keys, and skips thread append/create and distillation for those sessions (hook path and Context Engine `afterTurn`).
+- **Cron and isolated-agent runs no longer sync into Mem threads by default.** OpenClaw schedules these as `agent:<agentId>:cron:...` (for example the `cron-worker` agent). They were previously captured like normal chat because `captureExclude` defaulted to empty and segment-based globs do not cover variable-depth keys. The plugin now calls OpenClaw's published `isCronSessionKey` from `openclaw/plugin-sdk/routing` (no duplicated parsing logic), also skips bare `cron:*` internal keys that the SDK does not classify, and applies this in hook handlers and Context Engine `afterTurn` (thread append + distillation).
 
 ### Added
 

--- a/nowledge-mem-openclaw-plugin/CHANGELOG.md
+++ b/nowledge-mem-openclaw-plugin/CHANGELOG.md
@@ -6,7 +6,7 @@ All notable changes to the Nowledge Mem OpenClaw plugin will be documented in th
 
 ### Fixed
 
-- **Cron and isolated-agent runs no longer sync into Mem threads by default.** OpenClaw schedules these as `agent:<agentId>:cron:...` (for example the `cron-worker` agent). They were previously captured like normal chat because `captureExclude` defaulted to empty and segment-based globs do not cover variable-depth keys. The plugin now calls OpenClaw's published `isCronSessionKey` from `openclaw/plugin-sdk/routing` (no duplicated parsing logic), also skips bare `cron:*` internal keys that the SDK does not classify, and applies this in hook handlers and Context Engine `afterTurn` (thread append + distillation).
+- **Cron and isolated-agent runs no longer sync into Mem threads by default.** OpenClaw schedules these as `agent:<agentId>:cron:...` (for example the `cron-worker` agent). They were previously captured like normal chat because `captureExclude` defaulted to empty and segment-based globs do not cover variable-depth keys. The plugin now detects cron session keys by parsing the `agent:<id>:cron:...` format (matching OpenClaw's internal logic), also skips bare `cron:*` internal keys, and applies this in hook handlers and Context Engine `afterTurn` (thread append + distillation).
 
 ### Added
 

--- a/nowledge-mem-openclaw-plugin/CHANGELOG.md
+++ b/nowledge-mem-openclaw-plugin/CHANGELOG.md
@@ -6,7 +6,7 @@ All notable changes to the Nowledge Mem OpenClaw plugin will be documented in th
 
 ### Fixed
 
-- **Cron and isolated-agent runs no longer sync into Mem threads by default.** OpenClaw schedules these as `agent:<agentId>:cron:...` (for example the `cron-worker` agent). They were previously captured like normal chat because `captureExclude` defaulted to empty and segment-based globs do not cover variable-depth keys. The plugin now detects cron session keys by parsing the `agent:<id>:cron:...` format (matching OpenClaw's internal logic), also skips bare `cron:*` internal keys, and applies this in hook handlers and Context Engine `afterTurn` (thread append + distillation).
+- **Cron and isolated-agent runs no longer sync into Mem threads by default.** OpenClaw schedules these as `agent:<agentId>:cron:...` (for example the `cron-worker` agent). They were previously captured like normal chat because `captureExclude` defaulted to empty and segment-based globs do not cover variable-depth keys. The plugin now calls OpenClaw's published `isCronSessionKey` from `openclaw/plugin-sdk/routing` (available since v2026.3.22, no duplicated parsing logic), also skips bare `cron:*` internal keys that the SDK does not classify, and applies this in hook handlers and Context Engine `afterTurn` (thread append + distillation).
 
 ### Added
 

--- a/nowledge-mem-openclaw-plugin/CHANGELOG.md
+++ b/nowledge-mem-openclaw-plugin/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to the Nowledge Mem OpenClaw plugin will be documented in this file.
 
+## [0.8.1] - 2026-04-07
+
+### Fixed
+
+- **Thread provenance linking now handles API response shape.** The backend returns `source_thread` as an `{id, title}` object, but `_normalizeMemory` and `memory-get.js` assigned it directly to `sourceThreadId`, producing `[object Object]` instead of a usable thread ID. Both paths now extract the `.id` string, with fallbacks for the CLI string format and metadata `source_thread_id`.
+- **Child process env no longer leaks `"undefined"` strings.** `spawn-env.js` set `NMEM_API_URL` and `NMEM_API_KEY` to JavaScript `undefined` to clear inherited values, but Node's `child_process` stringifies that to the literal `"undefined"`. Now uses `delete` to properly remove the keys.
+
 ## [0.8.0] - 2026-04-07
 
 ### Fixed

--- a/nowledge-mem-openclaw-plugin/CHANGELOG.md
+++ b/nowledge-mem-openclaw-plugin/CHANGELOG.md
@@ -4,7 +4,12 @@ All notable changes to the Nowledge Mem OpenClaw plugin will be documented in th
 
 ## [0.8.0] - 2026-04-07
 
+### Fixed
+
+- **Cron and isolated-agent runs no longer sync into Mem threads by default.** OpenClaw schedules these as `agent:<agentId>:cron:...` (for example the `cron-worker` agent). They were previously captured like normal chat because `captureExclude` defaulted to empty and glob examples only match fixed segment counts. The plugin now detects the same session-key shape as OpenClaw's `isCronSessionKey`, plus bare `cron:*` keys, and skips thread append/create and distillation for those sessions (hook path and Context Engine `afterTurn`).
+
 ### Added
+
 
 - **Corpus supplement for OpenClaw dreaming.** Nowledge Mem's knowledge graph now participates in memory-core's recall pipeline and dreaming promotion. When `corpusSupplement: true` is set, memories stored in Nowledge Mem are searchable through memory-core's native `memory_search` tool and its three-phase dreaming system (light, deep, REM). Recalled Nowledge Mem content accumulates frequency, relevance, and diversity scores that feed into deep-phase promotion decisions. Cross-tool knowledge organically strengthens OpenClaw's local workspace memory.
 

--- a/nowledge-mem-openclaw-plugin/CLAUDE.md
+++ b/nowledge-mem-openclaw-plugin/CLAUDE.md
@@ -7,7 +7,7 @@ Continuation guide for `community/nowledge-mem-openclaw-plugin`.
 - Plugin target: OpenClaw plugin runtime (memory slot + context engine)
 - Runtime: JS ESM modules under `src/`, no TS build pipeline
 - Memory backend: `nmem` CLI (fallback: `uvx --from nmem-cli nmem`)
-- OpenClaw minimum: `2026.3.7` (`appendSystemContext` / system-context guidance required)
+- OpenClaw minimum: `2026.4.5` (`registerMemoryCorpusSupplement` for dreaming integration)
 - Architecture: **CLI-first via OpenClaw runtime** - all CLI execution goes through `api.runtime.system.runCommandWithTimeout`, not direct `child_process`
 - Context engine: registered via `api.registerContextEngine("nowledge-mem", factory)`. Activated when user sets `plugins.slots.contextEngine: "nowledge-mem"`. Falls back to hooks when CE is not active.
 - Remote mode: `~/.nowledge-mem/config.json` (shared) or OpenClaw dashboard. Legacy `openclaw.json` still honored.
@@ -34,6 +34,7 @@ src/
   client.js         - CLI wrapper with API fallback; async runtime command execution; credential handling
   spawn-env.js      - env-only credential injection for the nmem runner
   config.js         - config cascade: openclaw.json (legacy) > pluginConfig > config.json (credentials) > env > defaults
+  corpus-supplement.js - MemoryCorpusSupplement for memory-core dreaming pipeline; search + get backed by nmem
   hooks/
     behavioral.js   - always-on behavioral guidance (~50 tokens/turn); no-ops when CE active
     recall.js       - before_prompt_build: inject Working Memory + recalled memories; no-ops when CE active
@@ -55,6 +56,28 @@ openclaw.plugin.json - manifest + config schema (version, uiHints, configSchema,
 ~/.nowledge-mem/openclaw.json - legacy config file (still honored, deprecated in docs)
 ~/.nowledge-mem/config.json   - shared credentials (apiUrl/apiKey) read by all Nowledge Mem tools
 ```
+
+## Corpus Supplement (Dreaming Integration)
+
+When `corpusSupplement: true`, the plugin registers a `MemoryCorpusSupplement` via `api.registerMemoryCorpusSupplement()`. This makes Nowledge Mem's knowledge graph searchable through memory-core's recall pipeline, including its three-phase dreaming system (light, deep, REM).
+
+### How it works
+
+1. **Recall**: When memory-core's `memory_search` runs, it fans out to all registered corpus supplements. Our supplement calls `client.search()` and maps results to `MemoryCorpusSearchResult` format.
+2. **Dreaming**: Recalled Nowledge Mem content accumulates frequency, relevance, and diversity scores in memory-core's short-term recall store. High-scoring content is promoted to `MEMORY.md` during deep-phase dreaming.
+3. **Dedup**: When active, the recall hook and CE `assemble()` skip their own search-based recall (memories section only). Working Memory injection continues as before.
+
+### When to enable
+
+Enable when memory-core is the memory slot and you want cross-tool knowledge to participate in OpenClaw's native recall and dreaming. Most users have Nowledge Mem as the memory slot (default `false`).
+
+### Config keys
+
+| Key | Type | Default | Env Var | Description |
+|-----|------|---------|---------|-------------|
+| `corpusSupplement` | boolean | `false` | `NMEM_CORPUS_SUPPLEMENT` | Register as corpus supplement |
+| `corpusMaxResults` | integer 1-20 | `5` | `NMEM_CORPUS_MAX_RESULTS` | Max results per search call |
+| `corpusMinScore` | integer 0-100 | `0` | `NMEM_CORPUS_MIN_SCORE` | Min score filter (0 = include all) |
 
 ## Context Engine (CE) Architecture
 
@@ -153,6 +176,9 @@ Credentials (apiUrl/apiKey): also reads `~/.nowledge-mem/config.json` (shared wi
 | `maxThreadMessageChars` | integer 200-20000 | `800` | `NMEM_MAX_THREAD_MESSAGE_CHARS` | Max chars per captured thread message before truncation |
 | `captureExclude` | string[] | `[]` | — | Session key glob patterns to skip during auto-capture. `*` matches within a colon-segment. Example: `["agent:*:cron:*"]` |
 | `captureSkipMarker` | string | `"#nmem-skip"` | — | In-band marker: any message containing this text skips capture for the session. Not sticky across compaction |
+| `corpusSupplement` | boolean | `false` | `NMEM_CORPUS_SUPPLEMENT` | Register as MemoryCorpusSupplement for memory-core recall + dreaming |
+| `corpusMaxResults` | integer 1-20 | `5` | `NMEM_CORPUS_MAX_RESULTS` | Max results per corpus supplement search |
+| `corpusMinScore` | integer 0-100 | `0` | `NMEM_CORPUS_MIN_SCORE` | Min score for supplement results (0 = all) |
 | `apiUrl` | string | `""` | `NMEM_API_URL` | Remote server URL. Empty = local (127.0.0.1:14242) |
 | `apiKey` | string | `""` | `NMEM_API_KEY` | API key. Never logged. |
 

--- a/nowledge-mem-openclaw-plugin/README.md
+++ b/nowledge-mem-openclaw-plugin/README.md
@@ -9,7 +9,7 @@ This is not a flat note store. Nowledge Mem links related knowledge into a graph
 ## Requirements
 
 - [Nowledge Mem](https://mem.nowledge.co) desktop app **or** `nmem` CLI
-- [OpenClaw](https://openclaw.ai) >= 2026.3.7
+- [OpenClaw](https://openclaw.ai) >= 2026.4.5 (corpus supplement requires this version; core features work on >= 2026.3.7)
 
 ## Installation
 
@@ -186,6 +186,20 @@ flowchart LR
 Two entry points:
 1. **From a memory**: `memory_search` or `memory_get` returns `sourceThreadId`, then fetch the source conversation
 2. **Direct search**: `nowledge_mem_thread_search` finds conversations by keyword, then fetch any result
+
+### Corpus Supplement (Dreaming Integration)
+
+When OpenClaw's memory-core is the primary memory slot and Nowledge Mem runs alongside it, you can enable `corpusSupplement: true`. This registers Nowledge Mem as a searchable corpus inside memory-core's recall pipeline and three-phase dreaming system (light, deep, REM).
+
+**What happens:**
+- Every time memory-core runs `memory_search`, it also searches Nowledge Mem's knowledge graph via the supplement.
+- Recalled Nowledge Mem content accumulates frequency and relevance scores in memory-core's short-term store.
+- High-scoring content is promoted to `MEMORY.md` during deep-phase dreaming (daily, 3 AM).
+- The plugin's own search-based recall is automatically disabled to avoid duplicates. Working Memory injection continues as before.
+
+**When to enable:** When memory-core is the memory slot and you want your cross-tool knowledge graph to participate in OpenClaw's native dreaming cycle. Most users have Nowledge Mem as the memory slot directly, so this defaults to `false`.
+
+Requires OpenClaw >= 2026.4.5.
 
 ### Three Modes at a Glance
 
@@ -372,6 +386,9 @@ To change settings, use the OpenClaw plugin settings UI. Changes take effect on 
 | `maxContextResults` | integer | `5` | Max memories to inject at prompt time (1-20, only used when sessionContext is enabled) |
 | `recallMinScore` | integer | `0` | Min relevance score (0-100%) to include in auto-recall. 0 = include all |
 | `maxThreadMessageChars` | integer | `800` | Maximum characters preserved per captured OpenClaw thread message before truncation |
+| `corpusSupplement` | boolean | `false` | Register as a searchable corpus inside memory-core's recall and dreaming pipeline |
+| `corpusMaxResults` | integer | `5` | Max results per corpus supplement search (1-20) |
+| `corpusMinScore` | integer | `0` | Min relevance score (0-100%) for supplement results. 0 = include all |
 | `apiUrl` | string | `""` | Remote server URL. Empty = local (`http://127.0.0.1:14242`) |
 | `apiKey` | string | `""` | API key for remote access. Injected as `NMEM_API_KEY` env var, never logged |
 
@@ -399,6 +416,9 @@ NMEM_DIGEST_MIN_INTERVAL=300
 NMEM_MAX_CONTEXT_RESULTS=5
 NMEM_RECALL_MIN_SCORE=0
 NMEM_MAX_THREAD_MESSAGE_CHARS=800
+NMEM_CORPUS_SUPPLEMENT=false
+NMEM_CORPUS_MAX_RESULTS=5
+NMEM_CORPUS_MIN_SCORE=0
 NMEM_API_URL=https://...
 NMEM_API_KEY=your-key
 ```

--- a/nowledge-mem-openclaw-plugin/openclaw.plugin.json
+++ b/nowledge-mem-openclaw-plugin/openclaw.plugin.json
@@ -32,7 +32,7 @@
 		},
 		"captureExclude": {
 			"label": "Exclude session patterns",
-			"help": "Extra session key glob patterns to skip during auto-capture (* = one colon segment). Isolated cron sessions (OpenClaw `agent:*:cron:*` and bare `cron:*`) are always skipped \u2014 no config needed. Use this for subagents or other automation you want excluded."
+			"help": "Extra session key glob patterns to skip during auto-capture (* = one colon segment). OpenClaw cron / isolated automation sessions are always excluded using the host's own session classification\u2014no patterns required. Use this list for subagents or other sessions you want to filter."
 		},
 		"captureSkipMarker": {
 			"label": "Skip marker",
@@ -107,7 +107,7 @@
 					"type": "string"
 				},
 				"default": [],
-				"description": "Additional glob patterns to exclude from auto-capture. Cron / isolated-agent sessions are always excluded (same rule as OpenClaw's session-key utils). Glob * matches within one colon-delimited segment."
+				"description": "Additional glob patterns to exclude from auto-capture (* = one colon segment). Cron and isolated automation are always excluded via OpenClaw's isCronSessionKey (plugin-sdk) plus bare cron:* internal keys."
 			},
 			"captureSkipMarker": {
 				"type": "string",

--- a/nowledge-mem-openclaw-plugin/openclaw.plugin.json
+++ b/nowledge-mem-openclaw-plugin/openclaw.plugin.json
@@ -1,6 +1,6 @@
 {
 	"id": "openclaw-nowledge-mem",
-	"version": "0.8.0",
+	"version": "0.8.1",
 	"kind": "memory",
 	"skills": [
 		"skills/memory-guide"

--- a/nowledge-mem-openclaw-plugin/openclaw.plugin.json
+++ b/nowledge-mem-openclaw-plugin/openclaw.plugin.json
@@ -32,7 +32,7 @@
 		},
 		"captureExclude": {
 			"label": "Exclude session patterns",
-			"help": "Extra session key glob patterns to skip during auto-capture (* = one colon segment). Cron sessions (agent:<id>:cron:... and bare cron:*) are always excluded automatically. Use this list for subagents or other sessions you want to filter."
+			"help": "Extra session key glob patterns to skip during auto-capture (* = one colon segment). OpenClaw cron / isolated automation sessions are always excluded using the host's own session classification\u2014no patterns required. Use this list for subagents or other sessions you want to filter."
 		},
 		"captureSkipMarker": {
 			"label": "Skip marker",
@@ -107,7 +107,7 @@
 					"type": "string"
 				},
 				"default": [],
-				"description": "Additional glob patterns to exclude from auto-capture (* = one colon segment). Cron sessions (agent:<id>:cron:... and bare cron:*) are always excluded automatically."
+				"description": "Additional glob patterns to exclude from auto-capture (* = one colon segment). Cron and isolated automation are always excluded via OpenClaw's isCronSessionKey (plugin-sdk/routing) plus bare cron:* internal keys."
 			},
 			"captureSkipMarker": {
 				"type": "string",

--- a/nowledge-mem-openclaw-plugin/openclaw.plugin.json
+++ b/nowledge-mem-openclaw-plugin/openclaw.plugin.json
@@ -2,7 +2,9 @@
 	"id": "openclaw-nowledge-mem",
 	"version": "0.8.0",
 	"kind": "memory",
-	"skills": ["skills/memory-guide"],
+	"skills": [
+		"skills/memory-guide"
+	],
 	"uiHints": {
 		"sessionContext": {
 			"label": "Session context injection",
@@ -30,11 +32,11 @@
 		},
 		"captureExclude": {
 			"label": "Exclude session patterns",
-			"help": "Session key glob patterns to skip during auto-capture. Use * to match within a colon-segment. Example: agent:*:cron:*"
+			"help": "Extra session key glob patterns to skip during auto-capture (* = one colon segment). Isolated cron sessions (OpenClaw `agent:*:cron:*` and bare `cron:*`) are always skipped \u2014 no config needed. Use this for subagents or other automation you want excluded."
 		},
 		"captureSkipMarker": {
 			"label": "Skip marker",
-			"help": "Text marker in messages that prevents capture for the session. Default: #nmem-skip. Note: if compaction drops the marked message, capture resumes — use captureExclude patterns for persistent filtering."
+			"help": "Text marker in messages that prevents capture for the session. Default: #nmem-skip. Note: if compaction drops the marked message, capture resumes \u2014 use captureExclude patterns for persistent filtering."
 		},
 		"corpusSupplement": {
 			"label": "Register as corpus supplement",
@@ -101,14 +103,16 @@
 			},
 			"captureExclude": {
 				"type": "array",
-				"items": { "type": "string" },
+				"items": {
+					"type": "string"
+				},
 				"default": [],
-				"description": "Session key glob patterns to exclude from auto-capture. Glob * matches within a colon-delimited segment. Example: agent:*:cron:* excludes all cron job sessions."
+				"description": "Additional glob patterns to exclude from auto-capture. Cron / isolated-agent sessions are always excluded (same rule as OpenClaw's session-key utils). Glob * matches within one colon-delimited segment."
 			},
 			"captureSkipMarker": {
 				"type": "string",
 				"default": "#nmem-skip",
-				"description": "Text marker in messages that prevents capture for the entire session. When any message contains this marker, the session is skipped. Note: compaction may drop the marked message — use captureExclude for persistent filtering."
+				"description": "Text marker in messages that prevents capture for the entire session. When any message contains this marker, the session is skipped. Note: compaction may drop the marked message \u2014 use captureExclude for persistent filtering."
 			},
 			"corpusSupplement": {
 				"type": "boolean",

--- a/nowledge-mem-openclaw-plugin/openclaw.plugin.json
+++ b/nowledge-mem-openclaw-plugin/openclaw.plugin.json
@@ -1,6 +1,6 @@
 {
 	"id": "openclaw-nowledge-mem",
-	"version": "0.7.3",
+	"version": "0.8.0",
 	"kind": "memory",
 	"skills": ["skills/memory-guide"],
 	"uiHints": {
@@ -35,6 +35,18 @@
 		"captureSkipMarker": {
 			"label": "Skip marker",
 			"help": "Text marker in messages that prevents capture for the session. Default: #nmem-skip. Note: if compaction drops the marked message, capture resumes — use captureExclude patterns for persistent filtering."
+		},
+		"corpusSupplement": {
+			"label": "Register as corpus supplement",
+			"help": "Make Nowledge Mem searchable through memory-core's recall pipeline and dreaming promotion. Enable when memory-core is your memory slot and you want cross-tool knowledge to participate in OpenClaw's native recall and dreaming. When enabled, the plugin's own search-based recall is skipped to avoid duplicates (Working Memory injection continues)."
+		},
+		"corpusMaxResults": {
+			"label": "Corpus supplement max results",
+			"help": "Maximum results returned per corpus supplement search call (1-20). Only used when corpusSupplement is enabled."
+		},
+		"corpusMinScore": {
+			"label": "Corpus supplement min score (%)",
+			"help": "Minimum relevance score (0-100%) for corpus supplement results. Set to 0 to include all. Only used when corpusSupplement is enabled."
 		},
 		"apiUrl": {
 			"label": "Server URL (remote mode)",
@@ -97,6 +109,25 @@
 				"type": "string",
 				"default": "#nmem-skip",
 				"description": "Text marker in messages that prevents capture for the entire session. When any message contains this marker, the session is skipped. Note: compaction may drop the marked message — use captureExclude for persistent filtering."
+			},
+			"corpusSupplement": {
+				"type": "boolean",
+				"default": false,
+				"description": "Register Nowledge Mem as a MemoryCorpusSupplement for memory-core's recall pipeline and dreaming. Enable when memory-core is your memory slot."
+			},
+			"corpusMaxResults": {
+				"type": "integer",
+				"default": 5,
+				"minimum": 1,
+				"maximum": 20,
+				"description": "Maximum results per corpus supplement search call (only used when corpusSupplement is enabled)"
+			},
+			"corpusMinScore": {
+				"type": "integer",
+				"default": 0,
+				"minimum": 0,
+				"maximum": 100,
+				"description": "Minimum relevance score (0-100%) for corpus supplement results (only used when corpusSupplement is enabled)"
 			},
 			"apiUrl": {
 				"type": "string",

--- a/nowledge-mem-openclaw-plugin/openclaw.plugin.json
+++ b/nowledge-mem-openclaw-plugin/openclaw.plugin.json
@@ -32,7 +32,7 @@
 		},
 		"captureExclude": {
 			"label": "Exclude session patterns",
-			"help": "Extra session key glob patterns to skip during auto-capture (* = one colon segment). OpenClaw cron / isolated automation sessions are always excluded using the host's own session classification\u2014no patterns required. Use this list for subagents or other sessions you want to filter."
+			"help": "Extra session key glob patterns to skip during auto-capture (* = one colon segment). Cron sessions (agent:<id>:cron:... and bare cron:*) are always excluded automatically. Use this list for subagents or other sessions you want to filter."
 		},
 		"captureSkipMarker": {
 			"label": "Skip marker",
@@ -107,7 +107,7 @@
 					"type": "string"
 				},
 				"default": [],
-				"description": "Additional glob patterns to exclude from auto-capture (* = one colon segment). Cron and isolated automation are always excluded via OpenClaw's isCronSessionKey (plugin-sdk) plus bare cron:* internal keys."
+				"description": "Additional glob patterns to exclude from auto-capture (* = one colon segment). Cron sessions (agent:<id>:cron:... and bare cron:*) are always excluded automatically."
 			},
 			"captureSkipMarker": {
 				"type": "string",

--- a/nowledge-mem-openclaw-plugin/package-lock.json
+++ b/nowledge-mem-openclaw-plugin/package-lock.json
@@ -1,24 +1,24 @@
 {
 	"name": "@nowledge/openclaw-nowledge-mem",
-	"version": "0.6.11",
+	"version": "0.8.0",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "@nowledge/openclaw-nowledge-mem",
-			"version": "0.6.11",
+			"version": "0.8.0",
 			"license": "MIT",
 			"devDependencies": {
 				"@biomejs/biome": "^1.9.0"
 			},
 			"peerDependencies": {
-				"openclaw": ">=2026.3.7"
+				"openclaw": ">=2026.4.5"
 			}
 		},
 		"node_modules/@agentclientprotocol/sdk": {
-			"version": "0.14.1",
-			"resolved": "https://registry.npmjs.org/@agentclientprotocol/sdk/-/sdk-0.14.1.tgz",
-			"integrity": "sha512-b6r3PS3Nly+Wyw9U+0nOr47bV8tfS476EgyEMhoKvJCZLbgqoDFN7DJwkxL88RR0aiOqOYV1ZnESHqb+RmdH8w==",
+			"version": "0.18.0",
+			"resolved": "https://registry.npmjs.org/@agentclientprotocol/sdk/-/sdk-0.18.0.tgz",
+			"integrity": "sha512-JQGEi3EetQ38DLPpYxxnnz1fyo1/3qQEkKfUmj4JfiOJCEtjGWQ0nl54IH4LZceO7zIOrtUUxc+2cJRQbBOChA==",
 			"license": "Apache-2.0",
 			"peer": true,
 			"peerDependencies": {
@@ -26,9 +26,9 @@
 			}
 		},
 		"node_modules/@anthropic-ai/sdk": {
-			"version": "0.73.0",
-			"resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.73.0.tgz",
-			"integrity": "sha512-URURVzhxXGJDGUGFunIOtBlSl7KWvZiAAKY/ttTkZAkXT9bTPqdk2eK0b8qqSxXpikh3QKPnPYpiyX98zf5ebw==",
+			"version": "0.82.0",
+			"resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.82.0.tgz",
+			"integrity": "sha512-xdHTjL1GlUlDugHq/I47qdOKp/ROPvuHl7ROJCgUQigbvPu7asf9KcAcU1EqdrP2LuVhEKaTs7Z+ShpZDRzHdQ==",
 			"license": "MIT",
 			"peer": true,
 			"dependencies": {
@@ -44,6 +44,17 @@
 				"zod": {
 					"optional": true
 				}
+			}
+		},
+		"node_modules/@anthropic-ai/vertex-sdk": {
+			"version": "0.14.4",
+			"resolved": "https://registry.npmjs.org/@anthropic-ai/vertex-sdk/-/vertex-sdk-0.14.4.tgz",
+			"integrity": "sha512-BZUPRWghZxfSFtAxU563wH+jfWBPoedAwsVxG35FhmNsjeV8tyfN+lFriWhCpcZApxA4NdT6Soov+PzfnxxD5g==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"@anthropic-ai/sdk": ">=0.50.3 <1",
+				"google-auth-library": "^9.4.2"
 			}
 		},
 		"node_modules/@aws-crypto/crc32": {
@@ -197,51 +208,51 @@
 			}
 		},
 		"node_modules/@aws-sdk/client-bedrock": {
-			"version": "3.995.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/client-bedrock/-/client-bedrock-3.995.0.tgz",
-			"integrity": "sha512-ONw5c7pOeHe78kC+jK2j73hP727Kqp7cc9lZqkfshlBD8MWxXmZM9GihIQLrNBCSUKRhc19NH7DUM6B7uN0mMQ==",
+			"version": "3.1023.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/client-bedrock/-/client-bedrock-3.1023.0.tgz",
+			"integrity": "sha512-FmHGUYqToT7rsbeLukagUcYoAM22/ZxInkK+duVpZBmpu2D9cIoLIp5n/bKPjds3cw/8YTZKZt16kF2vJ6KbXA==",
 			"license": "Apache-2.0",
 			"peer": true,
 			"dependencies": {
 				"@aws-crypto/sha256-browser": "5.2.0",
 				"@aws-crypto/sha256-js": "5.2.0",
-				"@aws-sdk/core": "^3.973.11",
-				"@aws-sdk/credential-provider-node": "^3.972.10",
-				"@aws-sdk/middleware-host-header": "^3.972.3",
-				"@aws-sdk/middleware-logger": "^3.972.3",
-				"@aws-sdk/middleware-recursion-detection": "^3.972.3",
-				"@aws-sdk/middleware-user-agent": "^3.972.11",
-				"@aws-sdk/region-config-resolver": "^3.972.3",
-				"@aws-sdk/token-providers": "3.995.0",
-				"@aws-sdk/types": "^3.973.1",
-				"@aws-sdk/util-endpoints": "3.995.0",
-				"@aws-sdk/util-user-agent-browser": "^3.972.3",
-				"@aws-sdk/util-user-agent-node": "^3.972.10",
-				"@smithy/config-resolver": "^4.4.6",
-				"@smithy/core": "^3.23.2",
-				"@smithy/fetch-http-handler": "^5.3.9",
-				"@smithy/hash-node": "^4.2.8",
-				"@smithy/invalid-dependency": "^4.2.8",
-				"@smithy/middleware-content-length": "^4.2.8",
-				"@smithy/middleware-endpoint": "^4.4.16",
-				"@smithy/middleware-retry": "^4.4.33",
-				"@smithy/middleware-serde": "^4.2.9",
-				"@smithy/middleware-stack": "^4.2.8",
-				"@smithy/node-config-provider": "^4.3.8",
-				"@smithy/node-http-handler": "^4.4.10",
-				"@smithy/protocol-http": "^5.3.8",
-				"@smithy/smithy-client": "^4.11.5",
-				"@smithy/types": "^4.12.0",
-				"@smithy/url-parser": "^4.2.8",
-				"@smithy/util-base64": "^4.3.0",
-				"@smithy/util-body-length-browser": "^4.2.0",
-				"@smithy/util-body-length-node": "^4.2.1",
-				"@smithy/util-defaults-mode-browser": "^4.3.32",
-				"@smithy/util-defaults-mode-node": "^4.2.35",
-				"@smithy/util-endpoints": "^3.2.8",
-				"@smithy/util-middleware": "^4.2.8",
-				"@smithy/util-retry": "^4.2.8",
-				"@smithy/util-utf8": "^4.2.0",
+				"@aws-sdk/core": "^3.973.26",
+				"@aws-sdk/credential-provider-node": "^3.972.29",
+				"@aws-sdk/middleware-host-header": "^3.972.8",
+				"@aws-sdk/middleware-logger": "^3.972.8",
+				"@aws-sdk/middleware-recursion-detection": "^3.972.9",
+				"@aws-sdk/middleware-user-agent": "^3.972.28",
+				"@aws-sdk/region-config-resolver": "^3.972.10",
+				"@aws-sdk/token-providers": "3.1023.0",
+				"@aws-sdk/types": "^3.973.6",
+				"@aws-sdk/util-endpoints": "^3.996.5",
+				"@aws-sdk/util-user-agent-browser": "^3.972.8",
+				"@aws-sdk/util-user-agent-node": "^3.973.14",
+				"@smithy/config-resolver": "^4.4.13",
+				"@smithy/core": "^3.23.13",
+				"@smithy/fetch-http-handler": "^5.3.15",
+				"@smithy/hash-node": "^4.2.12",
+				"@smithy/invalid-dependency": "^4.2.12",
+				"@smithy/middleware-content-length": "^4.2.12",
+				"@smithy/middleware-endpoint": "^4.4.28",
+				"@smithy/middleware-retry": "^4.4.46",
+				"@smithy/middleware-serde": "^4.2.16",
+				"@smithy/middleware-stack": "^4.2.12",
+				"@smithy/node-config-provider": "^4.3.12",
+				"@smithy/node-http-handler": "^4.5.1",
+				"@smithy/protocol-http": "^5.3.12",
+				"@smithy/smithy-client": "^4.12.8",
+				"@smithy/types": "^4.13.1",
+				"@smithy/url-parser": "^4.2.12",
+				"@smithy/util-base64": "^4.3.2",
+				"@smithy/util-body-length-browser": "^4.2.2",
+				"@smithy/util-body-length-node": "^4.2.3",
+				"@smithy/util-defaults-mode-browser": "^4.3.44",
+				"@smithy/util-defaults-mode-node": "^4.2.48",
+				"@smithy/util-endpoints": "^3.3.3",
+				"@smithy/util-middleware": "^4.2.12",
+				"@smithy/util-retry": "^4.2.13",
+				"@smithy/util-utf8": "^4.2.2",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -249,125 +260,58 @@
 			}
 		},
 		"node_modules/@aws-sdk/client-bedrock-runtime": {
-			"version": "3.995.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/client-bedrock-runtime/-/client-bedrock-runtime-3.995.0.tgz",
-			"integrity": "sha512-nI7tT11L9s34AKr95GHmxs6k2+3ie+rEOew2cXOwsMC9k/5aifrZwh0JjAkBop4FqbmS8n0ZjCKDjBZFY/0YxQ==",
+			"version": "3.1023.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/client-bedrock-runtime/-/client-bedrock-runtime-3.1023.0.tgz",
+			"integrity": "sha512-C0He9qhrClUp6JEk3QjE0WScDN1GSZF8eruP0uoh5kXeQEJLxyfFDrR2TIYnHntlRs/sMwhO82Vu7yGGQM2pfQ==",
 			"license": "Apache-2.0",
 			"peer": true,
 			"dependencies": {
 				"@aws-crypto/sha256-browser": "5.2.0",
 				"@aws-crypto/sha256-js": "5.2.0",
-				"@aws-sdk/core": "^3.973.11",
-				"@aws-sdk/credential-provider-node": "^3.972.10",
-				"@aws-sdk/eventstream-handler-node": "^3.972.5",
-				"@aws-sdk/middleware-eventstream": "^3.972.3",
-				"@aws-sdk/middleware-host-header": "^3.972.3",
-				"@aws-sdk/middleware-logger": "^3.972.3",
-				"@aws-sdk/middleware-recursion-detection": "^3.972.3",
-				"@aws-sdk/middleware-user-agent": "^3.972.11",
-				"@aws-sdk/middleware-websocket": "^3.972.6",
-				"@aws-sdk/region-config-resolver": "^3.972.3",
-				"@aws-sdk/token-providers": "3.995.0",
-				"@aws-sdk/types": "^3.973.1",
-				"@aws-sdk/util-endpoints": "3.995.0",
-				"@aws-sdk/util-user-agent-browser": "^3.972.3",
-				"@aws-sdk/util-user-agent-node": "^3.972.10",
-				"@smithy/config-resolver": "^4.4.6",
-				"@smithy/core": "^3.23.2",
-				"@smithy/eventstream-serde-browser": "^4.2.8",
-				"@smithy/eventstream-serde-config-resolver": "^4.3.8",
-				"@smithy/eventstream-serde-node": "^4.2.8",
-				"@smithy/fetch-http-handler": "^5.3.9",
-				"@smithy/hash-node": "^4.2.8",
-				"@smithy/invalid-dependency": "^4.2.8",
-				"@smithy/middleware-content-length": "^4.2.8",
-				"@smithy/middleware-endpoint": "^4.4.16",
-				"@smithy/middleware-retry": "^4.4.33",
-				"@smithy/middleware-serde": "^4.2.9",
-				"@smithy/middleware-stack": "^4.2.8",
-				"@smithy/node-config-provider": "^4.3.8",
-				"@smithy/node-http-handler": "^4.4.10",
-				"@smithy/protocol-http": "^5.3.8",
-				"@smithy/smithy-client": "^4.11.5",
-				"@smithy/types": "^4.12.0",
-				"@smithy/url-parser": "^4.2.8",
-				"@smithy/util-base64": "^4.3.0",
-				"@smithy/util-body-length-browser": "^4.2.0",
-				"@smithy/util-body-length-node": "^4.2.1",
-				"@smithy/util-defaults-mode-browser": "^4.3.32",
-				"@smithy/util-defaults-mode-node": "^4.2.35",
-				"@smithy/util-endpoints": "^3.2.8",
-				"@smithy/util-middleware": "^4.2.8",
-				"@smithy/util-retry": "^4.2.8",
-				"@smithy/util-stream": "^4.5.12",
-				"@smithy/util-utf8": "^4.2.0",
-				"tslib": "^2.6.2"
-			},
-			"engines": {
-				"node": ">=20.0.0"
-			}
-		},
-		"node_modules/@aws-sdk/client-sso": {
-			"version": "3.993.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.993.0.tgz",
-			"integrity": "sha512-VLUN+wIeNX24fg12SCbzTUBnBENlL014yMKZvRhPkcn4wHR6LKgNrjsG3fZ03Xs0XoKaGtNFi1VVrq666sGBoQ==",
-			"license": "Apache-2.0",
-			"peer": true,
-			"dependencies": {
-				"@aws-crypto/sha256-browser": "5.2.0",
-				"@aws-crypto/sha256-js": "5.2.0",
-				"@aws-sdk/core": "^3.973.11",
-				"@aws-sdk/middleware-host-header": "^3.972.3",
-				"@aws-sdk/middleware-logger": "^3.972.3",
-				"@aws-sdk/middleware-recursion-detection": "^3.972.3",
-				"@aws-sdk/middleware-user-agent": "^3.972.11",
-				"@aws-sdk/region-config-resolver": "^3.972.3",
-				"@aws-sdk/types": "^3.973.1",
-				"@aws-sdk/util-endpoints": "3.993.0",
-				"@aws-sdk/util-user-agent-browser": "^3.972.3",
-				"@aws-sdk/util-user-agent-node": "^3.972.9",
-				"@smithy/config-resolver": "^4.4.6",
-				"@smithy/core": "^3.23.2",
-				"@smithy/fetch-http-handler": "^5.3.9",
-				"@smithy/hash-node": "^4.2.8",
-				"@smithy/invalid-dependency": "^4.2.8",
-				"@smithy/middleware-content-length": "^4.2.8",
-				"@smithy/middleware-endpoint": "^4.4.16",
-				"@smithy/middleware-retry": "^4.4.33",
-				"@smithy/middleware-serde": "^4.2.9",
-				"@smithy/middleware-stack": "^4.2.8",
-				"@smithy/node-config-provider": "^4.3.8",
-				"@smithy/node-http-handler": "^4.4.10",
-				"@smithy/protocol-http": "^5.3.8",
-				"@smithy/smithy-client": "^4.11.5",
-				"@smithy/types": "^4.12.0",
-				"@smithy/url-parser": "^4.2.8",
-				"@smithy/util-base64": "^4.3.0",
-				"@smithy/util-body-length-browser": "^4.2.0",
-				"@smithy/util-body-length-node": "^4.2.1",
-				"@smithy/util-defaults-mode-browser": "^4.3.32",
-				"@smithy/util-defaults-mode-node": "^4.2.35",
-				"@smithy/util-endpoints": "^3.2.8",
-				"@smithy/util-middleware": "^4.2.8",
-				"@smithy/util-retry": "^4.2.8",
-				"@smithy/util-utf8": "^4.2.0",
-				"tslib": "^2.6.2"
-			},
-			"engines": {
-				"node": ">=20.0.0"
-			}
-		},
-		"node_modules/@aws-sdk/client-sso/node_modules/@aws-sdk/util-endpoints": {
-			"version": "3.993.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.993.0.tgz",
-			"integrity": "sha512-j6vioBeRZ4eHX4SWGvGPpwGg/xSOcK7f1GL0VM+rdf3ZFTIsUEhCFmD78B+5r2PgztcECSzEfvHQX01k8dPQPw==",
-			"license": "Apache-2.0",
-			"peer": true,
-			"dependencies": {
-				"@aws-sdk/types": "^3.973.1",
-				"@smithy/types": "^4.12.0",
-				"@smithy/url-parser": "^4.2.8",
-				"@smithy/util-endpoints": "^3.2.8",
+				"@aws-sdk/core": "^3.973.26",
+				"@aws-sdk/credential-provider-node": "^3.972.29",
+				"@aws-sdk/eventstream-handler-node": "^3.972.12",
+				"@aws-sdk/middleware-eventstream": "^3.972.8",
+				"@aws-sdk/middleware-host-header": "^3.972.8",
+				"@aws-sdk/middleware-logger": "^3.972.8",
+				"@aws-sdk/middleware-recursion-detection": "^3.972.9",
+				"@aws-sdk/middleware-user-agent": "^3.972.28",
+				"@aws-sdk/middleware-websocket": "^3.972.14",
+				"@aws-sdk/region-config-resolver": "^3.972.10",
+				"@aws-sdk/token-providers": "3.1023.0",
+				"@aws-sdk/types": "^3.973.6",
+				"@aws-sdk/util-endpoints": "^3.996.5",
+				"@aws-sdk/util-user-agent-browser": "^3.972.8",
+				"@aws-sdk/util-user-agent-node": "^3.973.14",
+				"@smithy/config-resolver": "^4.4.13",
+				"@smithy/core": "^3.23.13",
+				"@smithy/eventstream-serde-browser": "^4.2.12",
+				"@smithy/eventstream-serde-config-resolver": "^4.3.12",
+				"@smithy/eventstream-serde-node": "^4.2.12",
+				"@smithy/fetch-http-handler": "^5.3.15",
+				"@smithy/hash-node": "^4.2.12",
+				"@smithy/invalid-dependency": "^4.2.12",
+				"@smithy/middleware-content-length": "^4.2.12",
+				"@smithy/middleware-endpoint": "^4.4.28",
+				"@smithy/middleware-retry": "^4.4.46",
+				"@smithy/middleware-serde": "^4.2.16",
+				"@smithy/middleware-stack": "^4.2.12",
+				"@smithy/node-config-provider": "^4.3.12",
+				"@smithy/node-http-handler": "^4.5.1",
+				"@smithy/protocol-http": "^5.3.12",
+				"@smithy/smithy-client": "^4.12.8",
+				"@smithy/types": "^4.13.1",
+				"@smithy/url-parser": "^4.2.12",
+				"@smithy/util-base64": "^4.3.2",
+				"@smithy/util-body-length-browser": "^4.2.2",
+				"@smithy/util-body-length-node": "^4.2.3",
+				"@smithy/util-defaults-mode-browser": "^4.3.44",
+				"@smithy/util-defaults-mode-node": "^4.2.48",
+				"@smithy/util-endpoints": "^3.3.3",
+				"@smithy/util-middleware": "^4.2.12",
+				"@smithy/util-retry": "^4.2.13",
+				"@smithy/util-stream": "^4.5.21",
+				"@smithy/util-utf8": "^4.2.2",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -375,24 +319,24 @@
 			}
 		},
 		"node_modules/@aws-sdk/core": {
-			"version": "3.973.11",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.973.11.tgz",
-			"integrity": "sha512-wdQ8vrvHkKIV7yNUKXyjPWKCdYEUrZTHJ8Ojd5uJxXp9vqPCkUR1dpi1NtOLcrDgueJH7MUH5lQZxshjFPSbDA==",
+			"version": "3.973.26",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.973.26.tgz",
+			"integrity": "sha512-A/E6n2W42ruU+sfWk+mMUOyVXbsSgGrY3MJ9/0Az5qUdG67y8I6HYzzoAa+e/lzxxl1uCYmEL6BTMi9ZiZnplQ==",
 			"license": "Apache-2.0",
 			"peer": true,
 			"dependencies": {
-				"@aws-sdk/types": "^3.973.1",
-				"@aws-sdk/xml-builder": "^3.972.5",
-				"@smithy/core": "^3.23.2",
-				"@smithy/node-config-provider": "^4.3.8",
-				"@smithy/property-provider": "^4.2.8",
-				"@smithy/protocol-http": "^5.3.8",
-				"@smithy/signature-v4": "^5.3.8",
-				"@smithy/smithy-client": "^4.11.5",
-				"@smithy/types": "^4.12.0",
-				"@smithy/util-base64": "^4.3.0",
-				"@smithy/util-middleware": "^4.2.8",
-				"@smithy/util-utf8": "^4.2.0",
+				"@aws-sdk/types": "^3.973.6",
+				"@aws-sdk/xml-builder": "^3.972.16",
+				"@smithy/core": "^3.23.13",
+				"@smithy/node-config-provider": "^4.3.12",
+				"@smithy/property-provider": "^4.2.12",
+				"@smithy/protocol-http": "^5.3.12",
+				"@smithy/signature-v4": "^5.3.12",
+				"@smithy/smithy-client": "^4.12.8",
+				"@smithy/types": "^4.13.1",
+				"@smithy/util-base64": "^4.3.2",
+				"@smithy/util-middleware": "^4.2.12",
+				"@smithy/util-utf8": "^4.2.2",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -400,16 +344,16 @@
 			}
 		},
 		"node_modules/@aws-sdk/credential-provider-env": {
-			"version": "3.972.9",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.972.9.tgz",
-			"integrity": "sha512-ZptrOwQynfupubvcngLkbdIq/aXvl/czdpEG8XJ8mN8Nb19BR0jaK0bR+tfuMU36Ez9q4xv7GGkHFqEEP2hUUQ==",
+			"version": "3.972.24",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.972.24.tgz",
+			"integrity": "sha512-FWg8uFmT6vQM7VuzELzwVo5bzExGaKHdubn0StjgrcU5FvuLExUe+k06kn/40uKv59rYzhez8eFNM4yYE/Yb/w==",
 			"license": "Apache-2.0",
 			"peer": true,
 			"dependencies": {
-				"@aws-sdk/core": "^3.973.11",
-				"@aws-sdk/types": "^3.973.1",
-				"@smithy/property-provider": "^4.2.8",
-				"@smithy/types": "^4.12.0",
+				"@aws-sdk/core": "^3.973.26",
+				"@aws-sdk/types": "^3.973.6",
+				"@smithy/property-provider": "^4.2.12",
+				"@smithy/types": "^4.13.1",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -417,21 +361,21 @@
 			}
 		},
 		"node_modules/@aws-sdk/credential-provider-http": {
-			"version": "3.972.11",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.972.11.tgz",
-			"integrity": "sha512-hECWoOoH386bGr89NQc9vA/abkGf5TJrMREt+lhNcnSNmoBS04fK7vc3LrJBSQAUGGVj0Tz3f4dHB3w5veovig==",
+			"version": "3.972.26",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.972.26.tgz",
+			"integrity": "sha512-CY4ppZ+qHYqcXqBVi//sdHST1QK3KzOEiLtpLsc9W2k2vfZPKExGaQIsOwcyvjpjUEolotitmd3mUNY56IwDEA==",
 			"license": "Apache-2.0",
 			"peer": true,
 			"dependencies": {
-				"@aws-sdk/core": "^3.973.11",
-				"@aws-sdk/types": "^3.973.1",
-				"@smithy/fetch-http-handler": "^5.3.9",
-				"@smithy/node-http-handler": "^4.4.10",
-				"@smithy/property-provider": "^4.2.8",
-				"@smithy/protocol-http": "^5.3.8",
-				"@smithy/smithy-client": "^4.11.5",
-				"@smithy/types": "^4.12.0",
-				"@smithy/util-stream": "^4.5.12",
+				"@aws-sdk/core": "^3.973.26",
+				"@aws-sdk/types": "^3.973.6",
+				"@smithy/fetch-http-handler": "^5.3.15",
+				"@smithy/node-http-handler": "^4.5.1",
+				"@smithy/property-provider": "^4.2.12",
+				"@smithy/protocol-http": "^5.3.12",
+				"@smithy/smithy-client": "^4.12.8",
+				"@smithy/types": "^4.13.1",
+				"@smithy/util-stream": "^4.5.21",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -439,25 +383,25 @@
 			}
 		},
 		"node_modules/@aws-sdk/credential-provider-ini": {
-			"version": "3.972.9",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.972.9.tgz",
-			"integrity": "sha512-zr1csEu9n4eDiHMTYJabX1mDGuGLgjgUnNckIivvk43DocJC9/f6DefFrnUPZXE+GHtbW50YuXb+JIxKykU74A==",
+			"version": "3.972.28",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.972.28.tgz",
+			"integrity": "sha512-wXYvq3+uQcZV7k+bE4yDXCTBdzWTU9x/nMiKBfzInmv6yYK1veMK0AKvRfRBd72nGWYKcL6AxwiPg9z/pYlgpw==",
 			"license": "Apache-2.0",
 			"peer": true,
 			"dependencies": {
-				"@aws-sdk/core": "^3.973.11",
-				"@aws-sdk/credential-provider-env": "^3.972.9",
-				"@aws-sdk/credential-provider-http": "^3.972.11",
-				"@aws-sdk/credential-provider-login": "^3.972.9",
-				"@aws-sdk/credential-provider-process": "^3.972.9",
-				"@aws-sdk/credential-provider-sso": "^3.972.9",
-				"@aws-sdk/credential-provider-web-identity": "^3.972.9",
-				"@aws-sdk/nested-clients": "3.993.0",
-				"@aws-sdk/types": "^3.973.1",
-				"@smithy/credential-provider-imds": "^4.2.8",
-				"@smithy/property-provider": "^4.2.8",
-				"@smithy/shared-ini-file-loader": "^4.4.3",
-				"@smithy/types": "^4.12.0",
+				"@aws-sdk/core": "^3.973.26",
+				"@aws-sdk/credential-provider-env": "^3.972.24",
+				"@aws-sdk/credential-provider-http": "^3.972.26",
+				"@aws-sdk/credential-provider-login": "^3.972.28",
+				"@aws-sdk/credential-provider-process": "^3.972.24",
+				"@aws-sdk/credential-provider-sso": "^3.972.28",
+				"@aws-sdk/credential-provider-web-identity": "^3.972.28",
+				"@aws-sdk/nested-clients": "^3.996.18",
+				"@aws-sdk/types": "^3.973.6",
+				"@smithy/credential-provider-imds": "^4.2.12",
+				"@smithy/property-provider": "^4.2.12",
+				"@smithy/shared-ini-file-loader": "^4.4.7",
+				"@smithy/types": "^4.13.1",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -465,19 +409,19 @@
 			}
 		},
 		"node_modules/@aws-sdk/credential-provider-login": {
-			"version": "3.972.9",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-login/-/credential-provider-login-3.972.9.tgz",
-			"integrity": "sha512-m4RIpVgZChv0vWS/HKChg1xLgZPpx8Z+ly9Fv7FwA8SOfuC6I3htcSaBz2Ch4bneRIiBUhwP4ziUo0UZgtJStQ==",
+			"version": "3.972.28",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-login/-/credential-provider-login-3.972.28.tgz",
+			"integrity": "sha512-ZSTfO6jqUTCysbdBPtEX5OUR//3rbD0lN7jO3sQeS2Gjr/Y+DT6SbIJ0oT2cemNw3UzKu97sNONd1CwNMthuZQ==",
 			"license": "Apache-2.0",
 			"peer": true,
 			"dependencies": {
-				"@aws-sdk/core": "^3.973.11",
-				"@aws-sdk/nested-clients": "3.993.0",
-				"@aws-sdk/types": "^3.973.1",
-				"@smithy/property-provider": "^4.2.8",
-				"@smithy/protocol-http": "^5.3.8",
-				"@smithy/shared-ini-file-loader": "^4.4.3",
-				"@smithy/types": "^4.12.0",
+				"@aws-sdk/core": "^3.973.26",
+				"@aws-sdk/nested-clients": "^3.996.18",
+				"@aws-sdk/types": "^3.973.6",
+				"@smithy/property-provider": "^4.2.12",
+				"@smithy/protocol-http": "^5.3.12",
+				"@smithy/shared-ini-file-loader": "^4.4.7",
+				"@smithy/types": "^4.13.1",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -485,23 +429,23 @@
 			}
 		},
 		"node_modules/@aws-sdk/credential-provider-node": {
-			"version": "3.972.10",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.972.10.tgz",
-			"integrity": "sha512-70nCESlvnzjo4LjJ8By8MYIiBogkYPSXl3WmMZfH9RZcB/Nt9qVWbFpYj6Fk1vLa4Vk8qagFVeXgxdieMxG1QA==",
+			"version": "3.972.29",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.972.29.tgz",
+			"integrity": "sha512-clSzDcvndpFJAggLDnDb36sPdlZYyEs5Zm6zgZjjUhwsJgSWiWKwFIXUVBcbruidNyBdbpOv2tNDL9sX8y3/0g==",
 			"license": "Apache-2.0",
 			"peer": true,
 			"dependencies": {
-				"@aws-sdk/credential-provider-env": "^3.972.9",
-				"@aws-sdk/credential-provider-http": "^3.972.11",
-				"@aws-sdk/credential-provider-ini": "^3.972.9",
-				"@aws-sdk/credential-provider-process": "^3.972.9",
-				"@aws-sdk/credential-provider-sso": "^3.972.9",
-				"@aws-sdk/credential-provider-web-identity": "^3.972.9",
-				"@aws-sdk/types": "^3.973.1",
-				"@smithy/credential-provider-imds": "^4.2.8",
-				"@smithy/property-provider": "^4.2.8",
-				"@smithy/shared-ini-file-loader": "^4.4.3",
-				"@smithy/types": "^4.12.0",
+				"@aws-sdk/credential-provider-env": "^3.972.24",
+				"@aws-sdk/credential-provider-http": "^3.972.26",
+				"@aws-sdk/credential-provider-ini": "^3.972.28",
+				"@aws-sdk/credential-provider-process": "^3.972.24",
+				"@aws-sdk/credential-provider-sso": "^3.972.28",
+				"@aws-sdk/credential-provider-web-identity": "^3.972.28",
+				"@aws-sdk/types": "^3.973.6",
+				"@smithy/credential-provider-imds": "^4.2.12",
+				"@smithy/property-provider": "^4.2.12",
+				"@smithy/shared-ini-file-loader": "^4.4.7",
+				"@smithy/types": "^4.13.1",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -509,17 +453,17 @@
 			}
 		},
 		"node_modules/@aws-sdk/credential-provider-process": {
-			"version": "3.972.9",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.972.9.tgz",
-			"integrity": "sha512-gOWl0Fe2gETj5Bk151+LYKpeGi2lBDLNu+NMNpHRlIrKHdBmVun8/AalwMK8ci4uRfG5a3/+zvZBMpuen1SZ0A==",
+			"version": "3.972.24",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.972.24.tgz",
+			"integrity": "sha512-Q2k/XLrFXhEztPHqj4SLCNID3hEPdlhh1CDLBpNnM+1L8fq7P+yON9/9M1IGN/dA5W45v44ylERfXtDAlmMNmw==",
 			"license": "Apache-2.0",
 			"peer": true,
 			"dependencies": {
-				"@aws-sdk/core": "^3.973.11",
-				"@aws-sdk/types": "^3.973.1",
-				"@smithy/property-provider": "^4.2.8",
-				"@smithy/shared-ini-file-loader": "^4.4.3",
-				"@smithy/types": "^4.12.0",
+				"@aws-sdk/core": "^3.973.26",
+				"@aws-sdk/types": "^3.973.6",
+				"@smithy/property-provider": "^4.2.12",
+				"@smithy/shared-ini-file-loader": "^4.4.7",
+				"@smithy/types": "^4.13.1",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -527,19 +471,19 @@
 			}
 		},
 		"node_modules/@aws-sdk/credential-provider-sso": {
-			"version": "3.972.9",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.972.9.tgz",
-			"integrity": "sha512-ey7S686foGTArvFhi3ifQXmgptKYvLSGE2250BAQceMSXZddz7sUSNERGJT2S7u5KIe/kgugxrt01hntXVln6w==",
+			"version": "3.972.28",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.972.28.tgz",
+			"integrity": "sha512-IoUlmKMLEITFn1SiCTjPfR6KrE799FBo5baWyk/5Ppar2yXZoUdaRqZzJzK6TcJxx450M8m8DbpddRVYlp5R/A==",
 			"license": "Apache-2.0",
 			"peer": true,
 			"dependencies": {
-				"@aws-sdk/client-sso": "3.993.0",
-				"@aws-sdk/core": "^3.973.11",
-				"@aws-sdk/token-providers": "3.993.0",
-				"@aws-sdk/types": "^3.973.1",
-				"@smithy/property-provider": "^4.2.8",
-				"@smithy/shared-ini-file-loader": "^4.4.3",
-				"@smithy/types": "^4.12.0",
+				"@aws-sdk/core": "^3.973.26",
+				"@aws-sdk/nested-clients": "^3.996.18",
+				"@aws-sdk/token-providers": "3.1021.0",
+				"@aws-sdk/types": "^3.973.6",
+				"@smithy/property-provider": "^4.2.12",
+				"@smithy/shared-ini-file-loader": "^4.4.7",
+				"@smithy/types": "^4.13.1",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -547,18 +491,18 @@
 			}
 		},
 		"node_modules/@aws-sdk/credential-provider-sso/node_modules/@aws-sdk/token-providers": {
-			"version": "3.993.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.993.0.tgz",
-			"integrity": "sha512-+35g4c+8r7sB9Sjp1KPdM8qxGn6B/shBjJtEUN4e+Edw9UEQlZKIzioOGu3UAbyE0a/s450LdLZr4wbJChtmww==",
+			"version": "3.1021.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.1021.0.tgz",
+			"integrity": "sha512-TKY6h9spUk3OLs5v1oAgW9mAeBE3LAGNBwJokLy96wwmd4W2v/tYlXseProyed9ValDj2u1jK/4Rg1T+1NXyJA==",
 			"license": "Apache-2.0",
 			"peer": true,
 			"dependencies": {
-				"@aws-sdk/core": "^3.973.11",
-				"@aws-sdk/nested-clients": "3.993.0",
-				"@aws-sdk/types": "^3.973.1",
-				"@smithy/property-provider": "^4.2.8",
-				"@smithy/shared-ini-file-loader": "^4.4.3",
-				"@smithy/types": "^4.12.0",
+				"@aws-sdk/core": "^3.973.26",
+				"@aws-sdk/nested-clients": "^3.996.18",
+				"@aws-sdk/types": "^3.973.6",
+				"@smithy/property-provider": "^4.2.12",
+				"@smithy/shared-ini-file-loader": "^4.4.7",
+				"@smithy/types": "^4.13.1",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -566,18 +510,18 @@
 			}
 		},
 		"node_modules/@aws-sdk/credential-provider-web-identity": {
-			"version": "3.972.9",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.972.9.tgz",
-			"integrity": "sha512-8LnfS76nHXoEc9aRRiMMpxZxJeDG0yusdyo3NvPhCgESmBUgpMa4luhGbClW5NoX/qRcGxxM6Z/esqANSNMTow==",
+			"version": "3.972.28",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.972.28.tgz",
+			"integrity": "sha512-d+6h0SD8GGERzKe27v5rOzNGKOl0D+l0bWJdqrxH8WSQzHzjsQFIAPgIeOTUwBHVsKKwtSxc91K/SWax6XgswQ==",
 			"license": "Apache-2.0",
 			"peer": true,
 			"dependencies": {
-				"@aws-sdk/core": "^3.973.11",
-				"@aws-sdk/nested-clients": "3.993.0",
-				"@aws-sdk/types": "^3.973.1",
-				"@smithy/property-provider": "^4.2.8",
-				"@smithy/shared-ini-file-loader": "^4.4.3",
-				"@smithy/types": "^4.12.0",
+				"@aws-sdk/core": "^3.973.26",
+				"@aws-sdk/nested-clients": "^3.996.18",
+				"@aws-sdk/types": "^3.973.6",
+				"@smithy/property-provider": "^4.2.12",
+				"@smithy/shared-ini-file-loader": "^4.4.7",
+				"@smithy/types": "^4.13.1",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -585,15 +529,15 @@
 			}
 		},
 		"node_modules/@aws-sdk/eventstream-handler-node": {
-			"version": "3.972.5",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-handler-node/-/eventstream-handler-node-3.972.5.tgz",
-			"integrity": "sha512-xEmd3dnyn83K6t4AJxBJA63wpEoCD45ERFG0XMTViD2E/Ohls9TLxjOWPb1PAxR9/46cKy/TImez1GoqP6xVNQ==",
+			"version": "3.972.12",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-handler-node/-/eventstream-handler-node-3.972.12.tgz",
+			"integrity": "sha512-ruyc/MNR6e+cUrGCth7fLQ12RXBZDy/bV06tgqB9Z5n/0SN/C0m6bsQEV8FF9zPI6VSAOaRd0rNgmpYVnGawrQ==",
 			"license": "Apache-2.0",
 			"peer": true,
 			"dependencies": {
-				"@aws-sdk/types": "^3.973.1",
-				"@smithy/eventstream-codec": "^4.2.8",
-				"@smithy/types": "^4.12.0",
+				"@aws-sdk/types": "^3.973.6",
+				"@smithy/eventstream-codec": "^4.2.12",
+				"@smithy/types": "^4.13.1",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -601,15 +545,15 @@
 			}
 		},
 		"node_modules/@aws-sdk/middleware-eventstream": {
-			"version": "3.972.3",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-eventstream/-/middleware-eventstream-3.972.3.tgz",
-			"integrity": "sha512-pbvZ6Ye/Ks6BAZPa3RhsNjHrvxU9li25PMhSdDpbX0jzdpKpAkIR65gXSNKmA/REnSdEMWSD4vKUW+5eMFzB6w==",
+			"version": "3.972.8",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-eventstream/-/middleware-eventstream-3.972.8.tgz",
+			"integrity": "sha512-r+oP+tbCxgqXVC3pu3MUVePgSY0ILMjA+aEwOosS77m3/DRbtvHrHwqvMcw+cjANMeGzJ+i0ar+n77KXpRA8RQ==",
 			"license": "Apache-2.0",
 			"peer": true,
 			"dependencies": {
-				"@aws-sdk/types": "^3.973.1",
-				"@smithy/protocol-http": "^5.3.8",
-				"@smithy/types": "^4.12.0",
+				"@aws-sdk/types": "^3.973.6",
+				"@smithy/protocol-http": "^5.3.12",
+				"@smithy/types": "^4.13.1",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -617,15 +561,15 @@
 			}
 		},
 		"node_modules/@aws-sdk/middleware-host-header": {
-			"version": "3.972.3",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.972.3.tgz",
-			"integrity": "sha512-aknPTb2M+G3s+0qLCx4Li/qGZH8IIYjugHMv15JTYMe6mgZO8VBpYgeGYsNMGCqCZOcWzuf900jFBG5bopfzmA==",
+			"version": "3.972.8",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.972.8.tgz",
+			"integrity": "sha512-wAr2REfKsqoKQ+OkNqvOShnBoh+nkPurDKW7uAeVSu6kUECnWlSJiPvnoqxGlfousEY/v9LfS9sNc46hjSYDIQ==",
 			"license": "Apache-2.0",
 			"peer": true,
 			"dependencies": {
-				"@aws-sdk/types": "^3.973.1",
-				"@smithy/protocol-http": "^5.3.8",
-				"@smithy/types": "^4.12.0",
+				"@aws-sdk/types": "^3.973.6",
+				"@smithy/protocol-http": "^5.3.12",
+				"@smithy/types": "^4.13.1",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -633,14 +577,14 @@
 			}
 		},
 		"node_modules/@aws-sdk/middleware-logger": {
-			"version": "3.972.3",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.972.3.tgz",
-			"integrity": "sha512-Ftg09xNNRqaz9QNzlfdQWfpqMCJbsQdnZVJP55jfhbKi1+FTWxGuvfPoBhDHIovqWKjqbuiew3HuhxbJ0+OjgA==",
+			"version": "3.972.8",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.972.8.tgz",
+			"integrity": "sha512-CWl5UCM57WUFaFi5kB7IBY1UmOeLvNZAZ2/OZ5l20ldiJ3TiIz1pC65gYj8X0BCPWkeR1E32mpsCk1L1I4n+lA==",
 			"license": "Apache-2.0",
 			"peer": true,
 			"dependencies": {
-				"@aws-sdk/types": "^3.973.1",
-				"@smithy/types": "^4.12.0",
+				"@aws-sdk/types": "^3.973.6",
+				"@smithy/types": "^4.13.1",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -648,16 +592,16 @@
 			}
 		},
 		"node_modules/@aws-sdk/middleware-recursion-detection": {
-			"version": "3.972.3",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.972.3.tgz",
-			"integrity": "sha512-PY57QhzNuXHnwbJgbWYTrqIDHYSeOlhfYERTAuc16LKZpTZRJUjzBFokp9hF7u1fuGeE3D70ERXzdbMBOqQz7Q==",
+			"version": "3.972.9",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.972.9.tgz",
+			"integrity": "sha512-/Wt5+CT8dpTFQxEJ9iGy/UGrXr7p2wlIOEHvIr/YcHYByzoLjrqkYqXdJjd9UIgWjv7eqV2HnFJen93UTuwfTQ==",
 			"license": "Apache-2.0",
 			"peer": true,
 			"dependencies": {
-				"@aws-sdk/types": "^3.973.1",
+				"@aws-sdk/types": "^3.973.6",
 				"@aws/lambda-invoke-store": "^0.2.2",
-				"@smithy/protocol-http": "^5.3.8",
-				"@smithy/types": "^4.12.0",
+				"@smithy/protocol-http": "^5.3.12",
+				"@smithy/types": "^4.13.1",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -665,35 +609,19 @@
 			}
 		},
 		"node_modules/@aws-sdk/middleware-user-agent": {
-			"version": "3.972.11",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.972.11.tgz",
-			"integrity": "sha512-R8CvPsPHXwzIHCAza+bllY6PrctEk4lYq/SkHJz9NLoBHCcKQrbOcsfXxO6xmipSbUNIbNIUhH0lBsJGgsRdiw==",
+			"version": "3.972.28",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.972.28.tgz",
+			"integrity": "sha512-cfWZFlVh7Va9lRay4PN2A9ARFzaBYcA097InT5M2CdRS05ECF5yaz86jET8Wsl2WcyKYEvVr/QNmKtYtafUHtQ==",
 			"license": "Apache-2.0",
 			"peer": true,
 			"dependencies": {
-				"@aws-sdk/core": "^3.973.11",
-				"@aws-sdk/types": "^3.973.1",
-				"@aws-sdk/util-endpoints": "3.993.0",
-				"@smithy/core": "^3.23.2",
-				"@smithy/protocol-http": "^5.3.8",
-				"@smithy/types": "^4.12.0",
-				"tslib": "^2.6.2"
-			},
-			"engines": {
-				"node": ">=20.0.0"
-			}
-		},
-		"node_modules/@aws-sdk/middleware-user-agent/node_modules/@aws-sdk/util-endpoints": {
-			"version": "3.993.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.993.0.tgz",
-			"integrity": "sha512-j6vioBeRZ4eHX4SWGvGPpwGg/xSOcK7f1GL0VM+rdf3ZFTIsUEhCFmD78B+5r2PgztcECSzEfvHQX01k8dPQPw==",
-			"license": "Apache-2.0",
-			"peer": true,
-			"dependencies": {
-				"@aws-sdk/types": "^3.973.1",
-				"@smithy/types": "^4.12.0",
-				"@smithy/url-parser": "^4.2.8",
-				"@smithy/util-endpoints": "^3.2.8",
+				"@aws-sdk/core": "^3.973.26",
+				"@aws-sdk/types": "^3.973.6",
+				"@aws-sdk/util-endpoints": "^3.996.5",
+				"@smithy/core": "^3.23.13",
+				"@smithy/protocol-http": "^5.3.12",
+				"@smithy/types": "^4.13.1",
+				"@smithy/util-retry": "^4.2.13",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -701,23 +629,23 @@
 			}
 		},
 		"node_modules/@aws-sdk/middleware-websocket": {
-			"version": "3.972.6",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-websocket/-/middleware-websocket-3.972.6.tgz",
-			"integrity": "sha512-1DedO6N3m8zQ/vG6twNiHtsdwBgk773VdavLEbB3NXeKZDlzSK1BTviqWwvJdKx5UnIy4kGGP6WWpCEFEt/bhQ==",
+			"version": "3.972.14",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-websocket/-/middleware-websocket-3.972.14.tgz",
+			"integrity": "sha512-qnfDlIHjm6DrTYNvWOUbnZdVKgtoKbO/Qzj+C0Wp5Y7VUrsvBRQtGKxD+hc+mRTS4N0kBJ6iZ3+zxm4N1OSyjg==",
 			"license": "Apache-2.0",
 			"peer": true,
 			"dependencies": {
-				"@aws-sdk/types": "^3.973.1",
-				"@aws-sdk/util-format-url": "^3.972.3",
-				"@smithy/eventstream-codec": "^4.2.8",
-				"@smithy/eventstream-serde-browser": "^4.2.8",
-				"@smithy/fetch-http-handler": "^5.3.9",
-				"@smithy/protocol-http": "^5.3.8",
-				"@smithy/signature-v4": "^5.3.8",
-				"@smithy/types": "^4.12.0",
-				"@smithy/util-base64": "^4.3.0",
-				"@smithy/util-hex-encoding": "^4.2.0",
-				"@smithy/util-utf8": "^4.2.0",
+				"@aws-sdk/types": "^3.973.6",
+				"@aws-sdk/util-format-url": "^3.972.8",
+				"@smithy/eventstream-codec": "^4.2.12",
+				"@smithy/eventstream-serde-browser": "^4.2.12",
+				"@smithy/fetch-http-handler": "^5.3.15",
+				"@smithy/protocol-http": "^5.3.12",
+				"@smithy/signature-v4": "^5.3.12",
+				"@smithy/types": "^4.13.1",
+				"@smithy/util-base64": "^4.3.2",
+				"@smithy/util-hex-encoding": "^4.2.2",
+				"@smithy/util-utf8": "^4.2.2",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -725,66 +653,49 @@
 			}
 		},
 		"node_modules/@aws-sdk/nested-clients": {
-			"version": "3.993.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.993.0.tgz",
-			"integrity": "sha512-iOq86f2H67924kQUIPOAvlmMaOAvOLoDOIb66I2YqSUpMYB6ufiuJW3RlREgskxv86S5qKzMnfy/X6CqMjK6XQ==",
+			"version": "3.996.18",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.996.18.tgz",
+			"integrity": "sha512-c7ZSIXrESxHKx2Mcopgd8AlzZgoXMr20fkx5ViPWPOLBvmyhw9VwJx/Govg8Ef/IhEon5R9l53Z8fdYSEmp6VA==",
 			"license": "Apache-2.0",
 			"peer": true,
 			"dependencies": {
 				"@aws-crypto/sha256-browser": "5.2.0",
 				"@aws-crypto/sha256-js": "5.2.0",
-				"@aws-sdk/core": "^3.973.11",
-				"@aws-sdk/middleware-host-header": "^3.972.3",
-				"@aws-sdk/middleware-logger": "^3.972.3",
-				"@aws-sdk/middleware-recursion-detection": "^3.972.3",
-				"@aws-sdk/middleware-user-agent": "^3.972.11",
-				"@aws-sdk/region-config-resolver": "^3.972.3",
-				"@aws-sdk/types": "^3.973.1",
-				"@aws-sdk/util-endpoints": "3.993.0",
-				"@aws-sdk/util-user-agent-browser": "^3.972.3",
-				"@aws-sdk/util-user-agent-node": "^3.972.9",
-				"@smithy/config-resolver": "^4.4.6",
-				"@smithy/core": "^3.23.2",
-				"@smithy/fetch-http-handler": "^5.3.9",
-				"@smithy/hash-node": "^4.2.8",
-				"@smithy/invalid-dependency": "^4.2.8",
-				"@smithy/middleware-content-length": "^4.2.8",
-				"@smithy/middleware-endpoint": "^4.4.16",
-				"@smithy/middleware-retry": "^4.4.33",
-				"@smithy/middleware-serde": "^4.2.9",
-				"@smithy/middleware-stack": "^4.2.8",
-				"@smithy/node-config-provider": "^4.3.8",
-				"@smithy/node-http-handler": "^4.4.10",
-				"@smithy/protocol-http": "^5.3.8",
-				"@smithy/smithy-client": "^4.11.5",
-				"@smithy/types": "^4.12.0",
-				"@smithy/url-parser": "^4.2.8",
-				"@smithy/util-base64": "^4.3.0",
-				"@smithy/util-body-length-browser": "^4.2.0",
-				"@smithy/util-body-length-node": "^4.2.1",
-				"@smithy/util-defaults-mode-browser": "^4.3.32",
-				"@smithy/util-defaults-mode-node": "^4.2.35",
-				"@smithy/util-endpoints": "^3.2.8",
-				"@smithy/util-middleware": "^4.2.8",
-				"@smithy/util-retry": "^4.2.8",
-				"@smithy/util-utf8": "^4.2.0",
-				"tslib": "^2.6.2"
-			},
-			"engines": {
-				"node": ">=20.0.0"
-			}
-		},
-		"node_modules/@aws-sdk/nested-clients/node_modules/@aws-sdk/util-endpoints": {
-			"version": "3.993.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.993.0.tgz",
-			"integrity": "sha512-j6vioBeRZ4eHX4SWGvGPpwGg/xSOcK7f1GL0VM+rdf3ZFTIsUEhCFmD78B+5r2PgztcECSzEfvHQX01k8dPQPw==",
-			"license": "Apache-2.0",
-			"peer": true,
-			"dependencies": {
-				"@aws-sdk/types": "^3.973.1",
-				"@smithy/types": "^4.12.0",
-				"@smithy/url-parser": "^4.2.8",
-				"@smithy/util-endpoints": "^3.2.8",
+				"@aws-sdk/core": "^3.973.26",
+				"@aws-sdk/middleware-host-header": "^3.972.8",
+				"@aws-sdk/middleware-logger": "^3.972.8",
+				"@aws-sdk/middleware-recursion-detection": "^3.972.9",
+				"@aws-sdk/middleware-user-agent": "^3.972.28",
+				"@aws-sdk/region-config-resolver": "^3.972.10",
+				"@aws-sdk/types": "^3.973.6",
+				"@aws-sdk/util-endpoints": "^3.996.5",
+				"@aws-sdk/util-user-agent-browser": "^3.972.8",
+				"@aws-sdk/util-user-agent-node": "^3.973.14",
+				"@smithy/config-resolver": "^4.4.13",
+				"@smithy/core": "^3.23.13",
+				"@smithy/fetch-http-handler": "^5.3.15",
+				"@smithy/hash-node": "^4.2.12",
+				"@smithy/invalid-dependency": "^4.2.12",
+				"@smithy/middleware-content-length": "^4.2.12",
+				"@smithy/middleware-endpoint": "^4.4.28",
+				"@smithy/middleware-retry": "^4.4.46",
+				"@smithy/middleware-serde": "^4.2.16",
+				"@smithy/middleware-stack": "^4.2.12",
+				"@smithy/node-config-provider": "^4.3.12",
+				"@smithy/node-http-handler": "^4.5.1",
+				"@smithy/protocol-http": "^5.3.12",
+				"@smithy/smithy-client": "^4.12.8",
+				"@smithy/types": "^4.13.1",
+				"@smithy/url-parser": "^4.2.12",
+				"@smithy/util-base64": "^4.3.2",
+				"@smithy/util-body-length-browser": "^4.2.2",
+				"@smithy/util-body-length-node": "^4.2.3",
+				"@smithy/util-defaults-mode-browser": "^4.3.44",
+				"@smithy/util-defaults-mode-node": "^4.2.48",
+				"@smithy/util-endpoints": "^3.3.3",
+				"@smithy/util-middleware": "^4.2.12",
+				"@smithy/util-retry": "^4.2.13",
+				"@smithy/util-utf8": "^4.2.2",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -792,16 +703,16 @@
 			}
 		},
 		"node_modules/@aws-sdk/region-config-resolver": {
-			"version": "3.972.3",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.972.3.tgz",
-			"integrity": "sha512-v4J8qYAWfOMcZ4MJUyatntOicTzEMaU7j3OpkRCGGFSL2NgXQ5VbxauIyORA+pxdKZ0qQG2tCQjQjZDlXEC3Ow==",
+			"version": "3.972.10",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.972.10.tgz",
+			"integrity": "sha512-1dq9ToC6e070QvnVhhbAs3bb5r6cQ10gTVc6cyRV5uvQe7P138TV2uG2i6+Yok4bAkVAcx5AqkTEBUvWEtBlsQ==",
 			"license": "Apache-2.0",
 			"peer": true,
 			"dependencies": {
-				"@aws-sdk/types": "^3.973.1",
-				"@smithy/config-resolver": "^4.4.6",
-				"@smithy/node-config-provider": "^4.3.8",
-				"@smithy/types": "^4.12.0",
+				"@aws-sdk/types": "^3.973.6",
+				"@smithy/config-resolver": "^4.4.13",
+				"@smithy/node-config-provider": "^4.3.12",
+				"@smithy/types": "^4.13.1",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -809,68 +720,18 @@
 			}
 		},
 		"node_modules/@aws-sdk/token-providers": {
-			"version": "3.995.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.995.0.tgz",
-			"integrity": "sha512-lYSadNdZZ513qCKoj/KlJ+PgCycL3n8ZNS37qLVFC0t7TbHzoxvGquu9aD2n9OCERAn43OMhQ7dXjYDYdjAXzA==",
+			"version": "3.1023.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.1023.0.tgz",
+			"integrity": "sha512-g/t814ec7g+MbazONIdQzb0c8FalVnSKCLc665GLG4QdrviKXHzag7HQmf5wBhCDsUDNAIi77fLeElaZSkylTA==",
 			"license": "Apache-2.0",
 			"peer": true,
 			"dependencies": {
-				"@aws-sdk/core": "^3.973.11",
-				"@aws-sdk/nested-clients": "3.995.0",
-				"@aws-sdk/types": "^3.973.1",
-				"@smithy/property-provider": "^4.2.8",
-				"@smithy/shared-ini-file-loader": "^4.4.3",
-				"@smithy/types": "^4.12.0",
-				"tslib": "^2.6.2"
-			},
-			"engines": {
-				"node": ">=20.0.0"
-			}
-		},
-		"node_modules/@aws-sdk/token-providers/node_modules/@aws-sdk/nested-clients": {
-			"version": "3.995.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.995.0.tgz",
-			"integrity": "sha512-7gq9gismVhESiRsSt0eYe1y1b6jS20LqLk+e/YSyPmGi9yHdndHQLIq73RbEJnK/QPpkQGFqq70M1mI46M1HGw==",
-			"license": "Apache-2.0",
-			"peer": true,
-			"dependencies": {
-				"@aws-crypto/sha256-browser": "5.2.0",
-				"@aws-crypto/sha256-js": "5.2.0",
-				"@aws-sdk/core": "^3.973.11",
-				"@aws-sdk/middleware-host-header": "^3.972.3",
-				"@aws-sdk/middleware-logger": "^3.972.3",
-				"@aws-sdk/middleware-recursion-detection": "^3.972.3",
-				"@aws-sdk/middleware-user-agent": "^3.972.11",
-				"@aws-sdk/region-config-resolver": "^3.972.3",
-				"@aws-sdk/types": "^3.973.1",
-				"@aws-sdk/util-endpoints": "3.995.0",
-				"@aws-sdk/util-user-agent-browser": "^3.972.3",
-				"@aws-sdk/util-user-agent-node": "^3.972.10",
-				"@smithy/config-resolver": "^4.4.6",
-				"@smithy/core": "^3.23.2",
-				"@smithy/fetch-http-handler": "^5.3.9",
-				"@smithy/hash-node": "^4.2.8",
-				"@smithy/invalid-dependency": "^4.2.8",
-				"@smithy/middleware-content-length": "^4.2.8",
-				"@smithy/middleware-endpoint": "^4.4.16",
-				"@smithy/middleware-retry": "^4.4.33",
-				"@smithy/middleware-serde": "^4.2.9",
-				"@smithy/middleware-stack": "^4.2.8",
-				"@smithy/node-config-provider": "^4.3.8",
-				"@smithy/node-http-handler": "^4.4.10",
-				"@smithy/protocol-http": "^5.3.8",
-				"@smithy/smithy-client": "^4.11.5",
-				"@smithy/types": "^4.12.0",
-				"@smithy/url-parser": "^4.2.8",
-				"@smithy/util-base64": "^4.3.0",
-				"@smithy/util-body-length-browser": "^4.2.0",
-				"@smithy/util-body-length-node": "^4.2.1",
-				"@smithy/util-defaults-mode-browser": "^4.3.32",
-				"@smithy/util-defaults-mode-node": "^4.2.35",
-				"@smithy/util-endpoints": "^3.2.8",
-				"@smithy/util-middleware": "^4.2.8",
-				"@smithy/util-retry": "^4.2.8",
-				"@smithy/util-utf8": "^4.2.0",
+				"@aws-sdk/core": "^3.973.26",
+				"@aws-sdk/nested-clients": "^3.996.18",
+				"@aws-sdk/types": "^3.973.6",
+				"@smithy/property-provider": "^4.2.12",
+				"@smithy/shared-ini-file-loader": "^4.4.7",
+				"@smithy/types": "^4.13.1",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -878,13 +739,13 @@
 			}
 		},
 		"node_modules/@aws-sdk/types": {
-			"version": "3.973.1",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.973.1.tgz",
-			"integrity": "sha512-DwHBiMNOB468JiX6+i34c+THsKHErYUdNQ3HexeXZvVn4zouLjgaS4FejiGSi2HyBuzuyHg7SuOPmjSvoU9NRg==",
+			"version": "3.973.6",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.973.6.tgz",
+			"integrity": "sha512-Atfcy4E++beKtwJHiDln2Nby8W/mam64opFPTiHEqgsthqeydFS1pY+OUlN1ouNOmf8ArPU/6cDS65anOP3KQw==",
 			"license": "Apache-2.0",
 			"peer": true,
 			"dependencies": {
-				"@smithy/types": "^4.12.0",
+				"@smithy/types": "^4.13.1",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -892,16 +753,16 @@
 			}
 		},
 		"node_modules/@aws-sdk/util-endpoints": {
-			"version": "3.995.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.995.0.tgz",
-			"integrity": "sha512-aym/pjB8SLbo9w2nmkrDdAAVKVlf7CM71B9mKhjDbJTzwpSFBPHqJIMdDyj0mLumKC0aIVDr1H6U+59m9GvMFw==",
+			"version": "3.996.5",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.996.5.tgz",
+			"integrity": "sha512-Uh93L5sXFNbyR5sEPMzUU8tJ++Ku97EY4udmC01nB8Zu+xfBPwpIwJ6F7snqQeq8h2pf+8SGN5/NoytfKgYPIw==",
 			"license": "Apache-2.0",
 			"peer": true,
 			"dependencies": {
-				"@aws-sdk/types": "^3.973.1",
-				"@smithy/types": "^4.12.0",
-				"@smithy/url-parser": "^4.2.8",
-				"@smithy/util-endpoints": "^3.2.8",
+				"@aws-sdk/types": "^3.973.6",
+				"@smithy/types": "^4.13.1",
+				"@smithy/url-parser": "^4.2.12",
+				"@smithy/util-endpoints": "^3.3.3",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -909,15 +770,15 @@
 			}
 		},
 		"node_modules/@aws-sdk/util-format-url": {
-			"version": "3.972.3",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/util-format-url/-/util-format-url-3.972.3.tgz",
-			"integrity": "sha512-n7F2ycckcKFXa01vAsT/SJdjFHfKH9s96QHcs5gn8AaaigASICeME8WdUL9uBp8XV/OVwEt8+6gzn6KFUgQa8g==",
+			"version": "3.972.8",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/util-format-url/-/util-format-url-3.972.8.tgz",
+			"integrity": "sha512-J6DS9oocrgxM8xlUTTmQOuwRF6rnAGEujAN9SAzllcrQmwn5iJ58ogxy3SEhD0Q7JZvlA5jvIXBkpQRqEqlE9A==",
 			"license": "Apache-2.0",
 			"peer": true,
 			"dependencies": {
-				"@aws-sdk/types": "^3.973.1",
-				"@smithy/querystring-builder": "^4.2.8",
-				"@smithy/types": "^4.12.0",
+				"@aws-sdk/types": "^3.973.6",
+				"@smithy/querystring-builder": "^4.2.12",
+				"@smithy/types": "^4.13.1",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -925,9 +786,9 @@
 			}
 		},
 		"node_modules/@aws-sdk/util-locate-window": {
-			"version": "3.965.4",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/util-locate-window/-/util-locate-window-3.965.4.tgz",
-			"integrity": "sha512-H1onv5SkgPBK2P6JR2MjGgbOnttoNzSPIRoeZTNPZYyaplwGg50zS3amXvXqF0/qfXpWEC9rLWU564QTB9bSog==",
+			"version": "3.965.5",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/util-locate-window/-/util-locate-window-3.965.5.tgz",
+			"integrity": "sha512-WhlJNNINQB+9qtLtZJcpQdgZw3SCDCpXdUJP7cToGwHbCWCnRckGlc6Bx/OhWwIYFNAn+FIydY8SZ0QmVu3xTQ==",
 			"license": "Apache-2.0",
 			"peer": true,
 			"dependencies": {
@@ -938,29 +799,30 @@
 			}
 		},
 		"node_modules/@aws-sdk/util-user-agent-browser": {
-			"version": "3.972.3",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.972.3.tgz",
-			"integrity": "sha512-JurOwkRUcXD/5MTDBcqdyQ9eVedtAsZgw5rBwktsPTN7QtPiS2Ld1jkJepNgYoCufz1Wcut9iup7GJDoIHp8Fw==",
+			"version": "3.972.8",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.972.8.tgz",
+			"integrity": "sha512-B3KGXJviV2u6Cdw2SDY2aDhoJkVfY/Q/Trwk2CMSkikE1Oi6gRzxhvhIfiRpHfmIsAhV4EA54TVEX8K6CbHbkA==",
 			"license": "Apache-2.0",
 			"peer": true,
 			"dependencies": {
-				"@aws-sdk/types": "^3.973.1",
-				"@smithy/types": "^4.12.0",
+				"@aws-sdk/types": "^3.973.6",
+				"@smithy/types": "^4.13.1",
 				"bowser": "^2.11.0",
 				"tslib": "^2.6.2"
 			}
 		},
 		"node_modules/@aws-sdk/util-user-agent-node": {
-			"version": "3.972.10",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.972.10.tgz",
-			"integrity": "sha512-LVXzICPlsheET+sE6tkcS47Q5HkSTrANIlqL1iFxGAY/wRQ236DX/PCAK56qMh9QJoXAfXfoRW0B0Og4R+X7Nw==",
+			"version": "3.973.14",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.973.14.tgz",
+			"integrity": "sha512-vNSB/DYaPOyujVZBg/zUznH9QC142MaTHVmaFlF7uzzfg3CgT9f/l4C0Yi+vU/tbBhxVcXVB90Oohk5+o+ZbWw==",
 			"license": "Apache-2.0",
 			"peer": true,
 			"dependencies": {
-				"@aws-sdk/middleware-user-agent": "^3.972.11",
-				"@aws-sdk/types": "^3.973.1",
-				"@smithy/node-config-provider": "^4.3.8",
-				"@smithy/types": "^4.12.0",
+				"@aws-sdk/middleware-user-agent": "^3.972.28",
+				"@aws-sdk/types": "^3.973.6",
+				"@smithy/node-config-provider": "^4.3.12",
+				"@smithy/types": "^4.13.1",
+				"@smithy/util-config-provider": "^4.2.2",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -976,14 +838,14 @@
 			}
 		},
 		"node_modules/@aws-sdk/xml-builder": {
-			"version": "3.972.5",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.972.5.tgz",
-			"integrity": "sha512-mCae5Ys6Qm1LDu0qdGwx2UQ63ONUe+FHw908fJzLDqFKTDBK4LDZUqKWm4OkTCNFq19bftjsBSESIGLD/s3/rA==",
+			"version": "3.972.16",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.972.16.tgz",
+			"integrity": "sha512-iu2pyvaqmeatIJLURLqx9D+4jKAdTH20ntzB6BFwjyN7V960r4jK32mx0Zf7YbtOYAbmbtQfDNuL60ONinyw7A==",
 			"license": "Apache-2.0",
 			"peer": true,
 			"dependencies": {
-				"@smithy/types": "^4.12.0",
-				"fast-xml-parser": "5.3.6",
+				"@smithy/types": "^4.13.1",
+				"fast-xml-parser": "5.5.8",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -991,9 +853,9 @@
 			}
 		},
 		"node_modules/@aws/lambda-invoke-store": {
-			"version": "0.2.3",
-			"resolved": "https://registry.npmjs.org/@aws/lambda-invoke-store/-/lambda-invoke-store-0.2.3.tgz",
-			"integrity": "sha512-oLvsaPMTBejkkmHhjf09xTgk71mOqyr/409NKhRIL08If7AhVfUsJhVsx386uJaqNd42v9kWamQ9lFbkoC2dYw==",
+			"version": "0.2.4",
+			"resolved": "https://registry.npmjs.org/@aws/lambda-invoke-store/-/lambda-invoke-store-0.2.4.tgz",
+			"integrity": "sha512-iY8yvjE0y651BixKNPgmv1WrQc+GZ142sb0z4gYnChDDY2YqI4P/jsSopBWrKfAt7LOJAkOXt7rC/hms+WclQQ==",
 			"license": "Apache-2.0",
 			"peer": true,
 			"engines": {
@@ -1001,9 +863,9 @@
 			}
 		},
 		"node_modules/@babel/runtime": {
-			"version": "7.28.6",
-			"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.28.6.tgz",
-			"integrity": "sha512-05WQkdpL9COIMz4LjTxGpPNCdlpyimKppYNoJ5Di5EUObifl8t4tuLuUBBZEpoLYOmfvIWrsp9fCl0HoPRVTdA==",
+			"version": "7.29.2",
+			"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.2.tgz",
+			"integrity": "sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==",
 			"license": "MIT",
 			"peer": true,
 			"engines": {
@@ -1175,9 +1037,9 @@
 			}
 		},
 		"node_modules/@borewit/text-codec": {
-			"version": "0.2.1",
-			"resolved": "https://registry.npmjs.org/@borewit/text-codec/-/text-codec-0.2.1.tgz",
-			"integrity": "sha512-k7vvKPbf7J2fZ5klGRD9AeKfUvojuZIQ3BT5u7Jfv+puwXkUBUT5PVyMDfJZpy30CBDXGMgw7fguK/lpOMBvgw==",
+			"version": "0.2.2",
+			"resolved": "https://registry.npmjs.org/@borewit/text-codec/-/text-codec-0.2.2.tgz",
+			"integrity": "sha512-DDaRehssg1aNrH4+2hnj1B7vnUGEjU6OIlyRdkMd0aUdIUvKXrJfXsy8LVtXAy7DRvYVluWbMspsRhz2lcW0mQ==",
 			"license": "MIT",
 			"peer": true,
 			"funding": {
@@ -1185,275 +1047,34 @@
 				"url": "https://github.com/sponsors/Borewit"
 			}
 		},
-		"node_modules/@buape/carbon": {
-			"version": "0.0.0-beta-20260216184201",
-			"resolved": "https://registry.npmjs.org/@buape/carbon/-/carbon-0.0.0-beta-20260216184201.tgz",
-			"integrity": "sha512-u5mgYcigfPVqT7D9gVTGd+3YSflTreQmrWog7ORbb0z5w9eT8ft4rJOdw9fGwr75zMu9kXpSBaAcY2eZoJFSdA==",
-			"license": "MIT",
-			"peer": true,
-			"dependencies": {
-				"@types/node": "^25.0.9",
-				"discord-api-types": "0.38.37"
-			},
-			"optionalDependencies": {
-				"@cloudflare/workers-types": "4.20260120.0",
-				"@discordjs/voice": "0.19.0",
-				"@hono/node-server": "1.19.9",
-				"@types/bun": "1.3.9",
-				"@types/ws": "8.18.1",
-				"ws": "8.19.0"
-			}
-		},
-		"node_modules/@buape/carbon/node_modules/discord-api-types": {
-			"version": "0.38.37",
-			"resolved": "https://registry.npmjs.org/discord-api-types/-/discord-api-types-0.38.37.tgz",
-			"integrity": "sha512-Cv47jzY1jkGkh5sv0bfHYqGgKOWO1peOrGMkDFM4UmaGMOTgOW8QSexhvixa9sVOiz8MnVOBryWYyw/CEVhj7w==",
-			"license": "MIT",
-			"peer": true,
-			"workspaces": [
-				"scripts/actions/documentation"
-			]
-		},
-		"node_modules/@cacheable/memory": {
-			"version": "2.0.7",
-			"resolved": "https://registry.npmjs.org/@cacheable/memory/-/memory-2.0.7.tgz",
-			"integrity": "sha512-RbxnxAMf89Tp1dLhXMS7ceft/PGsDl1Ip7T20z5nZ+pwIAsQ1p2izPjVG69oCLv/jfQ7HDPHTWK0c9rcAWXN3A==",
-			"license": "MIT",
-			"peer": true,
-			"dependencies": {
-				"@cacheable/utils": "^2.3.3",
-				"@keyv/bigmap": "^1.3.0",
-				"hookified": "^1.14.0",
-				"keyv": "^5.5.5"
-			}
-		},
-		"node_modules/@cacheable/node-cache": {
-			"version": "1.7.6",
-			"resolved": "https://registry.npmjs.org/@cacheable/node-cache/-/node-cache-1.7.6.tgz",
-			"integrity": "sha512-6Omk2SgNnjtxB5f/E6bTIWIt5xhdpx39fGNRQgU9lojvRxU68v+qY+SXXLsp3ZGukqoPjsK21wZ6XABFr/Ge3A==",
-			"license": "MIT",
-			"peer": true,
-			"dependencies": {
-				"cacheable": "^2.3.1",
-				"hookified": "^1.14.0",
-				"keyv": "^5.5.5"
-			},
-			"engines": {
-				"node": ">=18"
-			}
-		},
-		"node_modules/@cacheable/utils": {
-			"version": "2.3.4",
-			"resolved": "https://registry.npmjs.org/@cacheable/utils/-/utils-2.3.4.tgz",
-			"integrity": "sha512-knwKUJEYgIfwShABS1BX6JyJJTglAFcEU7EXqzTdiGCXur4voqkiJkdgZIQtWNFhynzDWERcTYv/sETMu3uJWA==",
-			"license": "MIT",
-			"peer": true,
-			"dependencies": {
-				"hashery": "^1.3.0",
-				"keyv": "^5.6.0"
-			}
-		},
 		"node_modules/@clack/core": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/@clack/core/-/core-1.0.1.tgz",
-			"integrity": "sha512-WKeyK3NOBwDOzagPR5H08rFk9D/WuN705yEbuZvKqlkmoLM2woKtXb10OO2k1NoSU4SFG947i2/SCYh+2u5e4g==",
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/@clack/core/-/core-1.2.0.tgz",
+			"integrity": "sha512-qfxof/3T3t9DPU/Rj3OmcFyZInceqj/NVtO9rwIuJqCUgh32gwPjpFQQp/ben07qKlhpwq7GzfWpST4qdJ5Drg==",
 			"license": "MIT",
 			"peer": true,
 			"dependencies": {
-				"picocolors": "^1.0.0",
+				"fast-wrap-ansi": "^0.1.3",
 				"sisteransi": "^1.0.5"
 			}
 		},
 		"node_modules/@clack/prompts": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/@clack/prompts/-/prompts-1.0.1.tgz",
-			"integrity": "sha512-/42G73JkuYdyWZ6m8d/CJtBrGl1Hegyc7Fy78m5Ob+jF85TOUmLR5XLce/U3LxYAw0kJ8CT5aI99RIvPHcGp/Q==",
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/@clack/prompts/-/prompts-1.2.0.tgz",
+			"integrity": "sha512-4jmztR9fMqPMjz6H/UZXj0zEmE43ha1euENwkckKKel4XpSfokExPo5AiVStdHSAlHekz4d0CA/r45Ok1E4D3w==",
 			"license": "MIT",
 			"peer": true,
 			"dependencies": {
-				"@clack/core": "1.0.1",
-				"picocolors": "^1.0.0",
+				"@clack/core": "1.2.0",
+				"fast-string-width": "^1.1.0",
+				"fast-wrap-ansi": "^0.1.3",
 				"sisteransi": "^1.0.5"
 			}
 		},
-		"node_modules/@cloudflare/workers-types": {
-			"version": "4.20260120.0",
-			"resolved": "https://registry.npmjs.org/@cloudflare/workers-types/-/workers-types-4.20260120.0.tgz",
-			"integrity": "sha512-B8pueG+a5S+mdK3z8oKu1ShcxloZ7qWb68IEyLLaepvdryIbNC7JVPcY0bWsjS56UQVKc5fnyRge3yZIwc9bxw==",
-			"license": "MIT OR Apache-2.0",
-			"optional": true,
-			"peer": true
-		},
-		"node_modules/@discordjs/node-pre-gyp": {
-			"version": "0.4.5",
-			"resolved": "https://registry.npmjs.org/@discordjs/node-pre-gyp/-/node-pre-gyp-0.4.5.tgz",
-			"integrity": "sha512-YJOVVZ545x24mHzANfYoy0BJX5PDyeZlpiJjDkUBM/V/Ao7TFX9lcUvCN4nr0tbr5ubeaXxtEBILUrHtTphVeQ==",
-			"license": "BSD-3-Clause",
-			"optional": true,
-			"peer": true,
-			"dependencies": {
-				"detect-libc": "^2.0.0",
-				"https-proxy-agent": "^5.0.0",
-				"make-dir": "^3.1.0",
-				"node-fetch": "^2.6.7",
-				"nopt": "^5.0.0",
-				"npmlog": "^5.0.1",
-				"rimraf": "^3.0.2",
-				"semver": "^7.3.5",
-				"tar": "^6.1.11"
-			},
-			"bin": {
-				"node-pre-gyp": "bin/node-pre-gyp"
-			}
-		},
-		"node_modules/@discordjs/node-pre-gyp/node_modules/agent-base": {
-			"version": "6.0.2",
-			"resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
-			"integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
-			"license": "MIT",
-			"optional": true,
-			"peer": true,
-			"dependencies": {
-				"debug": "4"
-			},
-			"engines": {
-				"node": ">= 6.0.0"
-			}
-		},
-		"node_modules/@discordjs/node-pre-gyp/node_modules/ansi-regex": {
-			"version": "5.0.1",
-			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
-			"integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
-			"license": "MIT",
-			"optional": true,
-			"peer": true,
-			"engines": {
-				"node": ">=8"
-			}
-		},
-		"node_modules/@discordjs/node-pre-gyp/node_modules/are-we-there-yet": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-2.0.0.tgz",
-			"integrity": "sha512-Ci/qENmwHnsYo9xKIcUJN5LeDKdJ6R1Z1j9V/J5wyq8nh/mYPEpIKJbBZXtZjG04HiK7zV/p6Vs9952MrMeUIw==",
-			"deprecated": "This package is no longer supported.",
-			"license": "ISC",
-			"optional": true,
-			"peer": true,
-			"dependencies": {
-				"delegates": "^1.0.0",
-				"readable-stream": "^3.6.0"
-			},
-			"engines": {
-				"node": ">=10"
-			}
-		},
-		"node_modules/@discordjs/node-pre-gyp/node_modules/gauge": {
-			"version": "3.0.2",
-			"resolved": "https://registry.npmjs.org/gauge/-/gauge-3.0.2.tgz",
-			"integrity": "sha512-+5J6MS/5XksCuXq++uFRsnUd7Ovu1XenbeuIuNRJxYWjgQbPuFhT14lAvsWfqfAmnwluf1OwMjz39HjfLPci0Q==",
-			"deprecated": "This package is no longer supported.",
-			"license": "ISC",
-			"optional": true,
-			"peer": true,
-			"dependencies": {
-				"aproba": "^1.0.3 || ^2.0.0",
-				"color-support": "^1.1.2",
-				"console-control-strings": "^1.0.0",
-				"has-unicode": "^2.0.1",
-				"object-assign": "^4.1.1",
-				"signal-exit": "^3.0.0",
-				"string-width": "^4.2.3",
-				"strip-ansi": "^6.0.1",
-				"wide-align": "^1.1.2"
-			},
-			"engines": {
-				"node": ">=10"
-			}
-		},
-		"node_modules/@discordjs/node-pre-gyp/node_modules/https-proxy-agent": {
-			"version": "5.0.1",
-			"resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
-			"integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
-			"license": "MIT",
-			"optional": true,
-			"peer": true,
-			"dependencies": {
-				"agent-base": "6",
-				"debug": "4"
-			},
-			"engines": {
-				"node": ">= 6"
-			}
-		},
-		"node_modules/@discordjs/node-pre-gyp/node_modules/npmlog": {
-			"version": "5.0.1",
-			"resolved": "https://registry.npmjs.org/npmlog/-/npmlog-5.0.1.tgz",
-			"integrity": "sha512-AqZtDUWOMKs1G/8lwylVjrdYgqA4d9nu8hc+0gzRxlDb1I10+FHBGMXs6aiQHFdCUUlqH99MUMuLfzWDNDtfxw==",
-			"deprecated": "This package is no longer supported.",
-			"license": "ISC",
-			"optional": true,
-			"peer": true,
-			"dependencies": {
-				"are-we-there-yet": "^2.0.0",
-				"console-control-strings": "^1.1.0",
-				"gauge": "^3.0.0",
-				"set-blocking": "^2.0.0"
-			}
-		},
-		"node_modules/@discordjs/node-pre-gyp/node_modules/strip-ansi": {
-			"version": "6.0.1",
-			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
-			"integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-			"license": "MIT",
-			"optional": true,
-			"peer": true,
-			"dependencies": {
-				"ansi-regex": "^5.0.1"
-			},
-			"engines": {
-				"node": ">=8"
-			}
-		},
-		"node_modules/@discordjs/opus": {
-			"version": "0.10.0",
-			"resolved": "https://registry.npmjs.org/@discordjs/opus/-/opus-0.10.0.tgz",
-			"integrity": "sha512-HHEnSNrSPmFEyndRdQBJN2YE6egyXS9JUnJWyP6jficK0Y+qKMEZXyYTgmzpjrxXP1exM/hKaNP7BRBUEWkU5w==",
-			"hasInstallScript": true,
-			"license": "MIT",
-			"optional": true,
-			"peer": true,
-			"dependencies": {
-				"@discordjs/node-pre-gyp": "^0.4.5",
-				"node-addon-api": "^8.1.0"
-			},
-			"engines": {
-				"node": ">=12.0.0"
-			}
-		},
-		"node_modules/@discordjs/voice": {
-			"version": "0.19.0",
-			"resolved": "https://registry.npmjs.org/@discordjs/voice/-/voice-0.19.0.tgz",
-			"integrity": "sha512-UyX6rGEXzVyPzb1yvjHtPfTlnLvB5jX/stAMdiytHhfoydX+98hfympdOwsnTktzr+IRvphxTbdErgYDJkEsvw==",
-			"license": "Apache-2.0",
-			"peer": true,
-			"dependencies": {
-				"@types/ws": "^8.18.1",
-				"discord-api-types": "^0.38.16",
-				"prism-media": "^1.3.5",
-				"tslib": "^2.8.1",
-				"ws": "^8.18.3"
-			},
-			"engines": {
-				"node": ">=22.12.0"
-			},
-			"funding": {
-				"url": "https://github.com/discordjs/discord.js?sponsor"
-			}
-		},
 		"node_modules/@emnapi/runtime": {
-			"version": "1.8.1",
-			"resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.8.1.tgz",
-			"integrity": "sha512-mehfKSMWjjNol8659Z8KxEMrdSJDDot5SXMq00dM8BN4o+CLNXQ0xH2V7EchNHV4RmbZLmmPdEaXZc5H2FXmDg==",
+			"version": "1.9.2",
+			"resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.9.2.tgz",
+			"integrity": "sha512-3U4+MIWHImeyu1wnmVygh5WlgfYDtyf0k8AbLhMFxOipihf6nrWC4syIm/SwEeec0mNSafiiNnMJwbza/Is6Lw==",
 			"license": "MIT",
 			"optional": true,
 			"peer": true,
@@ -1462,9 +1083,9 @@
 			}
 		},
 		"node_modules/@google/genai": {
-			"version": "1.42.0",
-			"resolved": "https://registry.npmjs.org/@google/genai/-/genai-1.42.0.tgz",
-			"integrity": "sha512-+3nlMTcrQufbQ8IumGkOphxD5Pd5kKyJOzLcnY0/1IuE8upJk5aLmoexZ2BJhBp1zAjRJMEB4a2CJwKI9e2EYw==",
+			"version": "1.48.0",
+			"resolved": "https://registry.npmjs.org/@google/genai/-/genai-1.48.0.tgz",
+			"integrity": "sha512-plonYK4ML2PrxsRD9SeqmFt76eREWkQdPCglOA6aYDzL1AAbE+7PUnT54SvpWGfws13L0AZEqGSpL7+1IPnTxQ==",
 			"license": "Apache-2.0",
 			"peer": true,
 			"dependencies": {
@@ -1485,66 +1106,53 @@
 				}
 			}
 		},
-		"node_modules/@grammyjs/runner": {
-			"version": "2.0.3",
-			"resolved": "https://registry.npmjs.org/@grammyjs/runner/-/runner-2.0.3.tgz",
-			"integrity": "sha512-nckmTs1dPWfVQteK9cxqxzE+0m1VRvluLWB8UgFzsjg62w3qthPJt0TYtJBEdG7OedvfQq4vnFAyE6iaMkR42A==",
-			"license": "MIT",
+		"node_modules/@google/genai/node_modules/gcp-metadata": {
+			"version": "8.1.2",
+			"resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-8.1.2.tgz",
+			"integrity": "sha512-zV/5HKTfCeKWnxG0Dmrw51hEWFGfcF2xiXqcA3+J90WDuP0SvoiSO5ORvcBsifmx/FoIjgQN3oNOGaQ5PhLFkg==",
+			"license": "Apache-2.0",
 			"peer": true,
 			"dependencies": {
-				"abort-controller": "^3.0.0"
+				"gaxios": "^7.0.0",
+				"google-logging-utils": "^1.0.0",
+				"json-bigint": "^1.0.0"
 			},
 			"engines": {
-				"node": ">=12.20.0 || >=14.13.1"
-			},
-			"peerDependencies": {
-				"grammy": "^1.13.1"
+				"node": ">=18"
 			}
 		},
-		"node_modules/@grammyjs/transformer-throttler": {
-			"version": "1.2.1",
-			"resolved": "https://registry.npmjs.org/@grammyjs/transformer-throttler/-/transformer-throttler-1.2.1.tgz",
-			"integrity": "sha512-CpWB0F3rJdUiKsq7826QhQsxbZi4wqfz1ccKX+fr+AOC+o8K7ZvS+wqX0suSu1QCsyUq2MDpNiKhyL2ZOJUS4w==",
-			"license": "MIT",
+		"node_modules/@google/genai/node_modules/google-auth-library": {
+			"version": "10.6.2",
+			"resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-10.6.2.tgz",
+			"integrity": "sha512-e27Z6EThmVNNvtYASwQxose/G57rkRuaRbQyxM2bvYLLX/GqWZ5chWq2EBoUchJbCc57eC9ArzO5wMsEmWftCw==",
+			"license": "Apache-2.0",
 			"peer": true,
 			"dependencies": {
-				"bottleneck": "^2.0.0"
+				"base64-js": "^1.3.0",
+				"ecdsa-sig-formatter": "^1.0.11",
+				"gaxios": "^7.1.4",
+				"gcp-metadata": "8.1.2",
+				"google-logging-utils": "1.1.3",
+				"jws": "^4.0.0"
 			},
 			"engines": {
-				"node": "^12.20.0 || >=14.13.1"
-			},
-			"peerDependencies": {
-				"grammy": "^1.0.0"
+				"node": ">=18"
 			}
 		},
-		"node_modules/@grammyjs/types": {
-			"version": "3.24.0",
-			"resolved": "https://registry.npmjs.org/@grammyjs/types/-/types-3.24.0.tgz",
-			"integrity": "sha512-qQIEs4lN5WqUdr4aT8MeU6UFpMbGYAvcvYSW1A4OO1PABGJQHz/KLON6qvpf+5RxaNDQBxiY2k2otIhg/AG7RQ==",
-			"license": "MIT",
-			"peer": true
-		},
-		"node_modules/@hapi/boom": {
-			"version": "9.1.4",
-			"resolved": "https://registry.npmjs.org/@hapi/boom/-/boom-9.1.4.tgz",
-			"integrity": "sha512-Ls1oH8jaN1vNsqcaHVYJrKmgMcKsC1wcp8bujvXrHaAqD2iDYq3HoOwsxwo09Cuda5R5nC0o0IxlrlTuvPuzSw==",
-			"license": "BSD-3-Clause",
+		"node_modules/@google/genai/node_modules/google-logging-utils": {
+			"version": "1.1.3",
+			"resolved": "https://registry.npmjs.org/google-logging-utils/-/google-logging-utils-1.1.3.tgz",
+			"integrity": "sha512-eAmLkjDjAFCVXg7A1unxHsLf961m6y17QFqXqAXGj/gVkKFrEICfStRfwUlGNfeCEjNRa32JEWOUTlYXPyyKvA==",
+			"license": "Apache-2.0",
 			"peer": true,
-			"dependencies": {
-				"@hapi/hoek": "9.x.x"
+			"engines": {
+				"node": ">=14"
 			}
-		},
-		"node_modules/@hapi/hoek": {
-			"version": "9.3.0",
-			"resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-9.3.0.tgz",
-			"integrity": "sha512-/c6rf4UJlmHlC9b5BaNvzAcFv7HZ2QHaV0D4/HNlBdvFnvQq8RI4kYdhyPCl7Xj+oWvTWQ8ujhqS53LIgAe6KQ==",
-			"license": "BSD-3-Clause",
-			"peer": true
 		},
 		"node_modules/@homebridge/ciao": {
-			"version": "1.3.5",
-			"resolved": "https://registry.npmjs.org/@homebridge/ciao/-/ciao-1.3.5.tgz",
-			"integrity": "sha512-f7MAw7YuoEYgJEQ1VyRcLHGuVmCpmXi65GVR8CAtPWPqIZf/HFr4vHzVpOfQMpEQw9Pt5uh07guuLt5HE8ruog==",
+			"version": "1.3.6",
+			"resolved": "https://registry.npmjs.org/@homebridge/ciao/-/ciao-1.3.6.tgz",
+			"integrity": "sha512-2F9N/15Q/GnoBXimr8PFg7fb1QrAQBvuZpaW2kseWOOy14Lzc3yZB1mT9N1Ju/4hlkboU33uHxtOxZkvkPoE/w==",
 			"license": "MIT",
 			"peer": true,
 			"dependencies": {
@@ -1558,11 +1166,10 @@
 			}
 		},
 		"node_modules/@hono/node-server": {
-			"version": "1.19.9",
-			"resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.9.tgz",
-			"integrity": "sha512-vHL6w3ecZsky+8P5MD+eFfaGTyCeOHUIFYMGpQGbrBTSmNNoxv0if69rEZ5giu36weC5saFuznL411gRX7bJDw==",
+			"version": "1.19.13",
+			"resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.13.tgz",
+			"integrity": "sha512-TsQLe4i2gvoTtrHje625ngThGBySOgSK3Xo2XRYOdqGN1teR8+I7vchQC46uLJi8OF62YTYA3AhSpumtkhsaKQ==",
 			"license": "MIT",
-			"optional": true,
 			"peer": true,
 			"engines": {
 				"node": ">=18.14.1"
@@ -1571,20 +1178,10 @@
 				"hono": "^4"
 			}
 		},
-		"node_modules/@huggingface/jinja": {
-			"version": "0.5.5",
-			"resolved": "https://registry.npmjs.org/@huggingface/jinja/-/jinja-0.5.5.tgz",
-			"integrity": "sha512-xRlzazC+QZwr6z4ixEqYHo9fgwhTZ3xNSdljlKfUFGZSdlvt166DljRELFUfFytlYOYvo3vTisA/AFOuOAzFQQ==",
-			"license": "MIT",
-			"peer": true,
-			"engines": {
-				"node": ">=18"
-			}
-		},
 		"node_modules/@img/colour": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/@img/colour/-/colour-1.0.0.tgz",
-			"integrity": "sha512-A5P/LfWGFSl6nsckYtjw9da+19jB8hkJ6ACTGcDfEJ0aE+l2n2El7dsVM7UVHZQ9s2lmYMWlrS21YLy2IR1LUw==",
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/@img/colour/-/colour-1.1.0.tgz",
+			"integrity": "sha512-Td76q7j57o/tLVdgS746cYARfSyxk8iEfRxewL9h4OMzYhbW4TAcppl0mT4eyqXddh6L/jwoM75mo7ixa/pCeQ==",
 			"license": "MIT",
 			"peer": true,
 			"engines": {
@@ -1678,6 +1275,9 @@
 			"cpu": [
 				"arm"
 			],
+			"libc": [
+				"glibc"
+			],
 			"license": "LGPL-3.0-or-later",
 			"optional": true,
 			"os": [
@@ -1694,6 +1294,9 @@
 			"integrity": "sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==",
 			"cpu": [
 				"arm64"
+			],
+			"libc": [
+				"glibc"
 			],
 			"license": "LGPL-3.0-or-later",
 			"optional": true,
@@ -1712,6 +1315,9 @@
 			"cpu": [
 				"ppc64"
 			],
+			"libc": [
+				"glibc"
+			],
 			"license": "LGPL-3.0-or-later",
 			"optional": true,
 			"os": [
@@ -1728,6 +1334,9 @@
 			"integrity": "sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==",
 			"cpu": [
 				"riscv64"
+			],
+			"libc": [
+				"glibc"
 			],
 			"license": "LGPL-3.0-or-later",
 			"optional": true,
@@ -1746,6 +1355,9 @@
 			"cpu": [
 				"s390x"
 			],
+			"libc": [
+				"glibc"
+			],
 			"license": "LGPL-3.0-or-later",
 			"optional": true,
 			"os": [
@@ -1762,6 +1374,9 @@
 			"integrity": "sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==",
 			"cpu": [
 				"x64"
+			],
+			"libc": [
+				"glibc"
 			],
 			"license": "LGPL-3.0-or-later",
 			"optional": true,
@@ -1780,6 +1395,9 @@
 			"cpu": [
 				"arm64"
 			],
+			"libc": [
+				"musl"
+			],
 			"license": "LGPL-3.0-or-later",
 			"optional": true,
 			"os": [
@@ -1797,6 +1415,9 @@
 			"cpu": [
 				"x64"
 			],
+			"libc": [
+				"musl"
+			],
 			"license": "LGPL-3.0-or-later",
 			"optional": true,
 			"os": [
@@ -1813,6 +1434,9 @@
 			"integrity": "sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==",
 			"cpu": [
 				"arm"
+			],
+			"libc": [
+				"glibc"
 			],
 			"license": "Apache-2.0",
 			"optional": true,
@@ -1837,6 +1461,9 @@
 			"cpu": [
 				"arm64"
 			],
+			"libc": [
+				"glibc"
+			],
 			"license": "Apache-2.0",
 			"optional": true,
 			"os": [
@@ -1859,6 +1486,9 @@
 			"integrity": "sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==",
 			"cpu": [
 				"ppc64"
+			],
+			"libc": [
+				"glibc"
 			],
 			"license": "Apache-2.0",
 			"optional": true,
@@ -1883,6 +1513,9 @@
 			"cpu": [
 				"riscv64"
 			],
+			"libc": [
+				"glibc"
+			],
 			"license": "Apache-2.0",
 			"optional": true,
 			"os": [
@@ -1905,6 +1538,9 @@
 			"integrity": "sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==",
 			"cpu": [
 				"s390x"
+			],
+			"libc": [
+				"glibc"
 			],
 			"license": "Apache-2.0",
 			"optional": true,
@@ -1929,6 +1565,9 @@
 			"cpu": [
 				"x64"
 			],
+			"libc": [
+				"glibc"
+			],
 			"license": "Apache-2.0",
 			"optional": true,
 			"os": [
@@ -1952,6 +1591,9 @@
 			"cpu": [
 				"arm64"
 			],
+			"libc": [
+				"musl"
+			],
 			"license": "Apache-2.0",
 			"optional": true,
 			"os": [
@@ -1974,6 +1616,9 @@
 			"integrity": "sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==",
 			"cpu": [
 				"x64"
+			],
+			"libc": [
+				"musl"
 			],
 			"license": "Apache-2.0",
 			"optional": true,
@@ -2071,67 +1716,6 @@
 				"url": "https://opencollective.com/libvips"
 			}
 		},
-		"node_modules/@isaacs/cliui": {
-			"version": "8.0.2",
-			"resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
-			"integrity": "sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==",
-			"license": "ISC",
-			"peer": true,
-			"dependencies": {
-				"string-width": "^5.1.2",
-				"string-width-cjs": "npm:string-width@^4.2.0",
-				"strip-ansi": "^7.0.1",
-				"strip-ansi-cjs": "npm:strip-ansi@^6.0.1",
-				"wrap-ansi": "^8.1.0",
-				"wrap-ansi-cjs": "npm:wrap-ansi@^7.0.0"
-			},
-			"engines": {
-				"node": ">=12"
-			}
-		},
-		"node_modules/@isaacs/cliui/node_modules/emoji-regex": {
-			"version": "9.2.2",
-			"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
-			"integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
-			"license": "MIT",
-			"peer": true
-		},
-		"node_modules/@isaacs/cliui/node_modules/string-width": {
-			"version": "5.1.2",
-			"resolved": "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz",
-			"integrity": "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==",
-			"license": "MIT",
-			"peer": true,
-			"dependencies": {
-				"eastasianwidth": "^0.2.0",
-				"emoji-regex": "^9.2.2",
-				"strip-ansi": "^7.0.1"
-			},
-			"engines": {
-				"node": ">=12"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/@isaacs/cliui/node_modules/wrap-ansi": {
-			"version": "8.1.0",
-			"resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-8.1.0.tgz",
-			"integrity": "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==",
-			"license": "MIT",
-			"peer": true,
-			"dependencies": {
-				"ansi-styles": "^6.1.0",
-				"string-width": "^5.0.1",
-				"strip-ansi": "^7.0.1"
-			},
-			"engines": {
-				"node": ">=12"
-			},
-			"funding": {
-				"url": "https://github.com/chalk/wrap-ansi?sponsor=1"
-			}
-		},
 		"node_modules/@isaacs/fs-minipass": {
 			"version": "4.0.1",
 			"resolved": "https://registry.npmjs.org/@isaacs/fs-minipass/-/fs-minipass-4.0.1.tgz",
@@ -2143,63 +1727,6 @@
 			},
 			"engines": {
 				"node": ">=18.0.0"
-			}
-		},
-		"node_modules/@keyv/bigmap": {
-			"version": "1.3.1",
-			"resolved": "https://registry.npmjs.org/@keyv/bigmap/-/bigmap-1.3.1.tgz",
-			"integrity": "sha512-WbzE9sdmQtKy8vrNPa9BRnwZh5UF4s1KTmSK0KUVLo3eff5BlQNNWDnFOouNpKfPKDnms9xynJjsMYjMaT/aFQ==",
-			"license": "MIT",
-			"peer": true,
-			"dependencies": {
-				"hashery": "^1.4.0",
-				"hookified": "^1.15.0"
-			},
-			"engines": {
-				"node": ">= 18"
-			},
-			"peerDependencies": {
-				"keyv": "^5.6.0"
-			}
-		},
-		"node_modules/@keyv/serialize": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/@keyv/serialize/-/serialize-1.1.1.tgz",
-			"integrity": "sha512-dXn3FZhPv0US+7dtJsIi2R+c7qWYiReoEh5zUntWCf4oSpMNib8FDhSoed6m3QyZdx5hK7iLFkYk3rNxwt8vTA==",
-			"license": "MIT",
-			"peer": true
-		},
-		"node_modules/@kwsites/file-exists": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/@kwsites/file-exists/-/file-exists-1.1.1.tgz",
-			"integrity": "sha512-m9/5YGR18lIwxSFDwfE3oA7bWuq9kdau6ugN4H2rJeyhFQZcG9AgSHkQtSD15a8WvTgfz9aikZMrKPHvbpqFiw==",
-			"license": "MIT",
-			"peer": true,
-			"dependencies": {
-				"debug": "^4.1.1"
-			}
-		},
-		"node_modules/@kwsites/promise-deferred": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/@kwsites/promise-deferred/-/promise-deferred-1.1.1.tgz",
-			"integrity": "sha512-GaHYm+c0O9MjZRu0ongGBRbinu8gVAMd2UZjji6jVmqKtZluZnptXGWhz1E8j8D2HJ3f/yMxKAUC0b+57wncIw==",
-			"license": "MIT",
-			"peer": true
-		},
-		"node_modules/@larksuiteoapi/node-sdk": {
-			"version": "1.59.0",
-			"resolved": "https://registry.npmjs.org/@larksuiteoapi/node-sdk/-/node-sdk-1.59.0.tgz",
-			"integrity": "sha512-sBpkruTvZDOxnVtoTbepWKRX0j1Y1ZElQYu0x7+v088sI9pcpbVp6ZzCGn62dhrKPatzNyCJyzYCPXPYQWccrA==",
-			"license": "MIT",
-			"peer": true,
-			"dependencies": {
-				"axios": "~1.13.3",
-				"lodash.identity": "^3.0.0",
-				"lodash.merge": "^4.6.2",
-				"lodash.pickby": "^4.6.0",
-				"protobufjs": "^7.2.6",
-				"qs": "^6.14.2",
-				"ws": "^8.19.0"
 			}
 		},
 		"node_modules/@line/bot-sdk": {
@@ -2412,6 +1939,9 @@
 			"cpu": [
 				"arm64"
 			],
+			"libc": [
+				"glibc"
+			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -2428,6 +1958,9 @@
 			"integrity": "sha512-0/Gi5Xq2V6goXBop19ePoHvXsmJD9SzFlO3S+d6+T2b+BlPcpOu3Oa0wTjl+cZrLAAEzA86aPNBI+VVAFDFPKw==",
 			"cpu": [
 				"arm64"
+			],
+			"libc": [
+				"musl"
 			],
 			"license": "MIT",
 			"optional": true,
@@ -2446,6 +1979,9 @@
 			"cpu": [
 				"riscv64"
 			],
+			"libc": [
+				"glibc"
+			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -2463,6 +1999,9 @@
 			"cpu": [
 				"x64"
 			],
+			"libc": [
+				"glibc"
+			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -2479,6 +2018,9 @@
 			"integrity": "sha512-xVUtnoMQ8v2JVyfJLKKXACA6avdnchdbBkTsZs8BgJQo29qwCp5NIHAUO8gbJ40iaEGToW5RlmVk2M9V0HsHEw==",
 			"cpu": [
 				"x64"
+			],
+			"libc": [
+				"musl"
 			],
 			"license": "MIT",
 			"optional": true,
@@ -2539,34 +2081,34 @@
 			}
 		},
 		"node_modules/@mariozechner/pi-agent-core": {
-			"version": "0.54.1",
-			"resolved": "https://registry.npmjs.org/@mariozechner/pi-agent-core/-/pi-agent-core-0.54.1.tgz",
-			"integrity": "sha512-AC0SqEbR62PckWOyP0CmhYtfcC+Q6e1DGghwEcKpomTtmNfHTy7iTVy64mmtB2CFiN8j4rJFCqh2xJHgucUvkA==",
+			"version": "0.65.0",
+			"resolved": "https://registry.npmjs.org/@mariozechner/pi-agent-core/-/pi-agent-core-0.65.0.tgz",
+			"integrity": "sha512-QCDqkgxvCkizCgJOl0aFekT1gURppznzuBIGXS8dXWZMour/xX6YF7chxX56mZ0p0DXkILM1ixf5jXYBfDsP5w==",
 			"license": "MIT",
 			"peer": true,
 			"dependencies": {
-				"@mariozechner/pi-ai": "^0.54.1"
+				"@mariozechner/pi-ai": "^0.65.0"
 			},
 			"engines": {
 				"node": ">=20.0.0"
 			}
 		},
 		"node_modules/@mariozechner/pi-ai": {
-			"version": "0.54.1",
-			"resolved": "https://registry.npmjs.org/@mariozechner/pi-ai/-/pi-ai-0.54.1.tgz",
-			"integrity": "sha512-tiVvoNQV+3dpWgRQ1U/3bwJoDVSYwL17BE/kc00nXmaSLAPwNZoxLagtQ+HBr/rGzkq5viOgQf2dk+ud+/4UCg==",
+			"version": "0.65.0",
+			"resolved": "https://registry.npmjs.org/@mariozechner/pi-ai/-/pi-ai-0.65.0.tgz",
+			"integrity": "sha512-MsCsCHlHIlBYbg6jB2PJBeCNKbjzVZge7ddBNUJN2gsFY8sdjFh482+GB+r5Ou6k9Fnhi3nO779YDymo5+t89w==",
 			"license": "MIT",
 			"peer": true,
 			"dependencies": {
 				"@anthropic-ai/sdk": "^0.73.0",
 				"@aws-sdk/client-bedrock-runtime": "^3.983.0",
 				"@google/genai": "^1.40.0",
-				"@mistralai/mistralai": "1.10.0",
+				"@mistralai/mistralai": "1.14.1",
 				"@sinclair/typebox": "^0.34.41",
 				"ajv": "^8.17.1",
 				"ajv-formats": "^3.0.1",
 				"chalk": "^5.6.2",
-				"openai": "6.10.0",
+				"openai": "6.26.0",
 				"partial-json": "^0.1.7",
 				"proxy-agent": "^6.5.0",
 				"undici": "^7.19.1",
@@ -2579,56 +2121,122 @@
 				"node": ">=20.0.0"
 			}
 		},
+		"node_modules/@mariozechner/pi-ai/node_modules/@anthropic-ai/sdk": {
+			"version": "0.73.0",
+			"resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.73.0.tgz",
+			"integrity": "sha512-URURVzhxXGJDGUGFunIOtBlSl7KWvZiAAKY/ttTkZAkXT9bTPqdk2eK0b8qqSxXpikh3QKPnPYpiyX98zf5ebw==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"json-schema-to-ts": "^3.1.1"
+			},
+			"bin": {
+				"anthropic-ai-sdk": "bin/cli"
+			},
+			"peerDependencies": {
+				"zod": "^3.25.0 || ^4.0.0"
+			},
+			"peerDependenciesMeta": {
+				"zod": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@mariozechner/pi-ai/node_modules/undici": {
+			"version": "7.24.7",
+			"resolved": "https://registry.npmjs.org/undici/-/undici-7.24.7.tgz",
+			"integrity": "sha512-H/nlJ/h0ggGC+uRL3ovD+G0i4bqhvsDOpbDv7At5eFLlj2b41L8QliGbnl2H7SnDiYhENphh1tQFJZf+MyfLsQ==",
+			"license": "MIT",
+			"peer": true,
+			"engines": {
+				"node": ">=20.18.1"
+			}
+		},
 		"node_modules/@mariozechner/pi-coding-agent": {
-			"version": "0.54.1",
-			"resolved": "https://registry.npmjs.org/@mariozechner/pi-coding-agent/-/pi-coding-agent-0.54.1.tgz",
-			"integrity": "sha512-pPFrdaKZ16oIcdhZVcfWPhCDFx8PWHaACjQS9aFFcMOhLBduyKAGyf8bQtfysekl+gIbBSGDT2rgCxsOwK2bQw==",
+			"version": "0.65.0",
+			"resolved": "https://registry.npmjs.org/@mariozechner/pi-coding-agent/-/pi-coding-agent-0.65.0.tgz",
+			"integrity": "sha512-IEBZ74n17w8NxnG/X2ixErsSYcvLm/h5WKALNbPgPWJZqvafNtJ0GcrCfLCS6RVIq2o+O/a2QwsbSI6bgJ6W/A==",
 			"license": "MIT",
 			"peer": true,
 			"dependencies": {
 				"@mariozechner/jiti": "^2.6.2",
-				"@mariozechner/pi-agent-core": "^0.54.1",
-				"@mariozechner/pi-ai": "^0.54.1",
-				"@mariozechner/pi-tui": "^0.54.1",
+				"@mariozechner/pi-agent-core": "^0.65.0",
+				"@mariozechner/pi-ai": "^0.65.0",
+				"@mariozechner/pi-tui": "^0.65.0",
 				"@silvia-odwyer/photon-node": "^0.3.4",
+				"ajv": "^8.17.1",
 				"chalk": "^5.5.0",
 				"cli-highlight": "^2.1.11",
 				"diff": "^8.0.2",
+				"extract-zip": "^2.0.1",
 				"file-type": "^21.1.1",
 				"glob": "^13.0.1",
 				"hosted-git-info": "^9.0.2",
 				"ignore": "^7.0.5",
 				"marked": "^15.0.12",
-				"minimatch": "^10.1.1",
+				"minimatch": "^10.2.3",
 				"proper-lockfile": "^4.1.2",
+				"strip-ansi": "^7.1.0",
+				"undici": "^7.19.1",
 				"yaml": "^2.8.2"
 			},
 			"bin": {
 				"pi": "dist/cli.js"
 			},
 			"engines": {
-				"node": ">=20.0.0"
+				"node": ">=20.6.0"
 			},
 			"optionalDependencies": {
 				"@mariozechner/clipboard": "^0.3.2"
 			}
 		},
+		"node_modules/@mariozechner/pi-coding-agent/node_modules/file-type": {
+			"version": "21.3.4",
+			"resolved": "https://registry.npmjs.org/file-type/-/file-type-21.3.4.tgz",
+			"integrity": "sha512-Ievi/yy8DS3ygGvT47PjSfdFoX+2isQueoYP1cntFW1JLYAuS4GD7NUPGg4zv2iZfV52uDyk5w5Z0TdpRS6Q1g==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"@tokenizer/inflate": "^0.4.1",
+				"strtok3": "^10.3.4",
+				"token-types": "^6.1.1",
+				"uint8array-extras": "^1.4.0"
+			},
+			"engines": {
+				"node": ">=20"
+			},
+			"funding": {
+				"url": "https://github.com/sindresorhus/file-type?sponsor=1"
+			}
+		},
+		"node_modules/@mariozechner/pi-coding-agent/node_modules/undici": {
+			"version": "7.24.7",
+			"resolved": "https://registry.npmjs.org/undici/-/undici-7.24.7.tgz",
+			"integrity": "sha512-H/nlJ/h0ggGC+uRL3ovD+G0i4bqhvsDOpbDv7At5eFLlj2b41L8QliGbnl2H7SnDiYhENphh1tQFJZf+MyfLsQ==",
+			"license": "MIT",
+			"peer": true,
+			"engines": {
+				"node": ">=20.18.1"
+			}
+		},
 		"node_modules/@mariozechner/pi-tui": {
-			"version": "0.54.1",
-			"resolved": "https://registry.npmjs.org/@mariozechner/pi-tui/-/pi-tui-0.54.1.tgz",
-			"integrity": "sha512-FY8QcLlr9T276oZAwMSSPo1drg+J9Y7B+A0S9g8Jh6IFJxymKZZq29/Vit6XDziJfZIgJDraC6lpobtxgTEoFQ==",
+			"version": "0.65.0",
+			"resolved": "https://registry.npmjs.org/@mariozechner/pi-tui/-/pi-tui-0.65.0.tgz",
+			"integrity": "sha512-P5Uuf4x1sTplMNQw8NrC1Hyz0N/tZq9kC6CDRkTT7rZuxZEeXl9uhKvlLEGigdKVOVrWnPE7ip0jrO81POYy3g==",
 			"license": "MIT",
 			"peer": true,
 			"dependencies": {
 				"@types/mime-types": "^2.1.4",
 				"chalk": "^5.5.0",
 				"get-east-asian-width": "^1.3.0",
-				"koffi": "^2.9.0",
 				"marked": "^15.0.12",
 				"mime-types": "^3.0.1"
 			},
 			"engines": {
 				"node": ">=20.0.0"
+			},
+			"optionalDependencies": {
+				"koffi": "^2.9.0"
 			}
 		},
 		"node_modules/@mariozechner/pi-tui/node_modules/mime-db": {
@@ -2658,24 +2266,82 @@
 				"url": "https://opencollective.com/express"
 			}
 		},
-		"node_modules/@mistralai/mistralai": {
-			"version": "1.10.0",
-			"resolved": "https://registry.npmjs.org/@mistralai/mistralai/-/mistralai-1.10.0.tgz",
-			"integrity": "sha512-tdIgWs4Le8vpvPiUEWne6tK0qbVc+jMenujnvTqOjogrJUsCSQhus0tHTU1avDDh5//Rq2dFgP9mWRAdIEoBqg==",
+		"node_modules/@matrix-org/matrix-sdk-crypto-nodejs": {
+			"version": "0.4.0",
+			"resolved": "https://registry.npmjs.org/@matrix-org/matrix-sdk-crypto-nodejs/-/matrix-sdk-crypto-nodejs-0.4.0.tgz",
+			"integrity": "sha512-+qqgpn39XFSbsD0dFjssGO9vHEP7sTyfs8yTpt8vuqWpUpF20QMwpCZi0jpYw7GxjErNTsMshopuo8677DfGEA==",
+			"hasInstallScript": true,
+			"license": "Apache-2.0",
+			"optional": true,
 			"peer": true,
 			"dependencies": {
-				"zod": "^3.20.0",
+				"https-proxy-agent": "^7.0.5",
+				"node-downloader-helper": "^2.1.9"
+			},
+			"engines": {
+				"node": ">= 22"
+			}
+		},
+		"node_modules/@matrix-org/matrix-sdk-crypto-wasm": {
+			"version": "18.0.0",
+			"resolved": "https://registry.npmjs.org/@matrix-org/matrix-sdk-crypto-wasm/-/matrix-sdk-crypto-wasm-18.0.0.tgz",
+			"integrity": "sha512-88+n+dvxLI1cjS10UIlKXVYK7TGWbpAnnaDC9fow7ch/hCvdu3dFhJ3tS3/13N9s9+1QFXB4FFuommj+tHJPhQ==",
+			"license": "Apache-2.0",
+			"peer": true,
+			"engines": {
+				"node": ">= 18"
+			}
+		},
+		"node_modules/@mistralai/mistralai": {
+			"version": "1.14.1",
+			"resolved": "https://registry.npmjs.org/@mistralai/mistralai/-/mistralai-1.14.1.tgz",
+			"integrity": "sha512-IiLmmZFCCTReQgPAT33r7KQ1nYo5JPdvGkrkZqA8qQ2qB1GHgs5LoP5K2ICyrjnpw2n8oSxMM/VP+liiKcGNlQ==",
+			"peer": true,
+			"dependencies": {
+				"ws": "^8.18.0",
+				"zod": "^3.25.0 || ^4.0.0",
 				"zod-to-json-schema": "^3.24.1"
 			}
 		},
-		"node_modules/@mistralai/mistralai/node_modules/zod": {
-			"version": "3.25.76",
-			"resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
-			"integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+		"node_modules/@modelcontextprotocol/sdk": {
+			"version": "1.29.0",
+			"resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.29.0.tgz",
+			"integrity": "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==",
 			"license": "MIT",
 			"peer": true,
-			"funding": {
-				"url": "https://github.com/sponsors/colinhacks"
+			"dependencies": {
+				"@hono/node-server": "^1.19.9",
+				"ajv": "^8.17.1",
+				"ajv-formats": "^3.0.1",
+				"content-type": "^1.0.5",
+				"cors": "^2.8.5",
+				"cross-spawn": "^7.0.5",
+				"eventsource": "^3.0.2",
+				"eventsource-parser": "^3.0.0",
+				"express": "^5.2.1",
+				"express-rate-limit": "^8.2.1",
+				"hono": "^4.11.4",
+				"jose": "^6.1.3",
+				"json-schema-typed": "^8.0.2",
+				"pkce-challenge": "^5.0.0",
+				"raw-body": "^3.0.0",
+				"zod": "^3.25 || ^4.0",
+				"zod-to-json-schema": "^3.25.1"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"peerDependencies": {
+				"@cfworker/json-schema": "^4.1.1",
+				"zod": "^3.25 || ^4.0"
+			},
+			"peerDependenciesMeta": {
+				"@cfworker/json-schema": {
+					"optional": true
+				},
+				"zod": {
+					"optional": false
+				}
 			}
 		},
 		"node_modules/@mozilla/readability": {
@@ -2689,9 +2355,9 @@
 			}
 		},
 		"node_modules/@napi-rs/canvas": {
-			"version": "0.1.94",
-			"resolved": "https://registry.npmjs.org/@napi-rs/canvas/-/canvas-0.1.94.tgz",
-			"integrity": "sha512-8jBkvqynXNdQPNZjLJxB/Rp9PdnnMSHFBLzPmMc615nlt/O6w0ergBbkEDEOr8EbjL8nRQDpEklPx4pzD7zrbg==",
+			"version": "0.1.97",
+			"resolved": "https://registry.npmjs.org/@napi-rs/canvas/-/canvas-0.1.97.tgz",
+			"integrity": "sha512-8cFniXvrIEnVwuNSRCW9wirRZbHvrD3JVujdS2P5n5xiJZNZMOZcfOvJ1pb66c7jXMKHHglJEDVJGbm8XWFcXQ==",
 			"license": "MIT",
 			"peer": true,
 			"workspaces": [
@@ -2705,23 +2371,23 @@
 				"url": "https://github.com/sponsors/Brooooooklyn"
 			},
 			"optionalDependencies": {
-				"@napi-rs/canvas-android-arm64": "0.1.94",
-				"@napi-rs/canvas-darwin-arm64": "0.1.94",
-				"@napi-rs/canvas-darwin-x64": "0.1.94",
-				"@napi-rs/canvas-linux-arm-gnueabihf": "0.1.94",
-				"@napi-rs/canvas-linux-arm64-gnu": "0.1.94",
-				"@napi-rs/canvas-linux-arm64-musl": "0.1.94",
-				"@napi-rs/canvas-linux-riscv64-gnu": "0.1.94",
-				"@napi-rs/canvas-linux-x64-gnu": "0.1.94",
-				"@napi-rs/canvas-linux-x64-musl": "0.1.94",
-				"@napi-rs/canvas-win32-arm64-msvc": "0.1.94",
-				"@napi-rs/canvas-win32-x64-msvc": "0.1.94"
+				"@napi-rs/canvas-android-arm64": "0.1.97",
+				"@napi-rs/canvas-darwin-arm64": "0.1.97",
+				"@napi-rs/canvas-darwin-x64": "0.1.97",
+				"@napi-rs/canvas-linux-arm-gnueabihf": "0.1.97",
+				"@napi-rs/canvas-linux-arm64-gnu": "0.1.97",
+				"@napi-rs/canvas-linux-arm64-musl": "0.1.97",
+				"@napi-rs/canvas-linux-riscv64-gnu": "0.1.97",
+				"@napi-rs/canvas-linux-x64-gnu": "0.1.97",
+				"@napi-rs/canvas-linux-x64-musl": "0.1.97",
+				"@napi-rs/canvas-win32-arm64-msvc": "0.1.97",
+				"@napi-rs/canvas-win32-x64-msvc": "0.1.97"
 			}
 		},
 		"node_modules/@napi-rs/canvas-android-arm64": {
-			"version": "0.1.94",
-			"resolved": "https://registry.npmjs.org/@napi-rs/canvas-android-arm64/-/canvas-android-arm64-0.1.94.tgz",
-			"integrity": "sha512-YQ6K83RWNMQOtgpk1aIML97QTE3zxPmVCHTi5eA8Nss4+B9JZi5J7LHQr7B5oD7VwSfWd++xsPdUiJ1+frqsMg==",
+			"version": "0.1.97",
+			"resolved": "https://registry.npmjs.org/@napi-rs/canvas-android-arm64/-/canvas-android-arm64-0.1.97.tgz",
+			"integrity": "sha512-V1c/WVw+NzH8vk7ZK/O8/nyBSCQimU8sfMsB/9qeSvdkGKNU7+mxy/bIF0gTgeBFmHpj30S4E9WHMSrxXGQuVQ==",
 			"cpu": [
 				"arm64"
 			],
@@ -2740,9 +2406,9 @@
 			}
 		},
 		"node_modules/@napi-rs/canvas-darwin-arm64": {
-			"version": "0.1.94",
-			"resolved": "https://registry.npmjs.org/@napi-rs/canvas-darwin-arm64/-/canvas-darwin-arm64-0.1.94.tgz",
-			"integrity": "sha512-h1yl9XjqSrYZAbBUHCVLAhwd2knM8D8xt081Pv40KqNJXfeMmBrhG1SfroRymG2ak+pl42iQlWjFZ2Z8AWFdSw==",
+			"version": "0.1.97",
+			"resolved": "https://registry.npmjs.org/@napi-rs/canvas-darwin-arm64/-/canvas-darwin-arm64-0.1.97.tgz",
+			"integrity": "sha512-ok+SCEF4YejcxuJ9Rm+WWunHHpf2HmiPxfz6z1a/NFQECGXtsY7A4B8XocK1LmT1D7P174MzwPF9Wy3AUAwEPw==",
 			"cpu": [
 				"arm64"
 			],
@@ -2761,9 +2427,9 @@
 			}
 		},
 		"node_modules/@napi-rs/canvas-darwin-x64": {
-			"version": "0.1.94",
-			"resolved": "https://registry.npmjs.org/@napi-rs/canvas-darwin-x64/-/canvas-darwin-x64-0.1.94.tgz",
-			"integrity": "sha512-rkr/lrafbU0IIHebst+sQJf1HjdHvTMN0GGqWvw5OfaVS0K/sVxhNHtxi8oCfaRSvRE62aJZjWTcdc2ue/o6yw==",
+			"version": "0.1.97",
+			"resolved": "https://registry.npmjs.org/@napi-rs/canvas-darwin-x64/-/canvas-darwin-x64-0.1.97.tgz",
+			"integrity": "sha512-PUP6e6/UGlclUvAQNnuXCcnkpdUou6VYZfQOQxExLp86epOylmiwLkqXIvpFmjoTEDmPmXrI+coL/9EFU1gKPA==",
 			"cpu": [
 				"x64"
 			],
@@ -2782,9 +2448,9 @@
 			}
 		},
 		"node_modules/@napi-rs/canvas-linux-arm-gnueabihf": {
-			"version": "0.1.94",
-			"resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-arm-gnueabihf/-/canvas-linux-arm-gnueabihf-0.1.94.tgz",
-			"integrity": "sha512-q95TDo32YkTKdi+Sp2yQ2Npm7pmfKEruNoJ3RUIw1KvQQ9EHKL3fii/iuU60tnzP0W+c8BKN7BFstNFcm2KXCQ==",
+			"version": "0.1.97",
+			"resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-arm-gnueabihf/-/canvas-linux-arm-gnueabihf-0.1.97.tgz",
+			"integrity": "sha512-XyXH2L/cic8eTNtbrXCcvqHtMX/nEOxN18+7rMrAM2XtLYC/EB5s0wnO1FsLMWmK+04ZSLN9FBGipo7kpIkcOw==",
 			"cpu": [
 				"arm"
 			],
@@ -2803,11 +2469,14 @@
 			}
 		},
 		"node_modules/@napi-rs/canvas-linux-arm64-gnu": {
-			"version": "0.1.94",
-			"resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-arm64-gnu/-/canvas-linux-arm64-gnu-0.1.94.tgz",
-			"integrity": "sha512-Je5/gKVybWAoIGyDOcJF1zYgBTKWkPIkfOgvCzrQcl8h7DiDvRvEY70EapA+NicGe4X3DW9VsCT34KZJnerShA==",
+			"version": "0.1.97",
+			"resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-arm64-gnu/-/canvas-linux-arm64-gnu-0.1.97.tgz",
+			"integrity": "sha512-Kuq/M3djq0K8ktgz6nPlK7Ne5d4uWeDxPpyKWOjWDK2RIOhHVtLtyLiJw2fuldw7Vn4mhw05EZXCEr4Q76rs9w==",
 			"cpu": [
 				"arm64"
+			],
+			"libc": [
+				"glibc"
 			],
 			"license": "MIT",
 			"optional": true,
@@ -2824,11 +2493,14 @@
 			}
 		},
 		"node_modules/@napi-rs/canvas-linux-arm64-musl": {
-			"version": "0.1.94",
-			"resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-arm64-musl/-/canvas-linux-arm64-musl-0.1.94.tgz",
-			"integrity": "sha512-9YleDDauDEZNsFnfz3HyZvp1LK1ECu8N2gDUg1wtL7uWLQv8dUbfVeFtp5HOdxht1o7LsWRmQeqeIbnD4EqE2A==",
+			"version": "0.1.97",
+			"resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-arm64-musl/-/canvas-linux-arm64-musl-0.1.97.tgz",
+			"integrity": "sha512-kKmSkQVnWeqg7qdsiXvYxKhAFuHz3tkBjW/zyQv5YKUPhotpaVhpBGv5LqCngzyuRV85SXoe+OFj+Tv0a0QXkQ==",
 			"cpu": [
 				"arm64"
+			],
+			"libc": [
+				"musl"
 			],
 			"license": "MIT",
 			"optional": true,
@@ -2845,11 +2517,14 @@
 			}
 		},
 		"node_modules/@napi-rs/canvas-linux-riscv64-gnu": {
-			"version": "0.1.94",
-			"resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-riscv64-gnu/-/canvas-linux-riscv64-gnu-0.1.94.tgz",
-			"integrity": "sha512-lQUy9Xvz7ch8+0AXq8RkioLD41iQ6EqdKFu5uV40BxkBDijB2SCm1jna/BRhqitQRSjwAk2KlLUxTjHChyfNGg==",
+			"version": "0.1.97",
+			"resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-riscv64-gnu/-/canvas-linux-riscv64-gnu-0.1.97.tgz",
+			"integrity": "sha512-Jc7I3A51jnEOIAXeLsN/M/+Z28LUeakcsXs07FLq9prXc0eYOtVwsDEv913Gr+06IRo34gJJVgT0TXvmz+N2VA==",
 			"cpu": [
 				"riscv64"
+			],
+			"libc": [
+				"glibc"
 			],
 			"license": "MIT",
 			"optional": true,
@@ -2866,11 +2541,14 @@
 			}
 		},
 		"node_modules/@napi-rs/canvas-linux-x64-gnu": {
-			"version": "0.1.94",
-			"resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-x64-gnu/-/canvas-linux-x64-gnu-0.1.94.tgz",
-			"integrity": "sha512-0IYgyuUaugHdWxXRhDQUCMxTou8kAHHmpIBFtbmdRlciPlfK7AYQW5agvUU1PghPc5Ja3Zzp5qZfiiLu36vIWQ==",
+			"version": "0.1.97",
+			"resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-x64-gnu/-/canvas-linux-x64-gnu-0.1.97.tgz",
+			"integrity": "sha512-iDUBe7AilfuBSRbSa8/IGX38Mf+iCSBqoVKLSQ5XaY2JLOaqz1TVyPFEyIck7wT6mRQhQt5sN6ogfjIDfi74tg==",
 			"cpu": [
 				"x64"
+			],
+			"libc": [
+				"glibc"
 			],
 			"license": "MIT",
 			"optional": true,
@@ -2887,11 +2565,14 @@
 			}
 		},
 		"node_modules/@napi-rs/canvas-linux-x64-musl": {
-			"version": "0.1.94",
-			"resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-x64-musl/-/canvas-linux-x64-musl-0.1.94.tgz",
-			"integrity": "sha512-xuetfzzcflCIiBw2HJlOU4/+zTqhdxoe1BEcwdBsHAd/5wAQ4Pp+FGPi5g74gDvtcXQmTdEU3fLQvHc/j3wbxQ==",
+			"version": "0.1.97",
+			"resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-x64-musl/-/canvas-linux-x64-musl-0.1.97.tgz",
+			"integrity": "sha512-AKLFd/v0Z5fvgqBDqhvqtAdx+fHMJ5t9JcUNKq4FIZ5WH+iegGm8HPdj00NFlCSnm83Fp3Ln8I2f7uq1aIiWaA==",
 			"cpu": [
 				"x64"
+			],
+			"libc": [
+				"musl"
 			],
 			"license": "MIT",
 			"optional": true,
@@ -2908,9 +2589,9 @@
 			}
 		},
 		"node_modules/@napi-rs/canvas-win32-arm64-msvc": {
-			"version": "0.1.94",
-			"resolved": "https://registry.npmjs.org/@napi-rs/canvas-win32-arm64-msvc/-/canvas-win32-arm64-msvc-0.1.94.tgz",
-			"integrity": "sha512-2F3p8wci4Q4vjbENlQtSibqFWxBdpzYk1c8Jh1mqqLE92rBKElG018dBJ6C8Dp49vE350Hmy5LrfdLgFKMG8sg==",
+			"version": "0.1.97",
+			"resolved": "https://registry.npmjs.org/@napi-rs/canvas-win32-arm64-msvc/-/canvas-win32-arm64-msvc-0.1.97.tgz",
+			"integrity": "sha512-u883Yr6A6fO7Vpsy9YE4FVCIxzzo5sO+7pIUjjoDLjS3vQaNMkVzx5bdIpEL+ob+gU88WDK4VcxYMZ6nmnoX9A==",
 			"cpu": [
 				"arm64"
 			],
@@ -2929,9 +2610,9 @@
 			}
 		},
 		"node_modules/@napi-rs/canvas-win32-x64-msvc": {
-			"version": "0.1.94",
-			"resolved": "https://registry.npmjs.org/@napi-rs/canvas-win32-x64-msvc/-/canvas-win32-x64-msvc-0.1.94.tgz",
-			"integrity": "sha512-hjwaIKMrQLoNiu3724octSGhDVKkBwJtMeQ3qUXOi+y60h2q6Sxq3+MM2za3V88+XQzzwn0DgG0Xo6v6gzV8kQ==",
+			"version": "0.1.97",
+			"resolved": "https://registry.npmjs.org/@napi-rs/canvas-win32-x64-msvc/-/canvas-win32-x64-msvc-0.1.97.tgz",
+			"integrity": "sha512-sWtD2EE3fV0IzN+iiQUqr/Q1SwqWhs2O1FKItFlxtdDkikpEj5g7DKQpY3x55H/MAOnL8iomnlk3mcEeGiUMoQ==",
 			"cpu": [
 				"x64"
 			],
@@ -2947,616 +2628,6 @@
 			"funding": {
 				"type": "github",
 				"url": "https://github.com/sponsors/Brooooooklyn"
-			}
-		},
-		"node_modules/@node-llama-cpp/linux-arm64": {
-			"version": "3.15.1",
-			"resolved": "https://registry.npmjs.org/@node-llama-cpp/linux-arm64/-/linux-arm64-3.15.1.tgz",
-			"integrity": "sha512-g7JC/WwDyyBSmkIjSvRF2XLW+YA0z2ZVBSAKSv106mIPO4CzC078woTuTaPsykWgIaKcQRyXuW5v5XQMcT1OOA==",
-			"cpu": [
-				"arm64",
-				"x64"
-			],
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"peer": true,
-			"engines": {
-				"node": ">=20.0.0"
-			}
-		},
-		"node_modules/@node-llama-cpp/linux-armv7l": {
-			"version": "3.15.1",
-			"resolved": "https://registry.npmjs.org/@node-llama-cpp/linux-armv7l/-/linux-armv7l-3.15.1.tgz",
-			"integrity": "sha512-MSxR3A0vFSVWbmVSkNqNXQnI45L2Vg7/PRgJukcjChk7YzRxs9L+oQMeycVW3BsQ03mIZ0iORsZ9MNIBEbdS3g==",
-			"cpu": [
-				"arm",
-				"x64"
-			],
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"peer": true,
-			"engines": {
-				"node": ">=20.0.0"
-			}
-		},
-		"node_modules/@node-llama-cpp/linux-x64": {
-			"version": "3.15.1",
-			"resolved": "https://registry.npmjs.org/@node-llama-cpp/linux-x64/-/linux-x64-3.15.1.tgz",
-			"integrity": "sha512-w4SdxJaA9eJLVYWX+Jv48hTP4oO79BJQIFURMi7hXIFXbxyyOov/r6sVaQ1WiL83nVza37U5Qg4L9Gb/KRdNWQ==",
-			"cpu": [
-				"x64"
-			],
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"peer": true,
-			"engines": {
-				"node": ">=20.0.0"
-			}
-		},
-		"node_modules/@node-llama-cpp/linux-x64-cuda": {
-			"version": "3.15.1",
-			"resolved": "https://registry.npmjs.org/@node-llama-cpp/linux-x64-cuda/-/linux-x64-cuda-3.15.1.tgz",
-			"integrity": "sha512-kngwoq1KdrqSr/b6+tn5jbtGHI0tZnW5wofKssZy+Il2ge3eN9FowKbXG4FH452g6qSSVoDccAoTvYOxyLyX+w==",
-			"cpu": [
-				"x64"
-			],
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"peer": true,
-			"engines": {
-				"node": ">=20.0.0"
-			}
-		},
-		"node_modules/@node-llama-cpp/linux-x64-cuda-ext": {
-			"version": "3.15.1",
-			"resolved": "https://registry.npmjs.org/@node-llama-cpp/linux-x64-cuda-ext/-/linux-x64-cuda-ext-3.15.1.tgz",
-			"integrity": "sha512-toepvLcXjgaQE/QGIThHBD58jbHGBWT1jhblJkCjYBRHfVOO+6n/PmVsJt+yMfu5Z93A2gF8YOvVyZXNXmGo5g==",
-			"cpu": [
-				"x64"
-			],
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"peer": true,
-			"engines": {
-				"node": ">=20.0.0"
-			}
-		},
-		"node_modules/@node-llama-cpp/linux-x64-vulkan": {
-			"version": "3.15.1",
-			"resolved": "https://registry.npmjs.org/@node-llama-cpp/linux-x64-vulkan/-/linux-x64-vulkan-3.15.1.tgz",
-			"integrity": "sha512-CMsyQkGKpHKeOH9+ZPxo0hO0usg8jabq5/aM3JwdX9CiuXhXUa3nu3NH4RObiNi596Zwn/zWzlps0HRwcpL8rw==",
-			"cpu": [
-				"x64"
-			],
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"peer": true,
-			"engines": {
-				"node": ">=20.0.0"
-			}
-		},
-		"node_modules/@node-llama-cpp/mac-arm64-metal": {
-			"version": "3.15.1",
-			"resolved": "https://registry.npmjs.org/@node-llama-cpp/mac-arm64-metal/-/mac-arm64-metal-3.15.1.tgz",
-			"integrity": "sha512-ePTweqohcy6Gjs1agXWy4FxAw5W4Avr7NeqqiFWJ5ngZ1U3ZXdruUHB8L/vDxyn3FzKvstrFyN7UScbi0pzXrA==",
-			"cpu": [
-				"arm64",
-				"x64"
-			],
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"darwin"
-			],
-			"peer": true,
-			"engines": {
-				"node": ">=20.0.0"
-			}
-		},
-		"node_modules/@node-llama-cpp/mac-x64": {
-			"version": "3.15.1",
-			"resolved": "https://registry.npmjs.org/@node-llama-cpp/mac-x64/-/mac-x64-3.15.1.tgz",
-			"integrity": "sha512-NAetSQONxpNXTBnEo7oOkKZ84wO2avBy6V9vV9ntjJLb/07g7Rar8s/jVaicc/rVl6C+8ljZNwqJeynirgAC5w==",
-			"cpu": [
-				"x64"
-			],
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"darwin"
-			],
-			"peer": true,
-			"engines": {
-				"node": ">=20.0.0"
-			}
-		},
-		"node_modules/@node-llama-cpp/win-arm64": {
-			"version": "3.15.1",
-			"resolved": "https://registry.npmjs.org/@node-llama-cpp/win-arm64/-/win-arm64-3.15.1.tgz",
-			"integrity": "sha512-1O9tNSUgvgLL5hqgEuYiz7jRdA3+9yqzNJyPW1jExlQo442OA0eIpHBmeOtvXLwMkY7qv7wE75FdOPR7NVEnvg==",
-			"cpu": [
-				"arm64",
-				"x64"
-			],
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"win32"
-			],
-			"peer": true,
-			"engines": {
-				"node": ">=20.0.0"
-			}
-		},
-		"node_modules/@node-llama-cpp/win-x64": {
-			"version": "3.15.1",
-			"resolved": "https://registry.npmjs.org/@node-llama-cpp/win-x64/-/win-x64-3.15.1.tgz",
-			"integrity": "sha512-jtoXBa6h+VPsQgefrO7HDjYv4WvxfHtUO30ABwCUDuEgM0e05YYhxMZj1z2Ns47UrquNvd/LUPCyjHKqHUN+5Q==",
-			"cpu": [
-				"x64"
-			],
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"win32"
-			],
-			"peer": true,
-			"engines": {
-				"node": ">=20.0.0"
-			}
-		},
-		"node_modules/@node-llama-cpp/win-x64-cuda": {
-			"version": "3.15.1",
-			"resolved": "https://registry.npmjs.org/@node-llama-cpp/win-x64-cuda/-/win-x64-cuda-3.15.1.tgz",
-			"integrity": "sha512-swoyx0/dY4ixiu3mEWrIAinx0ffHn9IncELDNREKG+iIXfx6w0OujOMQ6+X+lGj+sjE01yMUP/9fv6GEp2pmBw==",
-			"cpu": [
-				"x64"
-			],
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"win32"
-			],
-			"peer": true,
-			"engines": {
-				"node": ">=20.0.0"
-			}
-		},
-		"node_modules/@node-llama-cpp/win-x64-cuda-ext": {
-			"version": "3.15.1",
-			"resolved": "https://registry.npmjs.org/@node-llama-cpp/win-x64-cuda-ext/-/win-x64-cuda-ext-3.15.1.tgz",
-			"integrity": "sha512-mO3Tf6D3UlFkjQF5J96ynTkjdF7dac/f5f61cEh6oU4D3hdx+cwnmBWT1gVhDSLboJYzCHtx7U2EKPP6n8HoWA==",
-			"cpu": [
-				"x64"
-			],
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"win32"
-			],
-			"peer": true,
-			"engines": {
-				"node": ">=20.0.0"
-			}
-		},
-		"node_modules/@node-llama-cpp/win-x64-vulkan": {
-			"version": "3.15.1",
-			"resolved": "https://registry.npmjs.org/@node-llama-cpp/win-x64-vulkan/-/win-x64-vulkan-3.15.1.tgz",
-			"integrity": "sha512-BPBjUEIkFTdcHSsQyblP0v/aPPypi6uqQIq27mo4A49CYjX22JDmk4ncdBLk6cru+UkvwEEe+F2RomjoMt32aQ==",
-			"cpu": [
-				"x64"
-			],
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"win32"
-			],
-			"peer": true,
-			"engines": {
-				"node": ">=20.0.0"
-			}
-		},
-		"node_modules/@octokit/app": {
-			"version": "16.1.2",
-			"resolved": "https://registry.npmjs.org/@octokit/app/-/app-16.1.2.tgz",
-			"integrity": "sha512-8j7sEpUYVj18dxvh0KWj6W/l6uAiVRBl1JBDVRqH1VHKAO/G5eRVl4yEoYACjakWers1DjUkcCHyJNQK47JqyQ==",
-			"license": "MIT",
-			"peer": true,
-			"dependencies": {
-				"@octokit/auth-app": "^8.1.2",
-				"@octokit/auth-unauthenticated": "^7.0.3",
-				"@octokit/core": "^7.0.6",
-				"@octokit/oauth-app": "^8.0.3",
-				"@octokit/plugin-paginate-rest": "^14.0.0",
-				"@octokit/types": "^16.0.0",
-				"@octokit/webhooks": "^14.0.0"
-			},
-			"engines": {
-				"node": ">= 20"
-			}
-		},
-		"node_modules/@octokit/auth-app": {
-			"version": "8.2.0",
-			"resolved": "https://registry.npmjs.org/@octokit/auth-app/-/auth-app-8.2.0.tgz",
-			"integrity": "sha512-vVjdtQQwomrZ4V46B9LaCsxsySxGoHsyw6IYBov/TqJVROrlYdyNgw5q6tQbB7KZt53v1l1W53RiqTvpzL907g==",
-			"license": "MIT",
-			"peer": true,
-			"dependencies": {
-				"@octokit/auth-oauth-app": "^9.0.3",
-				"@octokit/auth-oauth-user": "^6.0.2",
-				"@octokit/request": "^10.0.6",
-				"@octokit/request-error": "^7.0.2",
-				"@octokit/types": "^16.0.0",
-				"toad-cache": "^3.7.0",
-				"universal-github-app-jwt": "^2.2.0",
-				"universal-user-agent": "^7.0.0"
-			},
-			"engines": {
-				"node": ">= 20"
-			}
-		},
-		"node_modules/@octokit/auth-oauth-app": {
-			"version": "9.0.3",
-			"resolved": "https://registry.npmjs.org/@octokit/auth-oauth-app/-/auth-oauth-app-9.0.3.tgz",
-			"integrity": "sha512-+yoFQquaF8OxJSxTb7rnytBIC2ZLbLqA/yb71I4ZXT9+Slw4TziV9j/kyGhUFRRTF2+7WlnIWsePZCWHs+OGjg==",
-			"license": "MIT",
-			"peer": true,
-			"dependencies": {
-				"@octokit/auth-oauth-device": "^8.0.3",
-				"@octokit/auth-oauth-user": "^6.0.2",
-				"@octokit/request": "^10.0.6",
-				"@octokit/types": "^16.0.0",
-				"universal-user-agent": "^7.0.0"
-			},
-			"engines": {
-				"node": ">= 20"
-			}
-		},
-		"node_modules/@octokit/auth-oauth-device": {
-			"version": "8.0.3",
-			"resolved": "https://registry.npmjs.org/@octokit/auth-oauth-device/-/auth-oauth-device-8.0.3.tgz",
-			"integrity": "sha512-zh2W0mKKMh/VWZhSqlaCzY7qFyrgd9oTWmTmHaXnHNeQRCZr/CXy2jCgHo4e4dJVTiuxP5dLa0YM5p5QVhJHbw==",
-			"license": "MIT",
-			"peer": true,
-			"dependencies": {
-				"@octokit/oauth-methods": "^6.0.2",
-				"@octokit/request": "^10.0.6",
-				"@octokit/types": "^16.0.0",
-				"universal-user-agent": "^7.0.0"
-			},
-			"engines": {
-				"node": ">= 20"
-			}
-		},
-		"node_modules/@octokit/auth-oauth-user": {
-			"version": "6.0.2",
-			"resolved": "https://registry.npmjs.org/@octokit/auth-oauth-user/-/auth-oauth-user-6.0.2.tgz",
-			"integrity": "sha512-qLoPPc6E6GJoz3XeDG/pnDhJpTkODTGG4kY0/Py154i/I003O9NazkrwJwRuzgCalhzyIeWQ+6MDvkUmKXjg/A==",
-			"license": "MIT",
-			"peer": true,
-			"dependencies": {
-				"@octokit/auth-oauth-device": "^8.0.3",
-				"@octokit/oauth-methods": "^6.0.2",
-				"@octokit/request": "^10.0.6",
-				"@octokit/types": "^16.0.0",
-				"universal-user-agent": "^7.0.0"
-			},
-			"engines": {
-				"node": ">= 20"
-			}
-		},
-		"node_modules/@octokit/auth-token": {
-			"version": "6.0.0",
-			"resolved": "https://registry.npmjs.org/@octokit/auth-token/-/auth-token-6.0.0.tgz",
-			"integrity": "sha512-P4YJBPdPSpWTQ1NU4XYdvHvXJJDxM6YwpS0FZHRgP7YFkdVxsWcpWGy/NVqlAA7PcPCnMacXlRm1y2PFZRWL/w==",
-			"license": "MIT",
-			"peer": true,
-			"engines": {
-				"node": ">= 20"
-			}
-		},
-		"node_modules/@octokit/auth-unauthenticated": {
-			"version": "7.0.3",
-			"resolved": "https://registry.npmjs.org/@octokit/auth-unauthenticated/-/auth-unauthenticated-7.0.3.tgz",
-			"integrity": "sha512-8Jb1mtUdmBHL7lGmop9mU9ArMRUTRhg8vp0T1VtZ4yd9vEm3zcLwmjQkhNEduKawOOORie61xhtYIhTDN+ZQ3g==",
-			"license": "MIT",
-			"peer": true,
-			"dependencies": {
-				"@octokit/request-error": "^7.0.2",
-				"@octokit/types": "^16.0.0"
-			},
-			"engines": {
-				"node": ">= 20"
-			}
-		},
-		"node_modules/@octokit/core": {
-			"version": "7.0.6",
-			"resolved": "https://registry.npmjs.org/@octokit/core/-/core-7.0.6.tgz",
-			"integrity": "sha512-DhGl4xMVFGVIyMwswXeyzdL4uXD5OGILGX5N8Y+f6W7LhC1Ze2poSNrkF/fedpVDHEEZ+PHFW0vL14I+mm8K3Q==",
-			"license": "MIT",
-			"peer": true,
-			"dependencies": {
-				"@octokit/auth-token": "^6.0.0",
-				"@octokit/graphql": "^9.0.3",
-				"@octokit/request": "^10.0.6",
-				"@octokit/request-error": "^7.0.2",
-				"@octokit/types": "^16.0.0",
-				"before-after-hook": "^4.0.0",
-				"universal-user-agent": "^7.0.0"
-			},
-			"engines": {
-				"node": ">= 20"
-			}
-		},
-		"node_modules/@octokit/endpoint": {
-			"version": "11.0.3",
-			"resolved": "https://registry.npmjs.org/@octokit/endpoint/-/endpoint-11.0.3.tgz",
-			"integrity": "sha512-FWFlNxghg4HrXkD3ifYbS/IdL/mDHjh9QcsNyhQjN8dplUoZbejsdpmuqdA76nxj2xoWPs7p8uX2SNr9rYu0Ag==",
-			"license": "MIT",
-			"peer": true,
-			"dependencies": {
-				"@octokit/types": "^16.0.0",
-				"universal-user-agent": "^7.0.2"
-			},
-			"engines": {
-				"node": ">= 20"
-			}
-		},
-		"node_modules/@octokit/graphql": {
-			"version": "9.0.3",
-			"resolved": "https://registry.npmjs.org/@octokit/graphql/-/graphql-9.0.3.tgz",
-			"integrity": "sha512-grAEuupr/C1rALFnXTv6ZQhFuL1D8G5y8CN04RgrO4FIPMrtm+mcZzFG7dcBm+nq+1ppNixu+Jd78aeJOYxlGA==",
-			"license": "MIT",
-			"peer": true,
-			"dependencies": {
-				"@octokit/request": "^10.0.6",
-				"@octokit/types": "^16.0.0",
-				"universal-user-agent": "^7.0.0"
-			},
-			"engines": {
-				"node": ">= 20"
-			}
-		},
-		"node_modules/@octokit/oauth-app": {
-			"version": "8.0.3",
-			"resolved": "https://registry.npmjs.org/@octokit/oauth-app/-/oauth-app-8.0.3.tgz",
-			"integrity": "sha512-jnAjvTsPepyUaMu9e69hYBuozEPgYqP4Z3UnpmvoIzHDpf8EXDGvTY1l1jK0RsZ194oRd+k6Hm13oRU8EoDFwg==",
-			"license": "MIT",
-			"peer": true,
-			"dependencies": {
-				"@octokit/auth-oauth-app": "^9.0.2",
-				"@octokit/auth-oauth-user": "^6.0.1",
-				"@octokit/auth-unauthenticated": "^7.0.2",
-				"@octokit/core": "^7.0.5",
-				"@octokit/oauth-authorization-url": "^8.0.0",
-				"@octokit/oauth-methods": "^6.0.1",
-				"@types/aws-lambda": "^8.10.83",
-				"universal-user-agent": "^7.0.0"
-			},
-			"engines": {
-				"node": ">= 20"
-			}
-		},
-		"node_modules/@octokit/oauth-authorization-url": {
-			"version": "8.0.0",
-			"resolved": "https://registry.npmjs.org/@octokit/oauth-authorization-url/-/oauth-authorization-url-8.0.0.tgz",
-			"integrity": "sha512-7QoLPRh/ssEA/HuHBHdVdSgF8xNLz/Bc5m9fZkArJE5bb6NmVkDm3anKxXPmN1zh6b5WKZPRr3697xKT/yM3qQ==",
-			"license": "MIT",
-			"peer": true,
-			"engines": {
-				"node": ">= 20"
-			}
-		},
-		"node_modules/@octokit/oauth-methods": {
-			"version": "6.0.2",
-			"resolved": "https://registry.npmjs.org/@octokit/oauth-methods/-/oauth-methods-6.0.2.tgz",
-			"integrity": "sha512-HiNOO3MqLxlt5Da5bZbLV8Zarnphi4y9XehrbaFMkcoJ+FL7sMxH/UlUsCVxpddVu4qvNDrBdaTVE2o4ITK8ng==",
-			"license": "MIT",
-			"peer": true,
-			"dependencies": {
-				"@octokit/oauth-authorization-url": "^8.0.0",
-				"@octokit/request": "^10.0.6",
-				"@octokit/request-error": "^7.0.2",
-				"@octokit/types": "^16.0.0"
-			},
-			"engines": {
-				"node": ">= 20"
-			}
-		},
-		"node_modules/@octokit/openapi-types": {
-			"version": "27.0.0",
-			"resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-27.0.0.tgz",
-			"integrity": "sha512-whrdktVs1h6gtR+09+QsNk2+FO+49j6ga1c55YZudfEG+oKJVvJLQi3zkOm5JjiUXAagWK2tI2kTGKJ2Ys7MGA==",
-			"license": "MIT",
-			"peer": true
-		},
-		"node_modules/@octokit/openapi-webhooks-types": {
-			"version": "12.1.0",
-			"resolved": "https://registry.npmjs.org/@octokit/openapi-webhooks-types/-/openapi-webhooks-types-12.1.0.tgz",
-			"integrity": "sha512-WiuzhOsiOvb7W3Pvmhf8d2C6qaLHXrWiLBP4nJ/4kydu+wpagV5Fkz9RfQwV2afYzv3PB+3xYgp4mAdNGjDprA==",
-			"license": "MIT",
-			"peer": true
-		},
-		"node_modules/@octokit/plugin-paginate-graphql": {
-			"version": "6.0.0",
-			"resolved": "https://registry.npmjs.org/@octokit/plugin-paginate-graphql/-/plugin-paginate-graphql-6.0.0.tgz",
-			"integrity": "sha512-crfpnIoFiBtRkvPqOyLOsw12XsveYuY2ieP6uYDosoUegBJpSVxGwut9sxUgFFcll3VTOTqpUf8yGd8x1OmAkQ==",
-			"license": "MIT",
-			"peer": true,
-			"engines": {
-				"node": ">= 20"
-			},
-			"peerDependencies": {
-				"@octokit/core": ">=6"
-			}
-		},
-		"node_modules/@octokit/plugin-paginate-rest": {
-			"version": "14.0.0",
-			"resolved": "https://registry.npmjs.org/@octokit/plugin-paginate-rest/-/plugin-paginate-rest-14.0.0.tgz",
-			"integrity": "sha512-fNVRE7ufJiAA3XUrha2omTA39M6IXIc6GIZLvlbsm8QOQCYvpq/LkMNGyFlB1d8hTDzsAXa3OKtybdMAYsV/fw==",
-			"license": "MIT",
-			"peer": true,
-			"dependencies": {
-				"@octokit/types": "^16.0.0"
-			},
-			"engines": {
-				"node": ">= 20"
-			},
-			"peerDependencies": {
-				"@octokit/core": ">=6"
-			}
-		},
-		"node_modules/@octokit/plugin-rest-endpoint-methods": {
-			"version": "17.0.0",
-			"resolved": "https://registry.npmjs.org/@octokit/plugin-rest-endpoint-methods/-/plugin-rest-endpoint-methods-17.0.0.tgz",
-			"integrity": "sha512-B5yCyIlOJFPqUUeiD0cnBJwWJO8lkJs5d8+ze9QDP6SvfiXSz1BF+91+0MeI1d2yxgOhU/O+CvtiZ9jSkHhFAw==",
-			"license": "MIT",
-			"peer": true,
-			"dependencies": {
-				"@octokit/types": "^16.0.0"
-			},
-			"engines": {
-				"node": ">= 20"
-			},
-			"peerDependencies": {
-				"@octokit/core": ">=6"
-			}
-		},
-		"node_modules/@octokit/plugin-retry": {
-			"version": "8.1.0",
-			"resolved": "https://registry.npmjs.org/@octokit/plugin-retry/-/plugin-retry-8.1.0.tgz",
-			"integrity": "sha512-O1FZgXeiGb2sowEr/hYTr6YunGdSAFWnr2fyW39Ah85H8O33ELASQxcvOFF5LE6Tjekcyu2ms4qAzJVhSaJxTw==",
-			"license": "MIT",
-			"peer": true,
-			"dependencies": {
-				"@octokit/request-error": "^7.0.2",
-				"@octokit/types": "^16.0.0",
-				"bottleneck": "^2.15.3"
-			},
-			"engines": {
-				"node": ">= 20"
-			},
-			"peerDependencies": {
-				"@octokit/core": ">=7"
-			}
-		},
-		"node_modules/@octokit/plugin-throttling": {
-			"version": "11.0.3",
-			"resolved": "https://registry.npmjs.org/@octokit/plugin-throttling/-/plugin-throttling-11.0.3.tgz",
-			"integrity": "sha512-34eE0RkFCKycLl2D2kq7W+LovheM/ex3AwZCYN8udpi6bxsyjZidb2McXs69hZhLmJlDqTSP8cH+jSRpiaijBg==",
-			"license": "MIT",
-			"peer": true,
-			"dependencies": {
-				"@octokit/types": "^16.0.0",
-				"bottleneck": "^2.15.3"
-			},
-			"engines": {
-				"node": ">= 20"
-			},
-			"peerDependencies": {
-				"@octokit/core": "^7.0.0"
-			}
-		},
-		"node_modules/@octokit/request": {
-			"version": "10.0.8",
-			"resolved": "https://registry.npmjs.org/@octokit/request/-/request-10.0.8.tgz",
-			"integrity": "sha512-SJZNwY9pur9Agf7l87ywFi14W+Hd9Jg6Ifivsd33+/bGUQIjNujdFiXII2/qSlN2ybqUHfp5xpekMEjIBTjlSw==",
-			"license": "MIT",
-			"peer": true,
-			"dependencies": {
-				"@octokit/endpoint": "^11.0.3",
-				"@octokit/request-error": "^7.0.2",
-				"@octokit/types": "^16.0.0",
-				"fast-content-type-parse": "^3.0.0",
-				"json-with-bigint": "^3.5.3",
-				"universal-user-agent": "^7.0.2"
-			},
-			"engines": {
-				"node": ">= 20"
-			}
-		},
-		"node_modules/@octokit/request-error": {
-			"version": "7.1.0",
-			"resolved": "https://registry.npmjs.org/@octokit/request-error/-/request-error-7.1.0.tgz",
-			"integrity": "sha512-KMQIfq5sOPpkQYajXHwnhjCC0slzCNScLHs9JafXc4RAJI+9f+jNDlBNaIMTvazOPLgb4BnlhGJOTbnN0wIjPw==",
-			"license": "MIT",
-			"peer": true,
-			"dependencies": {
-				"@octokit/types": "^16.0.0"
-			},
-			"engines": {
-				"node": ">= 20"
-			}
-		},
-		"node_modules/@octokit/types": {
-			"version": "16.0.0",
-			"resolved": "https://registry.npmjs.org/@octokit/types/-/types-16.0.0.tgz",
-			"integrity": "sha512-sKq+9r1Mm4efXW1FCk7hFSeJo4QKreL/tTbR0rz/qx/r1Oa2VV83LTA/H/MuCOX7uCIJmQVRKBcbmWoySjAnSg==",
-			"license": "MIT",
-			"peer": true,
-			"dependencies": {
-				"@octokit/openapi-types": "^27.0.0"
-			}
-		},
-		"node_modules/@octokit/webhooks": {
-			"version": "14.2.0",
-			"resolved": "https://registry.npmjs.org/@octokit/webhooks/-/webhooks-14.2.0.tgz",
-			"integrity": "sha512-da6KbdNCV5sr1/txD896V+6W0iamFWrvVl8cHkBSPT+YlvmT3DwXa4jxZnQc+gnuTEqSWbBeoSZYTayXH9wXcw==",
-			"license": "MIT",
-			"peer": true,
-			"dependencies": {
-				"@octokit/openapi-webhooks-types": "12.1.0",
-				"@octokit/request-error": "^7.0.0",
-				"@octokit/webhooks-methods": "^6.0.0"
-			},
-			"engines": {
-				"node": ">= 20"
-			}
-		},
-		"node_modules/@octokit/webhooks-methods": {
-			"version": "6.0.0",
-			"resolved": "https://registry.npmjs.org/@octokit/webhooks-methods/-/webhooks-methods-6.0.0.tgz",
-			"integrity": "sha512-MFlzzoDJVw/GcbfzVC1RLR36QqkTLUf79vLVO3D+xn7r0QgxnFoLZgtrzxiQErAjFUOdH6fas2KeQJ1yr/qaXQ==",
-			"license": "MIT",
-			"peer": true,
-			"engines": {
-				"node": ">= 20"
-			}
-		},
-		"node_modules/@pinojs/redact": {
-			"version": "0.4.0",
-			"resolved": "https://registry.npmjs.org/@pinojs/redact/-/redact-0.4.0.tgz",
-			"integrity": "sha512-k2ENnmBugE/rzQfEcdWHcCY+/FM3VLzH9cYEsbdsoqrvzAKRhUZeRNhAZvB8OitQJ1TBed3yqWtdjzS6wJKBwg==",
-			"license": "MIT",
-			"peer": true
-		},
-		"node_modules/@pkgjs/parseargs": {
-			"version": "0.11.0",
-			"resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
-			"integrity": "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==",
-			"license": "MIT",
-			"optional": true,
-			"peer": true,
-			"engines": {
-				"node": ">=14"
 			}
 		},
 		"node_modules/@protobufjs/aspromise": {
@@ -3633,163 +2704,6 @@
 			"license": "BSD-3-Clause",
 			"peer": true
 		},
-		"node_modules/@reflink/reflink": {
-			"version": "0.1.19",
-			"resolved": "https://registry.npmjs.org/@reflink/reflink/-/reflink-0.1.19.tgz",
-			"integrity": "sha512-DmCG8GzysnCZ15bres3N5AHCmwBwYgp0As6xjhQ47rAUTUXxJiK+lLUxaGsX3hd/30qUpVElh05PbGuxRPgJwA==",
-			"license": "MIT",
-			"optional": true,
-			"peer": true,
-			"engines": {
-				"node": ">= 10"
-			},
-			"optionalDependencies": {
-				"@reflink/reflink-darwin-arm64": "0.1.19",
-				"@reflink/reflink-darwin-x64": "0.1.19",
-				"@reflink/reflink-linux-arm64-gnu": "0.1.19",
-				"@reflink/reflink-linux-arm64-musl": "0.1.19",
-				"@reflink/reflink-linux-x64-gnu": "0.1.19",
-				"@reflink/reflink-linux-x64-musl": "0.1.19",
-				"@reflink/reflink-win32-arm64-msvc": "0.1.19",
-				"@reflink/reflink-win32-x64-msvc": "0.1.19"
-			}
-		},
-		"node_modules/@reflink/reflink-darwin-arm64": {
-			"version": "0.1.19",
-			"resolved": "https://registry.npmjs.org/@reflink/reflink-darwin-arm64/-/reflink-darwin-arm64-0.1.19.tgz",
-			"integrity": "sha512-ruy44Lpepdk1FqDz38vExBY/PVUsjxZA+chd9wozjUH9JjuDT/HEaQYA6wYN9mf041l0yLVar6BCZuWABJvHSA==",
-			"cpu": [
-				"arm64"
-			],
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"darwin"
-			],
-			"peer": true,
-			"engines": {
-				"node": ">= 10"
-			}
-		},
-		"node_modules/@reflink/reflink-darwin-x64": {
-			"version": "0.1.19",
-			"resolved": "https://registry.npmjs.org/@reflink/reflink-darwin-x64/-/reflink-darwin-x64-0.1.19.tgz",
-			"integrity": "sha512-By85MSWrMZa+c26TcnAy8SDk0sTUkYlNnwknSchkhHpGXOtjNDUOxJE9oByBnGbeuIE1PiQsxDG3Ud+IVV9yuA==",
-			"cpu": [
-				"x64"
-			],
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"darwin"
-			],
-			"peer": true,
-			"engines": {
-				"node": ">= 10"
-			}
-		},
-		"node_modules/@reflink/reflink-linux-arm64-gnu": {
-			"version": "0.1.19",
-			"resolved": "https://registry.npmjs.org/@reflink/reflink-linux-arm64-gnu/-/reflink-linux-arm64-gnu-0.1.19.tgz",
-			"integrity": "sha512-7P+er8+rP9iNeN+bfmccM4hTAaLP6PQJPKWSA4iSk2bNvo6KU6RyPgYeHxXmzNKzPVRcypZQTpFgstHam6maVg==",
-			"cpu": [
-				"arm64"
-			],
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"peer": true,
-			"engines": {
-				"node": ">= 10"
-			}
-		},
-		"node_modules/@reflink/reflink-linux-arm64-musl": {
-			"version": "0.1.19",
-			"resolved": "https://registry.npmjs.org/@reflink/reflink-linux-arm64-musl/-/reflink-linux-arm64-musl-0.1.19.tgz",
-			"integrity": "sha512-37iO/Dp6m5DDaC2sf3zPtx/hl9FV3Xze4xoYidrxxS9bgP3S8ALroxRK6xBG/1TtfXKTvolvp+IjrUU6ujIGmA==",
-			"cpu": [
-				"arm64"
-			],
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"peer": true,
-			"engines": {
-				"node": ">= 10"
-			}
-		},
-		"node_modules/@reflink/reflink-linux-x64-gnu": {
-			"version": "0.1.19",
-			"resolved": "https://registry.npmjs.org/@reflink/reflink-linux-x64-gnu/-/reflink-linux-x64-gnu-0.1.19.tgz",
-			"integrity": "sha512-jbI8jvuYCaA3MVUdu8vLoLAFqC+iNMpiSuLbxlAgg7x3K5bsS8nOpTRnkLF7vISJ+rVR8W+7ThXlXlUQ93ulkw==",
-			"cpu": [
-				"x64"
-			],
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"peer": true,
-			"engines": {
-				"node": ">= 10"
-			}
-		},
-		"node_modules/@reflink/reflink-linux-x64-musl": {
-			"version": "0.1.19",
-			"resolved": "https://registry.npmjs.org/@reflink/reflink-linux-x64-musl/-/reflink-linux-x64-musl-0.1.19.tgz",
-			"integrity": "sha512-e9FBWDe+lv7QKAwtKOt6A2W/fyy/aEEfr0g6j/hWzvQcrzHCsz07BNQYlNOjTfeytrtLU7k449H1PI95jA4OjQ==",
-			"cpu": [
-				"x64"
-			],
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"peer": true,
-			"engines": {
-				"node": ">= 10"
-			}
-		},
-		"node_modules/@reflink/reflink-win32-arm64-msvc": {
-			"version": "0.1.19",
-			"resolved": "https://registry.npmjs.org/@reflink/reflink-win32-arm64-msvc/-/reflink-win32-arm64-msvc-0.1.19.tgz",
-			"integrity": "sha512-09PxnVIQcd+UOn4WAW73WU6PXL7DwGS6wPlkMhMg2zlHHG65F3vHepOw06HFCq+N42qkaNAc8AKIabWvtk6cIQ==",
-			"cpu": [
-				"arm64"
-			],
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"win32"
-			],
-			"peer": true,
-			"engines": {
-				"node": ">= 10"
-			}
-		},
-		"node_modules/@reflink/reflink-win32-x64-msvc": {
-			"version": "0.1.19",
-			"resolved": "https://registry.npmjs.org/@reflink/reflink-win32-x64-msvc/-/reflink-win32-x64-msvc-0.1.19.tgz",
-			"integrity": "sha512-E//yT4ni2SyhwP8JRjVGWr3cbnhWDiPLgnQ66qqaanjjnMiu3O/2tjCPQXlcGc/DEYofpDc9fvhv6tALQsMV9w==",
-			"cpu": [
-				"x64"
-			],
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"win32"
-			],
-			"peer": true,
-			"engines": {
-				"node": ">= 10"
-			}
-		},
 		"node_modules/@silvia-odwyer/photon-node": {
 			"version": "0.3.4",
 			"resolved": "https://registry.npmjs.org/@silvia-odwyer/photon-node/-/photon-node-0.3.4.tgz",
@@ -3798,151 +2712,24 @@
 			"peer": true
 		},
 		"node_modules/@sinclair/typebox": {
-			"version": "0.34.48",
-			"resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.34.48.tgz",
-			"integrity": "sha512-kKJTNuK3AQOrgjjotVxMrCn1sUJwM76wMszfq1kdU4uYVJjvEWuFQ6HgvLt4Xz3fSmZlTOxJ/Ie13KnIcWQXFA==",
+			"version": "0.34.49",
+			"resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.34.49.tgz",
+			"integrity": "sha512-brySQQs7Jtn0joV8Xh9ZV/hZb9Ozb0pmazDIASBkYKCjXrXU3mpcFahmK/z4YDhGkQvP9mWJbVyahdtU5wQA+A==",
 			"license": "MIT",
 			"peer": true
 		},
-		"node_modules/@slack/bolt": {
-			"version": "4.6.0",
-			"resolved": "https://registry.npmjs.org/@slack/bolt/-/bolt-4.6.0.tgz",
-			"integrity": "sha512-xPgfUs2+OXSugz54Ky07pA890+Qydk22SYToi8uGpXeHSt1JWwFJkRyd/9Vlg5I1AdfdpGXExDpwnbuN9Q/2dQ==",
-			"license": "MIT",
-			"peer": true,
-			"dependencies": {
-				"@slack/logger": "^4.0.0",
-				"@slack/oauth": "^3.0.4",
-				"@slack/socket-mode": "^2.0.5",
-				"@slack/types": "^2.18.0",
-				"@slack/web-api": "^7.12.0",
-				"axios": "^1.12.0",
-				"express": "^5.0.0",
-				"path-to-regexp": "^8.1.0",
-				"raw-body": "^3",
-				"tsscmp": "^1.0.6"
-			},
-			"engines": {
-				"node": ">=18",
-				"npm": ">=8.6.0"
-			},
-			"peerDependencies": {
-				"@types/express": "^5.0.0"
-			}
-		},
-		"node_modules/@slack/logger": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/@slack/logger/-/logger-4.0.0.tgz",
-			"integrity": "sha512-Wz7QYfPAlG/DR+DfABddUZeNgoeY7d1J39OCR2jR+v7VBsB8ezulDK5szTnDDPDwLH5IWhLvXIHlCFZV7MSKgA==",
-			"license": "MIT",
-			"peer": true,
-			"dependencies": {
-				"@types/node": ">=18.0.0"
-			},
-			"engines": {
-				"node": ">= 18",
-				"npm": ">= 8.6.0"
-			}
-		},
-		"node_modules/@slack/oauth": {
-			"version": "3.0.4",
-			"resolved": "https://registry.npmjs.org/@slack/oauth/-/oauth-3.0.4.tgz",
-			"integrity": "sha512-+8H0g7mbrHndEUbYCP7uYyBCbwqmm3E6Mo3nfsDvZZW74zKk1ochfH/fWSvGInYNCVvaBUbg3RZBbTp0j8yJCg==",
-			"license": "MIT",
-			"peer": true,
-			"dependencies": {
-				"@slack/logger": "^4",
-				"@slack/web-api": "^7.10.0",
-				"@types/jsonwebtoken": "^9",
-				"@types/node": ">=18",
-				"jsonwebtoken": "^9"
-			},
-			"engines": {
-				"node": ">=18",
-				"npm": ">=8.6.0"
-			}
-		},
-		"node_modules/@slack/socket-mode": {
-			"version": "2.0.5",
-			"resolved": "https://registry.npmjs.org/@slack/socket-mode/-/socket-mode-2.0.5.tgz",
-			"integrity": "sha512-VaapvmrAifeFLAFaDPfGhEwwunTKsI6bQhYzxRXw7BSujZUae5sANO76WqlVsLXuhVtCVrBWPiS2snAQR2RHJQ==",
-			"license": "MIT",
-			"peer": true,
-			"dependencies": {
-				"@slack/logger": "^4",
-				"@slack/web-api": "^7.10.0",
-				"@types/node": ">=18",
-				"@types/ws": "^8",
-				"eventemitter3": "^5",
-				"ws": "^8"
-			},
-			"engines": {
-				"node": ">= 18",
-				"npm": ">= 8.6.0"
-			}
-		},
-		"node_modules/@slack/types": {
-			"version": "2.20.0",
-			"resolved": "https://registry.npmjs.org/@slack/types/-/types-2.20.0.tgz",
-			"integrity": "sha512-PVF6P6nxzDMrzPC8fSCsnwaI+kF8YfEpxf3MqXmdyjyWTYsZQURpkK7WWUWvP5QpH55pB7zyYL9Qem/xSgc5VA==",
-			"license": "MIT",
-			"peer": true,
-			"engines": {
-				"node": ">= 12.13.0",
-				"npm": ">= 6.12.0"
-			}
-		},
-		"node_modules/@slack/web-api": {
-			"version": "7.14.1",
-			"resolved": "https://registry.npmjs.org/@slack/web-api/-/web-api-7.14.1.tgz",
-			"integrity": "sha512-RoygyteJeFswxDPJjUMESn9dldWVMD2xUcHHd9DenVavSfVC6FeVnSdDerOO7m8LLvw4Q132nQM4hX8JiF7dng==",
-			"license": "MIT",
-			"peer": true,
-			"dependencies": {
-				"@slack/logger": "^4.0.0",
-				"@slack/types": "^2.20.0",
-				"@types/node": ">=18.0.0",
-				"@types/retry": "0.12.0",
-				"axios": "^1.13.5",
-				"eventemitter3": "^5.0.1",
-				"form-data": "^4.0.4",
-				"is-electron": "2.2.2",
-				"is-stream": "^2",
-				"p-queue": "^6",
-				"p-retry": "^4",
-				"retry": "^0.13.1"
-			},
-			"engines": {
-				"node": ">= 18",
-				"npm": ">= 8.6.0"
-			}
-		},
-		"node_modules/@smithy/abort-controller": {
-			"version": "4.2.8",
-			"resolved": "https://registry.npmjs.org/@smithy/abort-controller/-/abort-controller-4.2.8.tgz",
-			"integrity": "sha512-peuVfkYHAmS5ybKxWcfraK7WBBP0J+rkfUcbHJJKQ4ir3UAUNQI+Y4Vt/PqSzGqgloJ5O1dk7+WzNL8wcCSXbw==",
-			"license": "Apache-2.0",
-			"peer": true,
-			"dependencies": {
-				"@smithy/types": "^4.12.0",
-				"tslib": "^2.6.2"
-			},
-			"engines": {
-				"node": ">=18.0.0"
-			}
-		},
 		"node_modules/@smithy/config-resolver": {
-			"version": "4.4.6",
-			"resolved": "https://registry.npmjs.org/@smithy/config-resolver/-/config-resolver-4.4.6.tgz",
-			"integrity": "sha512-qJpzYC64kaj3S0fueiu3kXm8xPrR3PcXDPEgnaNMRn0EjNSZFoFjvbUp0YUDsRhN1CB90EnHJtbxWKevnH99UQ==",
+			"version": "4.4.14",
+			"resolved": "https://registry.npmjs.org/@smithy/config-resolver/-/config-resolver-4.4.14.tgz",
+			"integrity": "sha512-N55f8mPEccpzKetUagdvmAy8oohf0J5cuj9jLI1TaSceRlq0pJsIZepY3kmAXAhyxqXPV6hDerDQhqQPKWgAoQ==",
 			"license": "Apache-2.0",
 			"peer": true,
 			"dependencies": {
-				"@smithy/node-config-provider": "^4.3.8",
-				"@smithy/types": "^4.12.0",
-				"@smithy/util-config-provider": "^4.2.0",
-				"@smithy/util-endpoints": "^3.2.8",
-				"@smithy/util-middleware": "^4.2.8",
+				"@smithy/node-config-provider": "^4.3.13",
+				"@smithy/types": "^4.14.0",
+				"@smithy/util-config-provider": "^4.2.2",
+				"@smithy/util-endpoints": "^3.3.4",
+				"@smithy/util-middleware": "^4.2.13",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -3950,21 +2737,21 @@
 			}
 		},
 		"node_modules/@smithy/core": {
-			"version": "3.23.3",
-			"resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.23.3.tgz",
-			"integrity": "sha512-5IETfbqrTuGs0fC22ZnTW6df+PHlrWpSbAbySzTozsUROWPiOXDIWt1Y4dCDzhJUQ6H3ig/dFOZaEeLsTjNGRQ==",
+			"version": "3.23.14",
+			"resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.23.14.tgz",
+			"integrity": "sha512-vJ0IhpZxZAkFYOegMKSrxw7ujhhT2pass/1UEcZ4kfl5srTAqtPU5I7MdYQoreVas3204ykCiNhY1o7Xlz6Yyg==",
 			"license": "Apache-2.0",
 			"peer": true,
 			"dependencies": {
-				"@smithy/middleware-serde": "^4.2.9",
-				"@smithy/protocol-http": "^5.3.8",
-				"@smithy/types": "^4.12.0",
-				"@smithy/util-base64": "^4.3.0",
-				"@smithy/util-body-length-browser": "^4.2.0",
-				"@smithy/util-middleware": "^4.2.8",
-				"@smithy/util-stream": "^4.5.13",
-				"@smithy/util-utf8": "^4.2.0",
-				"@smithy/uuid": "^1.1.0",
+				"@smithy/protocol-http": "^5.3.13",
+				"@smithy/types": "^4.14.0",
+				"@smithy/url-parser": "^4.2.13",
+				"@smithy/util-base64": "^4.3.2",
+				"@smithy/util-body-length-browser": "^4.2.2",
+				"@smithy/util-middleware": "^4.2.13",
+				"@smithy/util-stream": "^4.5.22",
+				"@smithy/util-utf8": "^4.2.2",
+				"@smithy/uuid": "^1.1.2",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -3972,16 +2759,16 @@
 			}
 		},
 		"node_modules/@smithy/credential-provider-imds": {
-			"version": "4.2.8",
-			"resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-4.2.8.tgz",
-			"integrity": "sha512-FNT0xHS1c/CPN8upqbMFP83+ul5YgdisfCfkZ86Jh2NSmnqw/AJ6x5pEogVCTVvSm7j9MopRU89bmDelxuDMYw==",
+			"version": "4.2.13",
+			"resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-4.2.13.tgz",
+			"integrity": "sha512-wboCPijzf6RJKLOvnjDAiBxGSmSnGXj35o5ZAWKDaHa/cvQ5U3ZJ13D4tMCE8JG4dxVAZFy/P0x/V9CwwdfULQ==",
 			"license": "Apache-2.0",
 			"peer": true,
 			"dependencies": {
-				"@smithy/node-config-provider": "^4.3.8",
-				"@smithy/property-provider": "^4.2.8",
-				"@smithy/types": "^4.12.0",
-				"@smithy/url-parser": "^4.2.8",
+				"@smithy/node-config-provider": "^4.3.13",
+				"@smithy/property-provider": "^4.2.13",
+				"@smithy/types": "^4.14.0",
+				"@smithy/url-parser": "^4.2.13",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -3989,15 +2776,15 @@
 			}
 		},
 		"node_modules/@smithy/eventstream-codec": {
-			"version": "4.2.8",
-			"resolved": "https://registry.npmjs.org/@smithy/eventstream-codec/-/eventstream-codec-4.2.8.tgz",
-			"integrity": "sha512-jS/O5Q14UsufqoGhov7dHLOPCzkYJl9QDzusI2Psh4wyYx/izhzvX9P4D69aTxcdfVhEPhjK+wYyn/PzLjKbbw==",
+			"version": "4.2.13",
+			"resolved": "https://registry.npmjs.org/@smithy/eventstream-codec/-/eventstream-codec-4.2.13.tgz",
+			"integrity": "sha512-vYahwBAtRaAcFbOmE9aLr12z7RiHYDSLcnogSdxfm7kKfsNa3wH+NU5r7vTeB5rKvLsWyPjVX8iH94brP7umiQ==",
 			"license": "Apache-2.0",
 			"peer": true,
 			"dependencies": {
 				"@aws-crypto/crc32": "5.2.0",
-				"@smithy/types": "^4.12.0",
-				"@smithy/util-hex-encoding": "^4.2.0",
+				"@smithy/types": "^4.14.0",
+				"@smithy/util-hex-encoding": "^4.2.2",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -4005,14 +2792,14 @@
 			}
 		},
 		"node_modules/@smithy/eventstream-serde-browser": {
-			"version": "4.2.8",
-			"resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-browser/-/eventstream-serde-browser-4.2.8.tgz",
-			"integrity": "sha512-MTfQT/CRQz5g24ayXdjg53V0mhucZth4PESoA5IhvaWVDTOQLfo8qI9vzqHcPsdd2v6sqfTYqF5L/l+pea5Uyw==",
+			"version": "4.2.13",
+			"resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-browser/-/eventstream-serde-browser-4.2.13.tgz",
+			"integrity": "sha512-wwybfcOX0tLqCcBP378TIU9IqrDuZq/tDV48LlZNydMpCnqnYr+hWBAYbRE+rFFf/p7IkDJySM3bgiMKP2ihPg==",
 			"license": "Apache-2.0",
 			"peer": true,
 			"dependencies": {
-				"@smithy/eventstream-serde-universal": "^4.2.8",
-				"@smithy/types": "^4.12.0",
+				"@smithy/eventstream-serde-universal": "^4.2.13",
+				"@smithy/types": "^4.14.0",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -4020,13 +2807,13 @@
 			}
 		},
 		"node_modules/@smithy/eventstream-serde-config-resolver": {
-			"version": "4.3.8",
-			"resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-config-resolver/-/eventstream-serde-config-resolver-4.3.8.tgz",
-			"integrity": "sha512-ah12+luBiDGzBruhu3efNy1IlbwSEdNiw8fOZksoKoWW1ZHvO/04MQsdnws/9Aj+5b0YXSSN2JXKy/ClIsW8MQ==",
+			"version": "4.3.13",
+			"resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-config-resolver/-/eventstream-serde-config-resolver-4.3.13.tgz",
+			"integrity": "sha512-ied1lO559PtAsMJzg2TKRlctLnEi1PfkNeMMpdwXDImk1zV9uvS/Oxoy/vcy9uv1GKZAjDAB5xT6ziE9fzm5wA==",
 			"license": "Apache-2.0",
 			"peer": true,
 			"dependencies": {
-				"@smithy/types": "^4.12.0",
+				"@smithy/types": "^4.14.0",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -4034,14 +2821,14 @@
 			}
 		},
 		"node_modules/@smithy/eventstream-serde-node": {
-			"version": "4.2.8",
-			"resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-node/-/eventstream-serde-node-4.2.8.tgz",
-			"integrity": "sha512-cYpCpp29z6EJHa5T9WL0KAlq3SOKUQkcgSoeRfRVwjGgSFl7Uh32eYGt7IDYCX20skiEdRffyDpvF2efEZPC0A==",
+			"version": "4.2.13",
+			"resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-node/-/eventstream-serde-node-4.2.13.tgz",
+			"integrity": "sha512-hFyK+ORJrxAN3RYoaD6+gsGDQjeix8HOEkosoajvXYZ4VeqonM3G4jd9IIRm/sWGXUKmudkY9KdYjzosUqdM8A==",
 			"license": "Apache-2.0",
 			"peer": true,
 			"dependencies": {
-				"@smithy/eventstream-serde-universal": "^4.2.8",
-				"@smithy/types": "^4.12.0",
+				"@smithy/eventstream-serde-universal": "^4.2.13",
+				"@smithy/types": "^4.14.0",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -4049,14 +2836,14 @@
 			}
 		},
 		"node_modules/@smithy/eventstream-serde-universal": {
-			"version": "4.2.8",
-			"resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-universal/-/eventstream-serde-universal-4.2.8.tgz",
-			"integrity": "sha512-iJ6YNJd0bntJYnX6s52NC4WFYcZeKrPUr1Kmmr5AwZcwCSzVpS7oavAmxMR7pMq7V+D1G4s9F5NJK0xwOsKAlQ==",
+			"version": "4.2.13",
+			"resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-universal/-/eventstream-serde-universal-4.2.13.tgz",
+			"integrity": "sha512-kRrq4EKLGeOxhC2CBEhRNcu1KSzNJzYY7RK3S7CxMPgB5dRrv55WqQOtRwQxQLC04xqORFLUgnDlc6xrNUULaA==",
 			"license": "Apache-2.0",
 			"peer": true,
 			"dependencies": {
-				"@smithy/eventstream-codec": "^4.2.8",
-				"@smithy/types": "^4.12.0",
+				"@smithy/eventstream-codec": "^4.2.13",
+				"@smithy/types": "^4.14.0",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -4064,16 +2851,16 @@
 			}
 		},
 		"node_modules/@smithy/fetch-http-handler": {
-			"version": "5.3.9",
-			"resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-5.3.9.tgz",
-			"integrity": "sha512-I4UhmcTYXBrct03rwzQX1Y/iqQlzVQaPxWjCjula++5EmWq9YGBrx6bbGqluGc1f0XEfhSkiY4jhLgbsJUMKRA==",
+			"version": "5.3.16",
+			"resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-5.3.16.tgz",
+			"integrity": "sha512-nYDRUIvNd4mFmuXraRWt6w5UsZTNqtj4hXJA/iiOD4tuseIdLP9Lq38teH/SZTcIFCa2f+27o7hYpIsWktJKEQ==",
 			"license": "Apache-2.0",
 			"peer": true,
 			"dependencies": {
-				"@smithy/protocol-http": "^5.3.8",
-				"@smithy/querystring-builder": "^4.2.8",
-				"@smithy/types": "^4.12.0",
-				"@smithy/util-base64": "^4.3.0",
+				"@smithy/protocol-http": "^5.3.13",
+				"@smithy/querystring-builder": "^4.2.13",
+				"@smithy/types": "^4.14.0",
+				"@smithy/util-base64": "^4.3.2",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -4081,15 +2868,15 @@
 			}
 		},
 		"node_modules/@smithy/hash-node": {
-			"version": "4.2.8",
-			"resolved": "https://registry.npmjs.org/@smithy/hash-node/-/hash-node-4.2.8.tgz",
-			"integrity": "sha512-7ZIlPbmaDGxVoxErDZnuFG18WekhbA/g2/i97wGj+wUBeS6pcUeAym8u4BXh/75RXWhgIJhyC11hBzig6MljwA==",
+			"version": "4.2.13",
+			"resolved": "https://registry.npmjs.org/@smithy/hash-node/-/hash-node-4.2.13.tgz",
+			"integrity": "sha512-4/oy9h0jjmY80a2gOIo75iLl8TOPhmtx4E2Hz+PfMjvx/vLtGY4TMU/35WRyH2JHPfT5CVB38u4JRow7gnmzJA==",
 			"license": "Apache-2.0",
 			"peer": true,
 			"dependencies": {
-				"@smithy/types": "^4.12.0",
-				"@smithy/util-buffer-from": "^4.2.0",
-				"@smithy/util-utf8": "^4.2.0",
+				"@smithy/types": "^4.14.0",
+				"@smithy/util-buffer-from": "^4.2.2",
+				"@smithy/util-utf8": "^4.2.2",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -4097,13 +2884,13 @@
 			}
 		},
 		"node_modules/@smithy/invalid-dependency": {
-			"version": "4.2.8",
-			"resolved": "https://registry.npmjs.org/@smithy/invalid-dependency/-/invalid-dependency-4.2.8.tgz",
-			"integrity": "sha512-N9iozRybwAQ2dn9Fot9kI6/w9vos2oTXLhtK7ovGqwZjlOcxu6XhPlpLpC+INsxktqHinn5gS2DXDjDF2kG5sQ==",
+			"version": "4.2.13",
+			"resolved": "https://registry.npmjs.org/@smithy/invalid-dependency/-/invalid-dependency-4.2.13.tgz",
+			"integrity": "sha512-jvC0RB/8BLj2SMIkY0Npl425IdnxZJxInpZJbu563zIRnVjpDMXevU3VMCRSabaLB0kf/eFIOusdGstrLJ8IDg==",
 			"license": "Apache-2.0",
 			"peer": true,
 			"dependencies": {
-				"@smithy/types": "^4.12.0",
+				"@smithy/types": "^4.14.0",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -4111,9 +2898,9 @@
 			}
 		},
 		"node_modules/@smithy/is-array-buffer": {
-			"version": "4.2.0",
-			"resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-4.2.0.tgz",
-			"integrity": "sha512-DZZZBvC7sjcYh4MazJSGiWMI2L7E0oCiRHREDzIxi/M2LY79/21iXt6aPLHge82wi5LsuRF5A06Ds3+0mlh6CQ==",
+			"version": "4.2.2",
+			"resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-4.2.2.tgz",
+			"integrity": "sha512-n6rQ4N8Jj4YTQO3YFrlgZuwKodf4zUFs7EJIWH86pSCWBaAtAGBFfCM7Wx6D2bBJ2xqFNxGBSrUWswT3M0VJow==",
 			"license": "Apache-2.0",
 			"peer": true,
 			"dependencies": {
@@ -4124,14 +2911,14 @@
 			}
 		},
 		"node_modules/@smithy/middleware-content-length": {
-			"version": "4.2.8",
-			"resolved": "https://registry.npmjs.org/@smithy/middleware-content-length/-/middleware-content-length-4.2.8.tgz",
-			"integrity": "sha512-RO0jeoaYAB1qBRhfVyq0pMgBoUK34YEJxVxyjOWYZiOKOq2yMZ4MnVXMZCUDenpozHue207+9P5ilTV1zeda0A==",
+			"version": "4.2.13",
+			"resolved": "https://registry.npmjs.org/@smithy/middleware-content-length/-/middleware-content-length-4.2.13.tgz",
+			"integrity": "sha512-IPMLm/LE4AZwu6qiE8Rr8vJsWhs9AtOdySRXrOM7xnvclp77Tyh7hMs/FRrMf26kgIe67vFJXXOSmVxS7oKeig==",
 			"license": "Apache-2.0",
 			"peer": true,
 			"dependencies": {
-				"@smithy/protocol-http": "^5.3.8",
-				"@smithy/types": "^4.12.0",
+				"@smithy/protocol-http": "^5.3.13",
+				"@smithy/types": "^4.14.0",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -4139,19 +2926,19 @@
 			}
 		},
 		"node_modules/@smithy/middleware-endpoint": {
-			"version": "4.4.17",
-			"resolved": "https://registry.npmjs.org/@smithy/middleware-endpoint/-/middleware-endpoint-4.4.17.tgz",
-			"integrity": "sha512-QP8wuZ7iSNEQ4/HyihTHlDUlQ3eBrCo+HoMm8l2gPcNrR4TA1RCC10jR7IyCnn3ASTrUwEnRaQ062vFC2/eYJw==",
+			"version": "4.4.29",
+			"resolved": "https://registry.npmjs.org/@smithy/middleware-endpoint/-/middleware-endpoint-4.4.29.tgz",
+			"integrity": "sha512-R9Q/58U+qBiSARGWbAbFLczECg/RmysRksX6Q8BaQEpt75I7LI6WGDZnjuC9GXSGKljEbA7N118LhGaMbfrTXw==",
 			"license": "Apache-2.0",
 			"peer": true,
 			"dependencies": {
-				"@smithy/core": "^3.23.3",
-				"@smithy/middleware-serde": "^4.2.9",
-				"@smithy/node-config-provider": "^4.3.8",
-				"@smithy/shared-ini-file-loader": "^4.4.3",
-				"@smithy/types": "^4.12.0",
-				"@smithy/url-parser": "^4.2.8",
-				"@smithy/util-middleware": "^4.2.8",
+				"@smithy/core": "^3.23.14",
+				"@smithy/middleware-serde": "^4.2.17",
+				"@smithy/node-config-provider": "^4.3.13",
+				"@smithy/shared-ini-file-loader": "^4.4.8",
+				"@smithy/types": "^4.14.0",
+				"@smithy/url-parser": "^4.2.13",
+				"@smithy/util-middleware": "^4.2.13",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -4159,20 +2946,21 @@
 			}
 		},
 		"node_modules/@smithy/middleware-retry": {
-			"version": "4.4.34",
-			"resolved": "https://registry.npmjs.org/@smithy/middleware-retry/-/middleware-retry-4.4.34.tgz",
-			"integrity": "sha512-ROmCX/ev7ryOzgsQ6dnJ46gbVSrvR2HX7ioxkfXlrgfKEMMOUCWgl/OMOi7PZn95CXTxMMNJTbP3nkvWGFTz+w==",
+			"version": "4.5.0",
+			"resolved": "https://registry.npmjs.org/@smithy/middleware-retry/-/middleware-retry-4.5.0.tgz",
+			"integrity": "sha512-/NzISn4grj/BRFVua/xnQwF+7fakYZgimpw2dfmlPgcqecBMKxpB9g5mLYRrmBD5OrPoODokw4Vi1hrSR4zRyw==",
 			"license": "Apache-2.0",
 			"peer": true,
 			"dependencies": {
-				"@smithy/node-config-provider": "^4.3.8",
-				"@smithy/protocol-http": "^5.3.8",
-				"@smithy/service-error-classification": "^4.2.8",
-				"@smithy/smithy-client": "^4.11.6",
-				"@smithy/types": "^4.12.0",
-				"@smithy/util-middleware": "^4.2.8",
-				"@smithy/util-retry": "^4.2.8",
-				"@smithy/uuid": "^1.1.0",
+				"@smithy/core": "^3.23.14",
+				"@smithy/node-config-provider": "^4.3.13",
+				"@smithy/protocol-http": "^5.3.13",
+				"@smithy/service-error-classification": "^4.2.13",
+				"@smithy/smithy-client": "^4.12.9",
+				"@smithy/types": "^4.14.0",
+				"@smithy/util-middleware": "^4.2.13",
+				"@smithy/util-retry": "^4.3.0",
+				"@smithy/uuid": "^1.1.2",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -4180,14 +2968,15 @@
 			}
 		},
 		"node_modules/@smithy/middleware-serde": {
-			"version": "4.2.9",
-			"resolved": "https://registry.npmjs.org/@smithy/middleware-serde/-/middleware-serde-4.2.9.tgz",
-			"integrity": "sha512-eMNiej0u/snzDvlqRGSN3Vl0ESn3838+nKyVfF2FKNXFbi4SERYT6PR392D39iczngbqqGG0Jl1DlCnp7tBbXQ==",
+			"version": "4.2.17",
+			"resolved": "https://registry.npmjs.org/@smithy/middleware-serde/-/middleware-serde-4.2.17.tgz",
+			"integrity": "sha512-0T2mcaM6v9W1xku86Dk0bEW7aEseG6KenFkPK98XNw0ZhOqOiD1MrMsdnQw9QsL3/Oa85T53iSMlm0SZdSuIEQ==",
 			"license": "Apache-2.0",
 			"peer": true,
 			"dependencies": {
-				"@smithy/protocol-http": "^5.3.8",
-				"@smithy/types": "^4.12.0",
+				"@smithy/core": "^3.23.14",
+				"@smithy/protocol-http": "^5.3.13",
+				"@smithy/types": "^4.14.0",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -4195,13 +2984,13 @@
 			}
 		},
 		"node_modules/@smithy/middleware-stack": {
-			"version": "4.2.8",
-			"resolved": "https://registry.npmjs.org/@smithy/middleware-stack/-/middleware-stack-4.2.8.tgz",
-			"integrity": "sha512-w6LCfOviTYQjBctOKSwy6A8FIkQy7ICvglrZFl6Bw4FmcQ1Z420fUtIhxaUZZshRe0VCq4kvDiPiXrPZAe8oRA==",
+			"version": "4.2.13",
+			"resolved": "https://registry.npmjs.org/@smithy/middleware-stack/-/middleware-stack-4.2.13.tgz",
+			"integrity": "sha512-g72jN/sGDLyTanrCLH9fhg3oysO3f7tQa6eWWsMyn2BiYNCgjF24n4/I9wff/5XidFvjj9ilipAoQrurTUrLvw==",
 			"license": "Apache-2.0",
 			"peer": true,
 			"dependencies": {
-				"@smithy/types": "^4.12.0",
+				"@smithy/types": "^4.14.0",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -4209,15 +2998,15 @@
 			}
 		},
 		"node_modules/@smithy/node-config-provider": {
-			"version": "4.3.8",
-			"resolved": "https://registry.npmjs.org/@smithy/node-config-provider/-/node-config-provider-4.3.8.tgz",
-			"integrity": "sha512-aFP1ai4lrbVlWjfpAfRSL8KFcnJQYfTl5QxLJXY32vghJrDuFyPZ6LtUL+JEGYiFRG1PfPLHLoxj107ulncLIg==",
+			"version": "4.3.13",
+			"resolved": "https://registry.npmjs.org/@smithy/node-config-provider/-/node-config-provider-4.3.13.tgz",
+			"integrity": "sha512-iGxQ04DsKXLckbgnX4ipElrOTk+IHgTyu0q0WssZfYhDm9CQWHmu6cOeI5wmWRxpXbBDhIIfXMWz5tPEtcVqbw==",
 			"license": "Apache-2.0",
 			"peer": true,
 			"dependencies": {
-				"@smithy/property-provider": "^4.2.8",
-				"@smithy/shared-ini-file-loader": "^4.4.3",
-				"@smithy/types": "^4.12.0",
+				"@smithy/property-provider": "^4.2.13",
+				"@smithy/shared-ini-file-loader": "^4.4.8",
+				"@smithy/types": "^4.14.0",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -4225,16 +3014,15 @@
 			}
 		},
 		"node_modules/@smithy/node-http-handler": {
-			"version": "4.4.10",
-			"resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.4.10.tgz",
-			"integrity": "sha512-u4YeUwOWRZaHbWaebvrs3UhwQwj+2VNmcVCwXcYTvPIuVyM7Ex1ftAj+fdbG/P4AkBwLq/+SKn+ydOI4ZJE9PA==",
+			"version": "4.5.2",
+			"resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.5.2.tgz",
+			"integrity": "sha512-/oD7u8M0oj2ZTFw7GkuuHWpIxtWdLlnyNkbrWcyVYhd5RJNDuczdkb0wfnQICyNFrVPlr8YHOhamjNy3zidhmA==",
 			"license": "Apache-2.0",
 			"peer": true,
 			"dependencies": {
-				"@smithy/abort-controller": "^4.2.8",
-				"@smithy/protocol-http": "^5.3.8",
-				"@smithy/querystring-builder": "^4.2.8",
-				"@smithy/types": "^4.12.0",
+				"@smithy/protocol-http": "^5.3.13",
+				"@smithy/querystring-builder": "^4.2.13",
+				"@smithy/types": "^4.14.0",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -4242,13 +3030,13 @@
 			}
 		},
 		"node_modules/@smithy/property-provider": {
-			"version": "4.2.8",
-			"resolved": "https://registry.npmjs.org/@smithy/property-provider/-/property-provider-4.2.8.tgz",
-			"integrity": "sha512-EtCTbyIveCKeOXDSWSdze3k612yCPq1YbXsbqX3UHhkOSW8zKsM9NOJG5gTIya0vbY2DIaieG8pKo1rITHYL0w==",
+			"version": "4.2.13",
+			"resolved": "https://registry.npmjs.org/@smithy/property-provider/-/property-provider-4.2.13.tgz",
+			"integrity": "sha512-bGzUCthxRmezuxkbu9wD33wWg9KX3hJpCXpQ93vVkPrHn9ZW6KNNdY5xAUWNuRCwQ+VyboFuWirG1lZhhkcyRQ==",
 			"license": "Apache-2.0",
 			"peer": true,
 			"dependencies": {
-				"@smithy/types": "^4.12.0",
+				"@smithy/types": "^4.14.0",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -4256,13 +3044,13 @@
 			}
 		},
 		"node_modules/@smithy/protocol-http": {
-			"version": "5.3.8",
-			"resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-5.3.8.tgz",
-			"integrity": "sha512-QNINVDhxpZ5QnP3aviNHQFlRogQZDfYlCkQT+7tJnErPQbDhysondEjhikuANxgMsZrkGeiAxXy4jguEGsDrWQ==",
+			"version": "5.3.13",
+			"resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-5.3.13.tgz",
+			"integrity": "sha512-+HsmuJUF4u8POo6s8/a2Yb/AQ5t/YgLovCuHF9oxbocqv+SZ6gd8lC2duBFiCA/vFHoHQhoq7QjqJqZC6xOxxg==",
 			"license": "Apache-2.0",
 			"peer": true,
 			"dependencies": {
-				"@smithy/types": "^4.12.0",
+				"@smithy/types": "^4.14.0",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -4270,14 +3058,14 @@
 			}
 		},
 		"node_modules/@smithy/querystring-builder": {
-			"version": "4.2.8",
-			"resolved": "https://registry.npmjs.org/@smithy/querystring-builder/-/querystring-builder-4.2.8.tgz",
-			"integrity": "sha512-Xr83r31+DrE8CP3MqPgMJl+pQlLLmOfiEUnoyAlGzzJIrEsbKsPy1hqH0qySaQm4oWrCBlUqRt+idEgunKB+iw==",
+			"version": "4.2.13",
+			"resolved": "https://registry.npmjs.org/@smithy/querystring-builder/-/querystring-builder-4.2.13.tgz",
+			"integrity": "sha512-tG4aOYFCZdPMjbgfhnIQ322H//ojujldp1SrHPHpBSb3NqgUp3dwiUGRJzie87hS1DYwWGqDuPaowoDF+rYCbQ==",
 			"license": "Apache-2.0",
 			"peer": true,
 			"dependencies": {
-				"@smithy/types": "^4.12.0",
-				"@smithy/util-uri-escape": "^4.2.0",
+				"@smithy/types": "^4.14.0",
+				"@smithy/util-uri-escape": "^4.2.2",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -4285,13 +3073,13 @@
 			}
 		},
 		"node_modules/@smithy/querystring-parser": {
-			"version": "4.2.8",
-			"resolved": "https://registry.npmjs.org/@smithy/querystring-parser/-/querystring-parser-4.2.8.tgz",
-			"integrity": "sha512-vUurovluVy50CUlazOiXkPq40KGvGWSdmusa3130MwrR1UNnNgKAlj58wlOe61XSHRpUfIIh6cE0zZ8mzKaDPA==",
+			"version": "4.2.13",
+			"resolved": "https://registry.npmjs.org/@smithy/querystring-parser/-/querystring-parser-4.2.13.tgz",
+			"integrity": "sha512-hqW3Q4P+CDzUyQ87GrboGMeD7XYNMOF+CuTwu936UQRB/zeYn3jys8C3w+wMkDfY7CyyyVwZQ5cNFoG0x1pYmA==",
 			"license": "Apache-2.0",
 			"peer": true,
 			"dependencies": {
-				"@smithy/types": "^4.12.0",
+				"@smithy/types": "^4.14.0",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -4299,26 +3087,26 @@
 			}
 		},
 		"node_modules/@smithy/service-error-classification": {
-			"version": "4.2.8",
-			"resolved": "https://registry.npmjs.org/@smithy/service-error-classification/-/service-error-classification-4.2.8.tgz",
-			"integrity": "sha512-mZ5xddodpJhEt3RkCjbmUQuXUOaPNTkbMGR0bcS8FE0bJDLMZlhmpgrvPNCYglVw5rsYTpSnv19womw9WWXKQQ==",
+			"version": "4.2.13",
+			"resolved": "https://registry.npmjs.org/@smithy/service-error-classification/-/service-error-classification-4.2.13.tgz",
+			"integrity": "sha512-a0s8XZMfOC/qpqq7RCPvJlk93rWFrElH6O++8WJKz0FqnA4Y7fkNi/0mnGgSH1C4x6MFsuBA8VKu4zxFrMe5Vw==",
 			"license": "Apache-2.0",
 			"peer": true,
 			"dependencies": {
-				"@smithy/types": "^4.12.0"
+				"@smithy/types": "^4.14.0"
 			},
 			"engines": {
 				"node": ">=18.0.0"
 			}
 		},
 		"node_modules/@smithy/shared-ini-file-loader": {
-			"version": "4.4.3",
-			"resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-4.4.3.tgz",
-			"integrity": "sha512-DfQjxXQnzC5UbCUPeC3Ie8u+rIWZTvuDPAGU/BxzrOGhRvgUanaP68kDZA+jaT3ZI+djOf+4dERGlm9mWfFDrg==",
+			"version": "4.4.8",
+			"resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-4.4.8.tgz",
+			"integrity": "sha512-VZCZx2bZasxdqxVgEAhREvDSlkatTPnkdWy1+Kiy8w7kYPBosW0V5IeDwzDUMvWBt56zpK658rx1cOBFOYaPaw==",
 			"license": "Apache-2.0",
 			"peer": true,
 			"dependencies": {
-				"@smithy/types": "^4.12.0",
+				"@smithy/types": "^4.14.0",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -4326,19 +3114,19 @@
 			}
 		},
 		"node_modules/@smithy/signature-v4": {
-			"version": "5.3.8",
-			"resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-5.3.8.tgz",
-			"integrity": "sha512-6A4vdGj7qKNRF16UIcO8HhHjKW27thsxYci+5r/uVRkdcBEkOEiY8OMPuydLX4QHSrJqGHPJzPRwwVTqbLZJhg==",
+			"version": "5.3.13",
+			"resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-5.3.13.tgz",
+			"integrity": "sha512-YpYSyM0vMDwKbHD/JA7bVOF6kToVRpa+FM5ateEVRpsTNu564g1muBlkTubXhSKKYXInhpADF46FPyrZcTLpXg==",
 			"license": "Apache-2.0",
 			"peer": true,
 			"dependencies": {
-				"@smithy/is-array-buffer": "^4.2.0",
-				"@smithy/protocol-http": "^5.3.8",
-				"@smithy/types": "^4.12.0",
-				"@smithy/util-hex-encoding": "^4.2.0",
-				"@smithy/util-middleware": "^4.2.8",
-				"@smithy/util-uri-escape": "^4.2.0",
-				"@smithy/util-utf8": "^4.2.0",
+				"@smithy/is-array-buffer": "^4.2.2",
+				"@smithy/protocol-http": "^5.3.13",
+				"@smithy/types": "^4.14.0",
+				"@smithy/util-hex-encoding": "^4.2.2",
+				"@smithy/util-middleware": "^4.2.13",
+				"@smithy/util-uri-escape": "^4.2.2",
+				"@smithy/util-utf8": "^4.2.2",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -4346,18 +3134,18 @@
 			}
 		},
 		"node_modules/@smithy/smithy-client": {
-			"version": "4.11.6",
-			"resolved": "https://registry.npmjs.org/@smithy/smithy-client/-/smithy-client-4.11.6.tgz",
-			"integrity": "sha512-g9FNlCTfQzkSpHW3ILOm+TWZfXuOj2UcrNWNBHLnY3Ch+67mLVmiu3fGWPWbs1XiRK174q5tGphnPCTHvImQUA==",
+			"version": "4.12.9",
+			"resolved": "https://registry.npmjs.org/@smithy/smithy-client/-/smithy-client-4.12.9.tgz",
+			"integrity": "sha512-ovaLEcTU5olSeHcRXcxV6viaKtpkHZumn6Ps0yn7dRf2rRSfy794vpjOtrWDO0d1auDSvAqxO+lyhERSXQ03EQ==",
 			"license": "Apache-2.0",
 			"peer": true,
 			"dependencies": {
-				"@smithy/core": "^3.23.3",
-				"@smithy/middleware-endpoint": "^4.4.17",
-				"@smithy/middleware-stack": "^4.2.8",
-				"@smithy/protocol-http": "^5.3.8",
-				"@smithy/types": "^4.12.0",
-				"@smithy/util-stream": "^4.5.13",
+				"@smithy/core": "^3.23.14",
+				"@smithy/middleware-endpoint": "^4.4.29",
+				"@smithy/middleware-stack": "^4.2.13",
+				"@smithy/protocol-http": "^5.3.13",
+				"@smithy/types": "^4.14.0",
+				"@smithy/util-stream": "^4.5.22",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -4365,9 +3153,9 @@
 			}
 		},
 		"node_modules/@smithy/types": {
-			"version": "4.12.0",
-			"resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.12.0.tgz",
-			"integrity": "sha512-9YcuJVTOBDjg9LWo23Qp0lTQ3D7fQsQtwle0jVfpbUHy9qBwCEgKuVH4FqFB3VYu0nwdHKiEMA+oXz7oV8X1kw==",
+			"version": "4.14.0",
+			"resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.14.0.tgz",
+			"integrity": "sha512-OWgntFLW88kx2qvf/c/67Vno1yuXm/f9M7QFAtVkkO29IJXGBIg0ycEaBTH0kvCtwmvZxRujrgP5a86RvsXJAQ==",
 			"license": "Apache-2.0",
 			"peer": true,
 			"dependencies": {
@@ -4378,14 +3166,14 @@
 			}
 		},
 		"node_modules/@smithy/url-parser": {
-			"version": "4.2.8",
-			"resolved": "https://registry.npmjs.org/@smithy/url-parser/-/url-parser-4.2.8.tgz",
-			"integrity": "sha512-NQho9U68TGMEU639YkXnVMV3GEFFULmmaWdlu1E9qzyIePOHsoSnagTGSDv1Zi8DCNN6btxOSdgmy5E/hsZwhA==",
+			"version": "4.2.13",
+			"resolved": "https://registry.npmjs.org/@smithy/url-parser/-/url-parser-4.2.13.tgz",
+			"integrity": "sha512-2G03yoboIRZlZze2+PT4GZEjgwQsJjUgn6iTsvxA02bVceHR6vp4Cuk7TUnPFWKF+ffNUk3kj4COwkENS2K3vw==",
 			"license": "Apache-2.0",
 			"peer": true,
 			"dependencies": {
-				"@smithy/querystring-parser": "^4.2.8",
-				"@smithy/types": "^4.12.0",
+				"@smithy/querystring-parser": "^4.2.13",
+				"@smithy/types": "^4.14.0",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -4393,14 +3181,14 @@
 			}
 		},
 		"node_modules/@smithy/util-base64": {
-			"version": "4.3.0",
-			"resolved": "https://registry.npmjs.org/@smithy/util-base64/-/util-base64-4.3.0.tgz",
-			"integrity": "sha512-GkXZ59JfyxsIwNTWFnjmFEI8kZpRNIBfxKjv09+nkAWPt/4aGaEWMM04m4sxgNVWkbt2MdSvE3KF/PfX4nFedQ==",
+			"version": "4.3.2",
+			"resolved": "https://registry.npmjs.org/@smithy/util-base64/-/util-base64-4.3.2.tgz",
+			"integrity": "sha512-XRH6b0H/5A3SgblmMa5ErXQ2XKhfbQB+Fm/oyLZ2O2kCUrwgg55bU0RekmzAhuwOjA9qdN5VU2BprOvGGUkOOQ==",
 			"license": "Apache-2.0",
 			"peer": true,
 			"dependencies": {
-				"@smithy/util-buffer-from": "^4.2.0",
-				"@smithy/util-utf8": "^4.2.0",
+				"@smithy/util-buffer-from": "^4.2.2",
+				"@smithy/util-utf8": "^4.2.2",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -4408,9 +3196,9 @@
 			}
 		},
 		"node_modules/@smithy/util-body-length-browser": {
-			"version": "4.2.0",
-			"resolved": "https://registry.npmjs.org/@smithy/util-body-length-browser/-/util-body-length-browser-4.2.0.tgz",
-			"integrity": "sha512-Fkoh/I76szMKJnBXWPdFkQJl2r9SjPt3cMzLdOB6eJ4Pnpas8hVoWPYemX/peO0yrrvldgCUVJqOAjUrOLjbxg==",
+			"version": "4.2.2",
+			"resolved": "https://registry.npmjs.org/@smithy/util-body-length-browser/-/util-body-length-browser-4.2.2.tgz",
+			"integrity": "sha512-JKCrLNOup3OOgmzeaKQwi4ZCTWlYR5H4Gm1r2uTMVBXoemo1UEghk5vtMi1xSu2ymgKVGW631e2fp9/R610ZjQ==",
 			"license": "Apache-2.0",
 			"peer": true,
 			"dependencies": {
@@ -4421,9 +3209,9 @@
 			}
 		},
 		"node_modules/@smithy/util-body-length-node": {
-			"version": "4.2.1",
-			"resolved": "https://registry.npmjs.org/@smithy/util-body-length-node/-/util-body-length-node-4.2.1.tgz",
-			"integrity": "sha512-h53dz/pISVrVrfxV1iqXlx5pRg3V2YWFcSQyPyXZRrZoZj4R4DeWRDo1a7dd3CPTcFi3kE+98tuNyD2axyZReA==",
+			"version": "4.2.3",
+			"resolved": "https://registry.npmjs.org/@smithy/util-body-length-node/-/util-body-length-node-4.2.3.tgz",
+			"integrity": "sha512-ZkJGvqBzMHVHE7r/hcuCxlTY8pQr1kMtdsVPs7ex4mMU+EAbcXppfo5NmyxMYi2XU49eqaz56j2gsk4dHHPG/g==",
 			"license": "Apache-2.0",
 			"peer": true,
 			"dependencies": {
@@ -4434,13 +3222,13 @@
 			}
 		},
 		"node_modules/@smithy/util-buffer-from": {
-			"version": "4.2.0",
-			"resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-4.2.0.tgz",
-			"integrity": "sha512-kAY9hTKulTNevM2nlRtxAG2FQ3B2OR6QIrPY3zE5LqJy1oxzmgBGsHLWTcNhWXKchgA0WHW+mZkQrng/pgcCew==",
+			"version": "4.2.2",
+			"resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-4.2.2.tgz",
+			"integrity": "sha512-FDXD7cvUoFWwN6vtQfEta540Y/YBe5JneK3SoZg9bThSoOAC/eGeYEua6RkBgKjGa/sz6Y+DuBZj3+YEY21y4Q==",
 			"license": "Apache-2.0",
 			"peer": true,
 			"dependencies": {
-				"@smithy/is-array-buffer": "^4.2.0",
+				"@smithy/is-array-buffer": "^4.2.2",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -4448,9 +3236,9 @@
 			}
 		},
 		"node_modules/@smithy/util-config-provider": {
-			"version": "4.2.0",
-			"resolved": "https://registry.npmjs.org/@smithy/util-config-provider/-/util-config-provider-4.2.0.tgz",
-			"integrity": "sha512-YEjpl6XJ36FTKmD+kRJJWYvrHeUvm5ykaUS5xK+6oXffQPHeEM4/nXlZPe+Wu0lsgRUcNZiliYNh/y7q9c2y6Q==",
+			"version": "4.2.2",
+			"resolved": "https://registry.npmjs.org/@smithy/util-config-provider/-/util-config-provider-4.2.2.tgz",
+			"integrity": "sha512-dWU03V3XUprJwaUIFVv4iOnS1FC9HnMHDfUrlNDSh4315v0cWyaIErP8KiqGVbf5z+JupoVpNM7ZB3jFiTejvQ==",
 			"license": "Apache-2.0",
 			"peer": true,
 			"dependencies": {
@@ -4461,15 +3249,15 @@
 			}
 		},
 		"node_modules/@smithy/util-defaults-mode-browser": {
-			"version": "4.3.33",
-			"resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-browser/-/util-defaults-mode-browser-4.3.33.tgz",
-			"integrity": "sha512-VutP/lyBWaTNUzNjI+NC3Kwts4Grhb8CTUyGZNQadf5lujqNy2IIM739D31qplSdbxqYBLOPvMXwy4CIKOArrg==",
+			"version": "4.3.45",
+			"resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-browser/-/util-defaults-mode-browser-4.3.45.tgz",
+			"integrity": "sha512-ag9sWc6/nWZAuK3Wm9KlFJUnRkXLrXn33RFjIAmCTFThqLHY+7wCst10BGq56FxslsDrjhSie46c8OULS+BiIw==",
 			"license": "Apache-2.0",
 			"peer": true,
 			"dependencies": {
-				"@smithy/property-provider": "^4.2.8",
-				"@smithy/smithy-client": "^4.11.6",
-				"@smithy/types": "^4.12.0",
+				"@smithy/property-provider": "^4.2.13",
+				"@smithy/smithy-client": "^4.12.9",
+				"@smithy/types": "^4.14.0",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -4477,18 +3265,18 @@
 			}
 		},
 		"node_modules/@smithy/util-defaults-mode-node": {
-			"version": "4.2.36",
-			"resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-node/-/util-defaults-mode-node-4.2.36.tgz",
-			"integrity": "sha512-x73FjvOgG8XBtxu4auMnMDhLi6bUVBLHgNAv8xU0noDGks0KF59JNSzgVQ0oOSuf/D6pVJ5tMEkajwz6IavBUg==",
+			"version": "4.2.49",
+			"resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-node/-/util-defaults-mode-node-4.2.49.tgz",
+			"integrity": "sha512-jlN6vHwE8gY5AfiFBavtD3QtCX2f7lM3BKkz7nFKSNfFR5nXLXLg6sqXTJEEyDwtxbztIDBQCfjsGVXlIru2lQ==",
 			"license": "Apache-2.0",
 			"peer": true,
 			"dependencies": {
-				"@smithy/config-resolver": "^4.4.6",
-				"@smithy/credential-provider-imds": "^4.2.8",
-				"@smithy/node-config-provider": "^4.3.8",
-				"@smithy/property-provider": "^4.2.8",
-				"@smithy/smithy-client": "^4.11.6",
-				"@smithy/types": "^4.12.0",
+				"@smithy/config-resolver": "^4.4.14",
+				"@smithy/credential-provider-imds": "^4.2.13",
+				"@smithy/node-config-provider": "^4.3.13",
+				"@smithy/property-provider": "^4.2.13",
+				"@smithy/smithy-client": "^4.12.9",
+				"@smithy/types": "^4.14.0",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -4496,14 +3284,14 @@
 			}
 		},
 		"node_modules/@smithy/util-endpoints": {
-			"version": "3.2.8",
-			"resolved": "https://registry.npmjs.org/@smithy/util-endpoints/-/util-endpoints-3.2.8.tgz",
-			"integrity": "sha512-8JaVTn3pBDkhZgHQ8R0epwWt+BqPSLCjdjXXusK1onwJlRuN69fbvSK66aIKKO7SwVFM6x2J2ox5X8pOaWcUEw==",
+			"version": "3.3.4",
+			"resolved": "https://registry.npmjs.org/@smithy/util-endpoints/-/util-endpoints-3.3.4.tgz",
+			"integrity": "sha512-BKoR/ubPp9KNKFxPpg1J28N1+bgu8NGAtJblBP7yHy8yQPBWhIAv9+l92SlQLpolGm71CVO+btB60gTgzT0wog==",
 			"license": "Apache-2.0",
 			"peer": true,
 			"dependencies": {
-				"@smithy/node-config-provider": "^4.3.8",
-				"@smithy/types": "^4.12.0",
+				"@smithy/node-config-provider": "^4.3.13",
+				"@smithy/types": "^4.14.0",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -4511,9 +3299,9 @@
 			}
 		},
 		"node_modules/@smithy/util-hex-encoding": {
-			"version": "4.2.0",
-			"resolved": "https://registry.npmjs.org/@smithy/util-hex-encoding/-/util-hex-encoding-4.2.0.tgz",
-			"integrity": "sha512-CCQBwJIvXMLKxVbO88IukazJD9a4kQ9ZN7/UMGBjBcJYvatpWk+9g870El4cB8/EJxfe+k+y0GmR9CAzkF+Nbw==",
+			"version": "4.2.2",
+			"resolved": "https://registry.npmjs.org/@smithy/util-hex-encoding/-/util-hex-encoding-4.2.2.tgz",
+			"integrity": "sha512-Qcz3W5vuHK4sLQdyT93k/rfrUwdJ8/HZ+nMUOyGdpeGA1Wxt65zYwi3oEl9kOM+RswvYq90fzkNDahPS8K0OIg==",
 			"license": "Apache-2.0",
 			"peer": true,
 			"dependencies": {
@@ -4524,13 +3312,13 @@
 			}
 		},
 		"node_modules/@smithy/util-middleware": {
-			"version": "4.2.8",
-			"resolved": "https://registry.npmjs.org/@smithy/util-middleware/-/util-middleware-4.2.8.tgz",
-			"integrity": "sha512-PMqfeJxLcNPMDgvPbbLl/2Vpin+luxqTGPpW3NAQVLbRrFRzTa4rNAASYeIGjRV9Ytuhzny39SpyU04EQreF+A==",
+			"version": "4.2.13",
+			"resolved": "https://registry.npmjs.org/@smithy/util-middleware/-/util-middleware-4.2.13.tgz",
+			"integrity": "sha512-GTooyrlmRTqvUen4eK7/K1p6kryF7bnDfq6XsAbIsf2mo51B/utaH+XThY6dKgNCWzMAaH/+OLmqaBuLhLWRow==",
 			"license": "Apache-2.0",
 			"peer": true,
 			"dependencies": {
-				"@smithy/types": "^4.12.0",
+				"@smithy/types": "^4.14.0",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -4538,14 +3326,14 @@
 			}
 		},
 		"node_modules/@smithy/util-retry": {
-			"version": "4.2.8",
-			"resolved": "https://registry.npmjs.org/@smithy/util-retry/-/util-retry-4.2.8.tgz",
-			"integrity": "sha512-CfJqwvoRY0kTGe5AkQokpURNCT1u/MkRzMTASWMPPo2hNSnKtF1D45dQl3DE2LKLr4m+PW9mCeBMJr5mCAVThg==",
+			"version": "4.3.0",
+			"resolved": "https://registry.npmjs.org/@smithy/util-retry/-/util-retry-4.3.0.tgz",
+			"integrity": "sha512-tSOPQNT/4KfbvqeMovWC3g23KSYy8czHd3tlN+tOYVNIDLSfxIsrPJihYi5TpNcoV789KWtgChUVedh2y6dDPg==",
 			"license": "Apache-2.0",
 			"peer": true,
 			"dependencies": {
-				"@smithy/service-error-classification": "^4.2.8",
-				"@smithy/types": "^4.12.0",
+				"@smithy/service-error-classification": "^4.2.13",
+				"@smithy/types": "^4.14.0",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -4553,19 +3341,19 @@
 			}
 		},
 		"node_modules/@smithy/util-stream": {
-			"version": "4.5.13",
-			"resolved": "https://registry.npmjs.org/@smithy/util-stream/-/util-stream-4.5.13.tgz",
-			"integrity": "sha512-ZJQh++mmjO7JiWAW4SdWFrsde1VE038g4uGtkTlvCGcpytMLsxIAg9o9blorLYaQG47EfY9QjLP38od88NLL8w==",
+			"version": "4.5.22",
+			"resolved": "https://registry.npmjs.org/@smithy/util-stream/-/util-stream-4.5.22.tgz",
+			"integrity": "sha512-3H8iq/0BfQjUs2/4fbHZ9aG9yNzcuZs24LPkcX1Q7Z+qpqaGM8+qbGmE8zo9m2nCRgamyvS98cHdcWvR6YUsew==",
 			"license": "Apache-2.0",
 			"peer": true,
 			"dependencies": {
-				"@smithy/fetch-http-handler": "^5.3.9",
-				"@smithy/node-http-handler": "^4.4.10",
-				"@smithy/types": "^4.12.0",
-				"@smithy/util-base64": "^4.3.0",
-				"@smithy/util-buffer-from": "^4.2.0",
-				"@smithy/util-hex-encoding": "^4.2.0",
-				"@smithy/util-utf8": "^4.2.0",
+				"@smithy/fetch-http-handler": "^5.3.16",
+				"@smithy/node-http-handler": "^4.5.2",
+				"@smithy/types": "^4.14.0",
+				"@smithy/util-base64": "^4.3.2",
+				"@smithy/util-buffer-from": "^4.2.2",
+				"@smithy/util-hex-encoding": "^4.2.2",
+				"@smithy/util-utf8": "^4.2.2",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -4573,9 +3361,9 @@
 			}
 		},
 		"node_modules/@smithy/util-uri-escape": {
-			"version": "4.2.0",
-			"resolved": "https://registry.npmjs.org/@smithy/util-uri-escape/-/util-uri-escape-4.2.0.tgz",
-			"integrity": "sha512-igZpCKV9+E/Mzrpq6YacdTQ0qTiLm85gD6N/IrmyDvQFA4UnU3d5g3m8tMT/6zG/vVkWSU+VxeUyGonL62DuxA==",
+			"version": "4.2.2",
+			"resolved": "https://registry.npmjs.org/@smithy/util-uri-escape/-/util-uri-escape-4.2.2.tgz",
+			"integrity": "sha512-2kAStBlvq+lTXHyAZYfJRb/DfS3rsinLiwb+69SstC9Vb0s9vNWkRwpnj918Pfi85mzi42sOqdV72OLxWAISnw==",
 			"license": "Apache-2.0",
 			"peer": true,
 			"dependencies": {
@@ -4586,13 +3374,13 @@
 			}
 		},
 		"node_modules/@smithy/util-utf8": {
-			"version": "4.2.0",
-			"resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-4.2.0.tgz",
-			"integrity": "sha512-zBPfuzoI8xyBtR2P6WQj63Rz8i3AmfAaJLuNG8dWsfvPe8lO4aCPYLn879mEgHndZH1zQ2oXmG8O1GGzzaoZiw==",
+			"version": "4.2.2",
+			"resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-4.2.2.tgz",
+			"integrity": "sha512-75MeYpjdWRe8M5E3AW0O4Cx3UadweS+cwdXjwYGBW5h/gxxnbeZ877sLPX/ZJA9GVTlL/qG0dXP29JWFCD1Ayw==",
 			"license": "Apache-2.0",
 			"peer": true,
 			"dependencies": {
-				"@smithy/util-buffer-from": "^4.2.0",
+				"@smithy/util-buffer-from": "^4.2.2",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -4600,9 +3388,9 @@
 			}
 		},
 		"node_modules/@smithy/uuid": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/@smithy/uuid/-/uuid-1.1.0.tgz",
-			"integrity": "sha512-4aUIteuyxtBUhVdiQqcDhKFitwfd9hqoSDYY2KRXiWtgoWJ9Bmise+KfEPDiVHWeJepvF8xJO9/9+WDIciMFFw==",
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/@smithy/uuid/-/uuid-1.1.2.tgz",
+			"integrity": "sha512-O/IEdcCUKkubz60tFbGA7ceITTAJsty+lBjNoorP4Z6XRqaFb/OjQjZODophEcuq68nKm6/0r+6/lLQ+XVpk8g==",
 			"license": "Apache-2.0",
 			"peer": true,
 			"dependencies": {
@@ -4612,19 +3400,13 @@
 				"node": ">=18.0.0"
 			}
 		},
-		"node_modules/@tinyhttp/content-disposition": {
-			"version": "2.2.4",
-			"resolved": "https://registry.npmjs.org/@tinyhttp/content-disposition/-/content-disposition-2.2.4.tgz",
-			"integrity": "sha512-5Kc5CM2Ysn3vTTArBs2vESUt0AQiWZA86yc1TI3B+lxXmtEq133C1nxXNOgnzhrivdPZIh3zLj5gDnZjoLL5GA==",
+		"node_modules/@telegraf/types": {
+			"version": "7.1.0",
+			"resolved": "https://registry.npmjs.org/@telegraf/types/-/types-7.1.0.tgz",
+			"integrity": "sha512-kGevOIbpMcIlCDeorKGpwZmdH7kHbqlk/Yj6dEpJMKEQw5lk0KVQY0OLXaCswy8GqlIVLd5625OB+rAntP9xVw==",
 			"license": "MIT",
-			"peer": true,
-			"engines": {
-				"node": ">=12.17.0"
-			},
-			"funding": {
-				"type": "individual",
-				"url": "https://github.com/tinyhttp/tinyhttp?sponsor=1"
-			}
+			"optional": true,
+			"peer": true
 		},
 		"node_modules/@tokenizer/inflate": {
 			"version": "0.4.1",
@@ -4658,92 +3440,10 @@
 			"license": "MIT",
 			"peer": true
 		},
-		"node_modules/@types/aws-lambda": {
-			"version": "8.10.160",
-			"resolved": "https://registry.npmjs.org/@types/aws-lambda/-/aws-lambda-8.10.160.tgz",
-			"integrity": "sha512-uoO4QVQNWFPJMh26pXtmtrRfGshPUSpMZGUyUQY20FhfHEElEBOPKgVmFs1z+kbpyBsRs2JnoOPT7++Z4GA9pA==",
-			"license": "MIT",
-			"peer": true
-		},
-		"node_modules/@types/body-parser": {
-			"version": "1.19.6",
-			"resolved": "https://registry.npmjs.org/@types/body-parser/-/body-parser-1.19.6.tgz",
-			"integrity": "sha512-HLFeCYgz89uk22N5Qg3dvGvsv46B8GLvKKo1zKG4NybA8U2DiEO3w9lqGg29t/tfLRJpJ6iQxnVw4OnB7MoM9g==",
-			"license": "MIT",
-			"peer": true,
-			"dependencies": {
-				"@types/connect": "*",
-				"@types/node": "*"
-			}
-		},
-		"node_modules/@types/bun": {
-			"version": "1.3.9",
-			"resolved": "https://registry.npmjs.org/@types/bun/-/bun-1.3.9.tgz",
-			"integrity": "sha512-KQ571yULOdWJiMH+RIWIOZ7B2RXQGpL1YQrBtLIV3FqDcCu6FsbFUBwhdKUlCKUpS3PJDsHlJ1QKlpxoVR+xtw==",
-			"license": "MIT",
-			"optional": true,
-			"peer": true,
-			"dependencies": {
-				"bun-types": "1.3.9"
-			}
-		},
-		"node_modules/@types/connect": {
-			"version": "3.4.38",
-			"resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.38.tgz",
-			"integrity": "sha512-K6uROf1LD88uDQqJCktA4yzL1YYAK6NgfsI0v/mTgyPKWsX1CnJ0XPSDhViejru1GcRkLWb8RlzFYJRqGUbaug==",
-			"license": "MIT",
-			"peer": true,
-			"dependencies": {
-				"@types/node": "*"
-			}
-		},
-		"node_modules/@types/express": {
-			"version": "5.0.6",
-			"resolved": "https://registry.npmjs.org/@types/express/-/express-5.0.6.tgz",
-			"integrity": "sha512-sKYVuV7Sv9fbPIt/442koC7+IIwK5olP1KWeD88e/idgoJqDm3JV/YUiPwkoKK92ylff2MGxSz1CSjsXelx0YA==",
-			"license": "MIT",
-			"peer": true,
-			"dependencies": {
-				"@types/body-parser": "*",
-				"@types/express-serve-static-core": "^5.0.0",
-				"@types/serve-static": "^2"
-			}
-		},
-		"node_modules/@types/express-serve-static-core": {
-			"version": "5.1.1",
-			"resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-5.1.1.tgz",
-			"integrity": "sha512-v4zIMr/cX7/d2BpAEX3KNKL/JrT1s43s96lLvvdTmza1oEvDudCqK9aF/djc/SWgy8Yh0h30TZx5VpzqFCxk5A==",
-			"license": "MIT",
-			"peer": true,
-			"dependencies": {
-				"@types/node": "*",
-				"@types/qs": "*",
-				"@types/range-parser": "*",
-				"@types/send": "*"
-			}
-		},
-		"node_modules/@types/http-errors": {
-			"version": "2.0.5",
-			"resolved": "https://registry.npmjs.org/@types/http-errors/-/http-errors-2.0.5.tgz",
-			"integrity": "sha512-r8Tayk8HJnX0FztbZN7oVqGccWgw98T/0neJphO91KkmOzug1KkofZURD4UaD5uH8AqcFLfdPErnBod0u71/qg==",
-			"license": "MIT",
-			"peer": true
-		},
-		"node_modules/@types/jsonwebtoken": {
-			"version": "9.0.10",
-			"resolved": "https://registry.npmjs.org/@types/jsonwebtoken/-/jsonwebtoken-9.0.10.tgz",
-			"integrity": "sha512-asx5hIG9Qmf/1oStypjanR7iKTv0gXQ1Ov/jfrX6kS/EO0OFni8orbmGCn0672NHR3kXHwpAwR+B368ZGN/2rA==",
-			"license": "MIT",
-			"peer": true,
-			"dependencies": {
-				"@types/ms": "*",
-				"@types/node": "*"
-			}
-		},
-		"node_modules/@types/long": {
-			"version": "4.0.2",
-			"resolved": "https://registry.npmjs.org/@types/long/-/long-4.0.2.tgz",
-			"integrity": "sha512-MqTGEo5bj5t157U6fA/BiDynNkn0YknVdh48CMPkTSpFTVmvao5UQmm7uEF6xBEo7qIMAlY/JSleYaE6VOdpaA==",
+		"node_modules/@types/events": {
+			"version": "3.0.3",
+			"resolved": "https://registry.npmjs.org/@types/events/-/events-3.0.3.tgz",
+			"integrity": "sha512-trOc4AAUThEz9hapPtSd7wf5tiQKvTtu5b371UxXdTuqzIh0ArcRspRP0i0Viu+LXstIQ1z96t1nsPxT9ol01g==",
 			"license": "MIT",
 			"peer": true
 		},
@@ -4754,36 +3454,15 @@
 			"license": "MIT",
 			"peer": true
 		},
-		"node_modules/@types/ms": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/@types/ms/-/ms-2.1.0.tgz",
-			"integrity": "sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==",
-			"license": "MIT",
-			"peer": true
-		},
 		"node_modules/@types/node": {
-			"version": "25.3.0",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-25.3.0.tgz",
-			"integrity": "sha512-4K3bqJpXpqfg2XKGK9bpDTc6xO/xoUP/RBWS7AtRMug6zZFaRekiLzjVtAoZMquxoAbzBvy5nxQ7veS5eYzf8A==",
+			"version": "25.5.2",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-25.5.2.tgz",
+			"integrity": "sha512-tO4ZIRKNC+MDWV4qKVZe3Ql/woTnmHDr5JD8UI5hn2pwBrHEwOEMZK7WlNb5RKB6EoJ02gwmQS9OrjuFnZYdpg==",
 			"license": "MIT",
 			"peer": true,
 			"dependencies": {
 				"undici-types": "~7.18.0"
 			}
-		},
-		"node_modules/@types/qs": {
-			"version": "6.14.0",
-			"resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.14.0.tgz",
-			"integrity": "sha512-eOunJqu0K1923aExK6y8p6fsihYEn/BYuQ4g0CxAAgFc4b/ZLN4CrsRZ55srTdqoiLzU2B2evC+apEIxprEzkQ==",
-			"license": "MIT",
-			"peer": true
-		},
-		"node_modules/@types/range-parser": {
-			"version": "1.2.7",
-			"resolved": "https://registry.npmjs.org/@types/range-parser/-/range-parser-1.2.7.tgz",
-			"integrity": "sha512-hKormJbkJqzQGhziax5PItDUTMAM9uE2XXQmM37dyd4hVM+5aVl7oVxMVUiVQn2oCQFN/LKCZdvSM0pFRqbSmQ==",
-			"license": "MIT",
-			"peer": true
 		},
 		"node_modules/@types/retry": {
 			"version": "0.12.0",
@@ -4792,120 +3471,23 @@
 			"license": "MIT",
 			"peer": true
 		},
-		"node_modules/@types/send": {
-			"version": "1.2.1",
-			"resolved": "https://registry.npmjs.org/@types/send/-/send-1.2.1.tgz",
-			"integrity": "sha512-arsCikDvlU99zl1g69TcAB3mzZPpxgw0UQnaHeC1Nwb015xp8bknZv5rIfri9xTOcMuaVgvabfIRA7PSZVuZIQ==",
+		"node_modules/@types/yauzl": {
+			"version": "2.10.3",
+			"resolved": "https://registry.npmjs.org/@types/yauzl/-/yauzl-2.10.3.tgz",
+			"integrity": "sha512-oJoftv0LSuaDZE3Le4DbKX+KS9G36NzOeSap90UIK0yMA/NhKJhqlSGtNDORNRaIbQfzjXDrQa0ytJ6mNRGz/Q==",
 			"license": "MIT",
-			"peer": true,
-			"dependencies": {
-				"@types/node": "*"
-			}
-		},
-		"node_modules/@types/serve-static": {
-			"version": "2.2.0",
-			"resolved": "https://registry.npmjs.org/@types/serve-static/-/serve-static-2.2.0.tgz",
-			"integrity": "sha512-8mam4H1NHLtu7nmtalF7eyBH14QyOASmcxHhSfEoRyr0nP/YdoesEtU+uSRvMe96TW/HPTtkoKqQLl53N7UXMQ==",
-			"license": "MIT",
-			"peer": true,
-			"dependencies": {
-				"@types/http-errors": "*",
-				"@types/node": "*"
-			}
-		},
-		"node_modules/@types/ws": {
-			"version": "8.18.1",
-			"resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.18.1.tgz",
-			"integrity": "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==",
-			"license": "MIT",
-			"peer": true,
-			"dependencies": {
-				"@types/node": "*"
-			}
-		},
-		"node_modules/@whiskeysockets/baileys": {
-			"version": "7.0.0-rc.9",
-			"resolved": "https://registry.npmjs.org/@whiskeysockets/baileys/-/baileys-7.0.0-rc.9.tgz",
-			"integrity": "sha512-YFm5gKXfDP9byCXCW3OPHKXLzrAKzolzgVUlRosHHgwbnf2YOO3XknkMm6J7+F0ns8OA0uuSBhgkRHTDtqkacw==",
-			"hasInstallScript": true,
-			"license": "MIT",
-			"peer": true,
-			"dependencies": {
-				"@cacheable/node-cache": "^1.4.0",
-				"@hapi/boom": "^9.1.3",
-				"async-mutex": "^0.5.0",
-				"libsignal": "git+https://github.com/whiskeysockets/libsignal-node.git",
-				"lru-cache": "^11.1.0",
-				"music-metadata": "^11.7.0",
-				"p-queue": "^9.0.0",
-				"pino": "^9.6",
-				"protobufjs": "^7.2.4",
-				"ws": "^8.13.0"
-			},
-			"engines": {
-				"node": ">=20.0.0"
-			},
-			"peerDependencies": {
-				"audio-decode": "^2.1.3",
-				"jimp": "^1.6.0",
-				"link-preview-js": "^3.0.0",
-				"sharp": "*"
-			},
-			"peerDependenciesMeta": {
-				"audio-decode": {
-					"optional": true
-				},
-				"jimp": {
-					"optional": true
-				},
-				"link-preview-js": {
-					"optional": true
-				}
-			}
-		},
-		"node_modules/@whiskeysockets/baileys/node_modules/p-queue": {
-			"version": "9.1.0",
-			"resolved": "https://registry.npmjs.org/p-queue/-/p-queue-9.1.0.tgz",
-			"integrity": "sha512-O/ZPaXuQV29uSLbxWBGGZO1mCQXV2BLIwUr59JUU9SoH76mnYvtms7aafH/isNSNGwuEfP6W/4xD0/TJXxrizw==",
-			"license": "MIT",
-			"peer": true,
-			"dependencies": {
-				"eventemitter3": "^5.0.1",
-				"p-timeout": "^7.0.0"
-			},
-			"engines": {
-				"node": ">=20"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/@whiskeysockets/baileys/node_modules/p-timeout": {
-			"version": "7.0.1",
-			"resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-7.0.1.tgz",
-			"integrity": "sha512-AxTM2wDGORHGEkPCt8yqxOTMgpfbEHqF51f/5fJCmwFC3C/zNcGT63SymH2ttOAaiIws2zVg4+izQCjrakcwHg==",
-			"license": "MIT",
-			"peer": true,
-			"engines": {
-				"node": ">=20"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/abbrev": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
-			"integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==",
-			"license": "ISC",
 			"optional": true,
-			"peer": true
+			"peer": true,
+			"dependencies": {
+				"@types/node": "*"
+			}
 		},
 		"node_modules/abort-controller": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
 			"integrity": "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==",
 			"license": "MIT",
+			"optional": true,
 			"peer": true,
 			"dependencies": {
 				"event-target-shim": "^5.0.0"
@@ -5000,18 +3582,12 @@
 				}
 			}
 		},
-		"node_modules/ansi-escapes": {
-			"version": "6.2.1",
-			"resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-6.2.1.tgz",
-			"integrity": "sha512-4nJ3yixlEthEJ9Rk4vPcdBRkZvQZlYyu8j4/Mqz5sgIkddmEnH2Yj2ZrnP9S3tQOvSNRUIgVNF/1yPpRAGNRig==",
-			"license": "MIT",
-			"peer": true,
-			"engines": {
-				"node": ">=14.16"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
+		"node_modules/another-json": {
+			"version": "0.2.0",
+			"resolved": "https://registry.npmjs.org/another-json/-/another-json-0.2.0.tgz",
+			"integrity": "sha512-/Ndrl68UQLhnCdsAzEXLMFuOR546o2qbYRqCglaNHbjXrwG1ayTcdwr3zkSGOGtGXDyR5X9nCFfnyG2AFJIsqg==",
+			"license": "Apache-2.0",
+			"peer": true
 		},
 		"node_modules/ansi-regex": {
 			"version": "6.2.2",
@@ -5027,13 +3603,16 @@
 			}
 		},
 		"node_modules/ansi-styles": {
-			"version": "6.2.3",
-			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
-			"integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
+			"version": "4.3.0",
+			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+			"integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
 			"license": "MIT",
 			"peer": true,
+			"dependencies": {
+				"color-convert": "^2.0.1"
+			},
 			"engines": {
-				"node": ">=12"
+				"node": ">=8"
 			},
 			"funding": {
 				"url": "https://github.com/chalk/ansi-styles?sponsor=1"
@@ -5045,28 +3624,6 @@
 			"integrity": "sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A==",
 			"license": "MIT",
 			"peer": true
-		},
-		"node_modules/aproba": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/aproba/-/aproba-2.1.0.tgz",
-			"integrity": "sha512-tLIEcj5GuR2RSTnxNKdkK0dJ/GrC7P38sUkiDmDuHfsHmbagTFAxDVIBltoklXEVIQ/f14IL8IMJ5pn9Hez1Ew==",
-			"license": "ISC",
-			"peer": true
-		},
-		"node_modules/are-we-there-yet": {
-			"version": "3.0.1",
-			"resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-3.0.1.tgz",
-			"integrity": "sha512-QZW4EDmGwlYur0Yyf/b2uGucHQMa8aFUP7eu9ddR73vvhFyt4V0Vl3QHPcTNJ8l6qYOBdxgXdnBXQrHilfRQBg==",
-			"deprecated": "This package is no longer supported.",
-			"license": "ISC",
-			"peer": true,
-			"dependencies": {
-				"delegates": "^1.0.0",
-				"readable-stream": "^3.6.0"
-			},
-			"engines": {
-				"node": "^12.13.0 || ^14.15.0 || >=16.0.0"
-			}
 		},
 		"node_modules/argparse": {
 			"version": "2.0.1",
@@ -5088,48 +3645,20 @@
 				"node": ">=4"
 			}
 		},
-		"node_modules/async-mutex": {
-			"version": "0.5.0",
-			"resolved": "https://registry.npmjs.org/async-mutex/-/async-mutex-0.5.0.tgz",
-			"integrity": "sha512-1A94B18jkJ3DYq284ohPxoXbfTA5HsQ7/Mf4DEhcyLx3Bz27Rh59iScbB6EPiP+B+joue6YCxcMXSbFC1tZKwA==",
-			"license": "MIT",
-			"peer": true,
-			"dependencies": {
-				"tslib": "^2.4.0"
-			}
-		},
-		"node_modules/async-retry": {
-			"version": "1.3.3",
-			"resolved": "https://registry.npmjs.org/async-retry/-/async-retry-1.3.3.tgz",
-			"integrity": "sha512-wfr/jstw9xNi/0teMHrRW7dsz3Lt5ARhYNZ2ewpadnhaIp5mbALhOAP+EAdsC7t4Z6wqsDVv9+W6gm1Dk9mEyw==",
-			"license": "MIT",
-			"peer": true,
-			"dependencies": {
-				"retry": "0.13.1"
-			}
-		},
 		"node_modules/asynckit": {
 			"version": "0.4.0",
 			"resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
 			"integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
 			"license": "MIT",
+			"optional": true,
 			"peer": true
-		},
-		"node_modules/atomic-sleep": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/atomic-sleep/-/atomic-sleep-1.0.0.tgz",
-			"integrity": "sha512-kNOjDqAh7px0XWNI+4QbzoiR/nTkHAWNud2uvnJquD1/x5a7EQZMJT0AczqK0Qn67oY/TTQ1LbUKajZpp3I9tQ==",
-			"license": "MIT",
-			"peer": true,
-			"engines": {
-				"node": ">=8.0.0"
-			}
 		},
 		"node_modules/axios": {
 			"version": "1.13.5",
 			"resolved": "https://registry.npmjs.org/axios/-/axios-1.13.5.tgz",
 			"integrity": "sha512-cz4ur7Vb0xS4/KUN0tPWe44eqxrIu31me+fbang3ijiNscE129POzipJJA6zniq2C/Z6sJCjMimjS8Lc/GAs8Q==",
 			"license": "MIT",
+			"optional": true,
 			"peer": true,
 			"dependencies": {
 				"follow-redirects": "^1.15.11",
@@ -5146,6 +3675,13 @@
 			"engines": {
 				"node": "18 || 20 || >=22"
 			}
+		},
+		"node_modules/base-x": {
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/base-x/-/base-x-5.0.1.tgz",
+			"integrity": "sha512-M7uio8Zt++eg3jPj+rHMfCC+IuygQHHCOU+IYsVtik6FWjuYpVt/+MRKcgsAMHh8mMFAwnB+Bs+mTrFiXjMzKg==",
+			"license": "MIT",
+			"peer": true
 		},
 		"node_modules/base64-js": {
 			"version": "1.5.1",
@@ -5169,21 +3705,14 @@
 			"peer": true
 		},
 		"node_modules/basic-ftp": {
-			"version": "5.1.0",
-			"resolved": "https://registry.npmjs.org/basic-ftp/-/basic-ftp-5.1.0.tgz",
-			"integrity": "sha512-RkaJzeJKDbaDWTIPiJwubyljaEPwpVWkm9Rt5h9Nd6h7tEXTJ3VB4qxdZBioV7JO5yLUaOKwz7vDOzlncUsegw==",
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/basic-ftp/-/basic-ftp-5.2.0.tgz",
+			"integrity": "sha512-VoMINM2rqJwJgfdHq6RiUudKt2BV+FY5ZFezP/ypmwayk68+NzzAQy4XXLlqsGD4MCzq3DrmNFD/uUmBJuGoXw==",
 			"license": "MIT",
 			"peer": true,
 			"engines": {
 				"node": ">=10.0.0"
 			}
-		},
-		"node_modules/before-after-hook": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/before-after-hook/-/before-after-hook-4.0.0.tgz",
-			"integrity": "sha512-q6tR3RPqIB1pMiTRMFcZwuG5T8vwp+vUvEG0vuI6B+Rikh5BfPp2fQ82c925FOs+b0lcFQ8CFrL+KbilfZFhOQ==",
-			"license": "Apache-2.0",
-			"peer": true
 		},
 		"node_modules/bignumber.js": {
 			"version": "9.3.1",
@@ -5227,13 +3756,6 @@
 			"license": "ISC",
 			"peer": true
 		},
-		"node_modules/bottleneck": {
-			"version": "2.19.5",
-			"resolved": "https://registry.npmjs.org/bottleneck/-/bottleneck-2.19.5.tgz",
-			"integrity": "sha512-VHiNCbI1lKdl44tGrhNfU3lup0Tj/ZBMJB5/2ZbNXRCPuRCO7ed2mgcK4r17y+KB2EfuYuRaVlwNbAeaWGSpbw==",
-			"license": "MIT",
-			"peer": true
-		},
 		"node_modules/bowser": {
 			"version": "2.14.1",
 			"resolved": "https://registry.npmjs.org/bowser/-/bowser-2.14.1.tgz",
@@ -5242,9 +3764,9 @@
 			"peer": true
 		},
 		"node_modules/brace-expansion": {
-			"version": "5.0.3",
-			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.3.tgz",
-			"integrity": "sha512-fy6KJm2RawA5RcHkLa1z/ScpBeA762UF9KmZQxwIbDtRJrgLzM10depAiEQ+CXYcoiqW1/m96OAAoke2nE9EeA==",
+			"version": "5.0.5",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
+			"integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
 			"license": "MIT",
 			"peer": true,
 			"dependencies": {
@@ -5254,11 +3776,59 @@
 				"node": "18 || 20 || >=22"
 			}
 		},
+		"node_modules/bs58": {
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/bs58/-/bs58-6.0.0.tgz",
+			"integrity": "sha512-PD0wEnEYg6ijszw/u8s+iI3H17cTymlrwkKhDhPZq+Sokl3AU4htyBFTjAeNAlCCmg0f53g6ih3jATyCKftTfw==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"base-x": "^5.0.0"
+			}
+		},
+		"node_modules/buffer-alloc": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/buffer-alloc/-/buffer-alloc-1.2.0.tgz",
+			"integrity": "sha512-CFsHQgjtW1UChdXgbyJGtnm+O/uLQeZdtbDo8mfUgYXCHSM1wgrVxXm6bSyrUuErEb+4sYVGCzASBRot7zyrow==",
+			"license": "MIT",
+			"optional": true,
+			"peer": true,
+			"dependencies": {
+				"buffer-alloc-unsafe": "^1.1.0",
+				"buffer-fill": "^1.0.0"
+			}
+		},
+		"node_modules/buffer-alloc-unsafe": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/buffer-alloc-unsafe/-/buffer-alloc-unsafe-1.1.0.tgz",
+			"integrity": "sha512-TEM2iMIEQdJ2yjPJoSIsldnleVaAk1oW3DBVUykyOLsEsFmEc9kn+SFFPz+gl54KQNxlDnAwCXosOS9Okx2xAg==",
+			"license": "MIT",
+			"optional": true,
+			"peer": true
+		},
+		"node_modules/buffer-crc32": {
+			"version": "0.2.13",
+			"resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
+			"integrity": "sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ==",
+			"license": "MIT",
+			"peer": true,
+			"engines": {
+				"node": "*"
+			}
+		},
 		"node_modules/buffer-equal-constant-time": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
 			"integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==",
 			"license": "BSD-3-Clause",
+			"peer": true
+		},
+		"node_modules/buffer-fill": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/buffer-fill/-/buffer-fill-1.0.0.tgz",
+			"integrity": "sha512-T7zexNBwiiaCOGDg9xNX9PBmjrubblRkENuptryuI64URkXDFum9il/JGL8Lm8wYfAXpredVXXZz7eMHilimiQ==",
+			"license": "MIT",
+			"optional": true,
 			"peer": true
 		},
 		"node_modules/buffer-from": {
@@ -5268,17 +3838,6 @@
 			"license": "MIT",
 			"peer": true
 		},
-		"node_modules/bun-types": {
-			"version": "1.3.9",
-			"resolved": "https://registry.npmjs.org/bun-types/-/bun-types-1.3.9.tgz",
-			"integrity": "sha512-+UBWWOakIP4Tswh0Bt0QD0alpTY8cb5hvgiYeWCMet9YukHbzuruIEeXC2D7nMJPB12kbh8C7XJykSexEqGKJg==",
-			"license": "MIT",
-			"optional": true,
-			"peer": true,
-			"dependencies": {
-				"@types/node": "*"
-			}
-		},
 		"node_modules/bytes": {
 			"version": "3.1.2",
 			"resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
@@ -5287,20 +3846,6 @@
 			"peer": true,
 			"engines": {
 				"node": ">= 0.8"
-			}
-		},
-		"node_modules/cacheable": {
-			"version": "2.3.2",
-			"resolved": "https://registry.npmjs.org/cacheable/-/cacheable-2.3.2.tgz",
-			"integrity": "sha512-w+ZuRNmex9c1TR9RcsxbfTKCjSL0rh1WA5SABbrWprIHeNBdmyQLSYonlDy9gpD+63XT8DgZ/wNh1Smvc9WnJA==",
-			"license": "MIT",
-			"peer": true,
-			"dependencies": {
-				"@cacheable/memory": "^2.0.7",
-				"@cacheable/utils": "^2.3.3",
-				"hookified": "^1.15.0",
-				"keyv": "^5.5.5",
-				"qified": "^0.6.0"
 			}
 		},
 		"node_modules/call-bind-apply-helpers": {
@@ -5347,13 +3892,6 @@
 				"url": "https://github.com/chalk/chalk?sponsor=1"
 			}
 		},
-		"node_modules/chmodrp": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/chmodrp/-/chmodrp-1.0.2.tgz",
-			"integrity": "sha512-TdngOlFV1FLTzU0o1w8MB6/BFywhtLC0SzRTGJU7T9lmdjlCWeMRt1iVo0Ki+ldwNk0BqNiKoc8xpLZEQ8mY1w==",
-			"license": "MIT",
-			"peer": true
-		},
 		"node_modules/chokidar": {
 			"version": "5.0.0",
 			"resolved": "https://registry.npmjs.org/chokidar/-/chokidar-5.0.0.tgz",
@@ -5371,45 +3909,13 @@
 			}
 		},
 		"node_modules/chownr": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/chownr/-/chownr-2.0.0.tgz",
-			"integrity": "sha512-bIomtDF5KGpdogkLd9VspvFzk9KfpyyGlS8YFVZl7TGPBHL5snIOnxeshwVgPteQ9b4Eydl+pVbIyE1DcvCWgQ==",
-			"license": "ISC",
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/chownr/-/chownr-3.0.0.tgz",
+			"integrity": "sha512-+IxzY9BZOQd/XuYPRmrvEVjF/nqj5kgT4kEq7VofrDoM1MxoRjEWkrCC3EtLi59TVawxTAn+orJwFQcrqEN1+g==",
+			"license": "BlueOak-1.0.0",
 			"peer": true,
-			"engines": {
-				"node": ">=10"
-			}
-		},
-		"node_modules/ci-info": {
-			"version": "4.4.0",
-			"resolved": "https://registry.npmjs.org/ci-info/-/ci-info-4.4.0.tgz",
-			"integrity": "sha512-77PSwercCZU2Fc4sX94eF8k8Pxte6JAwL4/ICZLFjJLqegs7kCuAsqqj/70NQF6TvDpgFjkubQB2FW2ZZddvQg==",
-			"funding": [
-				{
-					"type": "github",
-					"url": "https://github.com/sponsors/sibiraj-s"
-				}
-			],
-			"license": "MIT",
-			"peer": true,
-			"engines": {
-				"node": ">=8"
-			}
-		},
-		"node_modules/cli-cursor": {
-			"version": "5.0.0",
-			"resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-5.0.0.tgz",
-			"integrity": "sha512-aCj4O5wKyszjMmDT4tZj93kxyydN/K5zPWSCe6/0AV/AA1pqe5ZBIw0a2ZfPQV7lL5/yb5HsUreJ6UFAF1tEQw==",
-			"license": "MIT",
-			"peer": true,
-			"dependencies": {
-				"restore-cursor": "^5.0.0"
-			},
 			"engines": {
 				"node": ">=18"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
 		"node_modules/cli-highlight": {
@@ -5442,22 +3948,6 @@
 			"peer": true,
 			"engines": {
 				"node": ">=8"
-			}
-		},
-		"node_modules/cli-highlight/node_modules/ansi-styles": {
-			"version": "4.3.0",
-			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-			"integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-			"license": "MIT",
-			"peer": true,
-			"dependencies": {
-				"color-convert": "^2.0.1"
-			},
-			"engines": {
-				"node": ">=8"
-			},
-			"funding": {
-				"url": "https://github.com/chalk/ansi-styles?sponsor=1"
 			}
 		},
 		"node_modules/cli-highlight/node_modules/chalk": {
@@ -5531,19 +4021,6 @@
 				"node": ">=10"
 			}
 		},
-		"node_modules/cli-spinners": {
-			"version": "2.9.2",
-			"resolved": "https://registry.npmjs.org/cli-spinners/-/cli-spinners-2.9.2.tgz",
-			"integrity": "sha512-ywqV+5MmyL4E7ybXgKys4DugZbX0FC6LnwrhjuykIjnK9k8OQacQ7axGKnjDXWNhns0xot3bZI5h55H8yo9cJg==",
-			"license": "MIT",
-			"peer": true,
-			"engines": {
-				"node": ">=6"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
 		"node_modules/cliui": {
 			"version": "8.0.1",
 			"resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
@@ -5582,56 +4059,6 @@
 				"node": ">=8"
 			}
 		},
-		"node_modules/cmake-js": {
-			"version": "7.4.0",
-			"resolved": "https://registry.npmjs.org/cmake-js/-/cmake-js-7.4.0.tgz",
-			"integrity": "sha512-Lw0JxEHrmk+qNj1n9W9d4IvkDdYTBn7l2BW6XmtLj7WPpIo2shvxUy+YokfjMxAAOELNonQwX3stkPhM5xSC2Q==",
-			"license": "MIT",
-			"peer": true,
-			"dependencies": {
-				"axios": "^1.6.5",
-				"debug": "^4",
-				"fs-extra": "^11.2.0",
-				"memory-stream": "^1.0.0",
-				"node-api-headers": "^1.1.0",
-				"npmlog": "^6.0.2",
-				"rc": "^1.2.7",
-				"semver": "^7.5.4",
-				"tar": "^6.2.0",
-				"url-join": "^4.0.1",
-				"which": "^2.0.2",
-				"yargs": "^17.7.2"
-			},
-			"bin": {
-				"cmake-js": "bin/cmake-js"
-			},
-			"engines": {
-				"node": ">= 14.15.0"
-			}
-		},
-		"node_modules/cmake-js/node_modules/isexe": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
-			"integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
-			"license": "ISC",
-			"peer": true
-		},
-		"node_modules/cmake-js/node_modules/which": {
-			"version": "2.0.2",
-			"resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
-			"integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
-			"license": "ISC",
-			"peer": true,
-			"dependencies": {
-				"isexe": "^2.0.0"
-			},
-			"bin": {
-				"node-which": "bin/node-which"
-			},
-			"engines": {
-				"node": ">= 8"
-			}
-		},
 		"node_modules/color-convert": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
@@ -5652,21 +4079,12 @@
 			"license": "MIT",
 			"peer": true
 		},
-		"node_modules/color-support": {
-			"version": "1.1.3",
-			"resolved": "https://registry.npmjs.org/color-support/-/color-support-1.1.3.tgz",
-			"integrity": "sha512-qiBjkpbMLO/HL68y+lh4q0/O1MZFj2RX6X/KmMa3+gJD3z+WwI1ZzDHysvqHGS3mP6mznPckpXmw1nI9cJjyRg==",
-			"license": "ISC",
-			"peer": true,
-			"bin": {
-				"color-support": "bin.js"
-			}
-		},
 		"node_modules/combined-stream": {
 			"version": "1.0.8",
 			"resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
 			"integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
 			"license": "MIT",
+			"optional": true,
 			"peer": true,
 			"dependencies": {
 				"delayed-stream": "~1.0.0"
@@ -5674,31 +4092,6 @@
 			"engines": {
 				"node": ">= 0.8"
 			}
-		},
-		"node_modules/commander": {
-			"version": "10.0.1",
-			"resolved": "https://registry.npmjs.org/commander/-/commander-10.0.1.tgz",
-			"integrity": "sha512-y4Mg2tXshplEbSGzx7amzPwKKOCGuoSRP/CjEdwwk0FOGlUbq6lKuoyDZTNZkmxHdJtp54hdfY/JUrdL7Xfdug==",
-			"license": "MIT",
-			"peer": true,
-			"engines": {
-				"node": ">=14"
-			}
-		},
-		"node_modules/concat-map": {
-			"version": "0.0.1",
-			"resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-			"integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
-			"license": "MIT",
-			"optional": true,
-			"peer": true
-		},
-		"node_modules/console-control-strings": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
-			"integrity": "sha512-ty/fTekppD2fIwRvnZAVdeOiGd1c7YXEixbgJTNzqcxJWKQnjJ/V1bNEEE6hygpM3WjwHFUVK6HTjWSzV4a8sQ==",
-			"license": "ISC",
-			"peer": true
 		},
 		"node_modules/content-disposition": {
 			"version": "1.0.1",
@@ -5751,6 +4144,24 @@
 			"license": "MIT",
 			"peer": true
 		},
+		"node_modules/cors": {
+			"version": "2.8.6",
+			"resolved": "https://registry.npmjs.org/cors/-/cors-2.8.6.tgz",
+			"integrity": "sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"object-assign": "^4",
+				"vary": "^1"
+			},
+			"engines": {
+				"node": ">= 0.10"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/express"
+			}
+		},
 		"node_modules/croner": {
 			"version": "10.0.1",
 			"resolved": "https://registry.npmjs.org/croner/-/croner-10.0.1.tgz",
@@ -5781,29 +4192,6 @@
 				"path-key": "^3.1.0",
 				"shebang-command": "^2.0.0",
 				"which": "^2.0.1"
-			},
-			"engines": {
-				"node": ">= 8"
-			}
-		},
-		"node_modules/cross-spawn/node_modules/isexe": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
-			"integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
-			"license": "ISC",
-			"peer": true
-		},
-		"node_modules/cross-spawn/node_modules/which": {
-			"version": "2.0.2",
-			"resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
-			"integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
-			"license": "ISC",
-			"peer": true,
-			"dependencies": {
-				"isexe": "^2.0.0"
-			},
-			"bin": {
-				"node-which": "bin/node-which"
 			},
 			"engines": {
 				"node": ">= 8"
@@ -5846,21 +4234,14 @@
 			"license": "MIT",
 			"peer": true
 		},
-		"node_modules/curve25519-js": {
-			"version": "0.0.4",
-			"resolved": "https://registry.npmjs.org/curve25519-js/-/curve25519-js-0.0.4.tgz",
-			"integrity": "sha512-axn2UMEnkhyDUPWOwVKBMVIzSQy2ejH2xRGy1wq81dqRwApXfIzfbE3hIX0ZRFBIihf/KDqK158DLwESu4AK1w==",
-			"license": "MIT",
-			"peer": true
-		},
 		"node_modules/data-uri-to-buffer": {
-			"version": "6.0.2",
-			"resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-6.0.2.tgz",
-			"integrity": "sha512-7hvf7/GW8e86rW0ptuwS3OcBGDjIi6SZva7hCyWC0yYry2cOPmLIjXAUHI6DK2HsnwJd9ifmt57i8eV2n4YNpw==",
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-4.0.1.tgz",
+			"integrity": "sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==",
 			"license": "MIT",
 			"peer": true,
 			"engines": {
-				"node": ">= 14"
+				"node": ">= 12"
 			}
 		},
 		"node_modules/debug": {
@@ -5879,16 +4260,6 @@
 				"supports-color": {
 					"optional": true
 				}
-			}
-		},
-		"node_modules/deep-extend": {
-			"version": "0.6.0",
-			"resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
-			"integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
-			"license": "MIT",
-			"peer": true,
-			"engines": {
-				"node": ">=4.0.0"
 			}
 		},
 		"node_modules/degenerator": {
@@ -5911,17 +4282,11 @@
 			"resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
 			"integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
 			"license": "MIT",
+			"optional": true,
 			"peer": true,
 			"engines": {
 				"node": ">=0.4.0"
 			}
-		},
-		"node_modules/delegates": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
-			"integrity": "sha512-bd2L678uiWATM6m5Z1VzNCErI3jiGzt6HGY8OVICs40JQq/HALfbyNJmp0UDakEY4pMMaN0Ly5om/B1VI/+xfQ==",
-			"license": "MIT",
-			"peer": true
 		},
 		"node_modules/depd": {
 			"version": "2.0.0",
@@ -5944,24 +4309,14 @@
 			}
 		},
 		"node_modules/diff": {
-			"version": "8.0.3",
-			"resolved": "https://registry.npmjs.org/diff/-/diff-8.0.3.tgz",
-			"integrity": "sha512-qejHi7bcSD4hQAZE0tNAawRK1ZtafHDmMTMkrrIGgSLl7hTnQHmKCeB45xAcbfTqK2zowkM3j3bHt/4b/ARbYQ==",
+			"version": "8.0.4",
+			"resolved": "https://registry.npmjs.org/diff/-/diff-8.0.4.tgz",
+			"integrity": "sha512-DPi0FmjiSU5EvQV0++GFDOJ9ASQUVFh5kD+OzOnYdi7n3Wpm9hWWGfB/O2blfHcMVTL5WkQXSnRiK9makhrcnw==",
 			"license": "BSD-3-Clause",
 			"peer": true,
 			"engines": {
 				"node": ">=0.3.1"
 			}
-		},
-		"node_modules/discord-api-types": {
-			"version": "0.38.40",
-			"resolved": "https://registry.npmjs.org/discord-api-types/-/discord-api-types-0.38.40.tgz",
-			"integrity": "sha512-P/His8cotqZgQqrt+hzrocp9L8RhQQz1GkrCnC9TMJ8Uw2q0tg8YyqJyGULxhXn/8kxHETN4IppmOv+P2m82lQ==",
-			"license": "MIT",
-			"peer": true,
-			"workspaces": [
-				"scripts/actions/documentation"
-			]
 		},
 		"node_modules/dom-serializer": {
 			"version": "2.0.0",
@@ -6023,9 +4378,9 @@
 			}
 		},
 		"node_modules/dotenv": {
-			"version": "17.3.1",
-			"resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.3.1.tgz",
-			"integrity": "sha512-IO8C/dzEb6O3F9/twg6ZLXz164a2fhTnEWb95H23Dm4OuN+92NmEAlTrupP9VW6Jm3sO26tQlqyvyi4CsnY9GA==",
+			"version": "17.4.1",
+			"resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.4.1.tgz",
+			"integrity": "sha512-k8DaKGP6r1G30Lx8V4+pCsLzKr8vLmV2paqEj1Y55GdAgJuIqpRp5FfajGF8KtwMxCz9qJc6wUIJnm053d/WCw==",
 			"license": "BSD-2-Clause",
 			"peer": true,
 			"engines": {
@@ -6049,13 +4404,6 @@
 			"engines": {
 				"node": ">= 0.4"
 			}
-		},
-		"node_modules/eastasianwidth": {
-			"version": "0.2.0",
-			"resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
-			"integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
-			"license": "MIT",
-			"peer": true
 		},
 		"node_modules/ecdsa-sig-formatter": {
 			"version": "1.0.11",
@@ -6091,6 +4439,16 @@
 				"node": ">= 0.8"
 			}
 		},
+		"node_modules/end-of-stream": {
+			"version": "1.4.5",
+			"resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.5.tgz",
+			"integrity": "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"once": "^1.4.0"
+			}
+		},
 		"node_modules/entities": {
 			"version": "4.5.0",
 			"resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
@@ -6102,16 +4460,6 @@
 			},
 			"funding": {
 				"url": "https://github.com/fb55/entities?sponsor=1"
-			}
-		},
-		"node_modules/env-var": {
-			"version": "7.5.0",
-			"resolved": "https://registry.npmjs.org/env-var/-/env-var-7.5.0.tgz",
-			"integrity": "sha512-mKZOzLRN0ETzau2W2QXefbFjo5EF4yWq28OyKb9ICdeNhHJlOE/pHHnz4hdYJ9cNZXcJHo5xN4OT4pzuSHSNvA==",
-			"license": "MIT",
-			"peer": true,
-			"engines": {
-				"node": ">=10"
 			}
 		},
 		"node_modules/es-define-property": {
@@ -6152,6 +4500,7 @@
 			"resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
 			"integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
 			"license": "MIT",
+			"optional": true,
 			"peer": true,
 			"dependencies": {
 				"es-errors": "^1.3.0",
@@ -6251,17 +4600,44 @@
 			"resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-5.0.1.tgz",
 			"integrity": "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==",
 			"license": "MIT",
+			"optional": true,
 			"peer": true,
 			"engines": {
 				"node": ">=6"
 			}
 		},
-		"node_modules/eventemitter3": {
-			"version": "5.0.4",
-			"resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.4.tgz",
-			"integrity": "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==",
+		"node_modules/events": {
+			"version": "3.3.0",
+			"resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
+			"integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==",
 			"license": "MIT",
-			"peer": true
+			"peer": true,
+			"engines": {
+				"node": ">=0.8.x"
+			}
+		},
+		"node_modules/eventsource": {
+			"version": "3.0.7",
+			"resolved": "https://registry.npmjs.org/eventsource/-/eventsource-3.0.7.tgz",
+			"integrity": "sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"eventsource-parser": "^3.0.1"
+			},
+			"engines": {
+				"node": ">=18.0.0"
+			}
+		},
+		"node_modules/eventsource-parser": {
+			"version": "3.0.6",
+			"resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.0.6.tgz",
+			"integrity": "sha512-Vo1ab+QXPzZ4tCa8SwIHJFaSzy4R6SHf7BY79rFBDf0idraZWAkYrDjDj8uWaSm3S2TK+hJ7/t1CEmZ7jXw+pg==",
+			"license": "MIT",
+			"peer": true,
+			"engines": {
+				"node": ">=18.0.0"
+			}
 		},
 		"node_modules/express": {
 			"version": "5.2.1",
@@ -6307,6 +4683,25 @@
 				"url": "https://opencollective.com/express"
 			}
 		},
+		"node_modules/express-rate-limit": {
+			"version": "8.3.2",
+			"resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.3.2.tgz",
+			"integrity": "sha512-77VmFeJkO0/rvimEDuUC5H30oqUC4EyOhyGccfqoLebB0oiEYfM7nwPrsDsBL1gsTpwfzX8SFy2MT3TDyRq+bg==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"ip-address": "10.1.0"
+			},
+			"engines": {
+				"node": ">= 16"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/express-rate-limit"
+			},
+			"peerDependencies": {
+				"express": ">= 4.11"
+			}
+		},
 		"node_modules/express/node_modules/mime-db": {
 			"version": "1.54.0",
 			"resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
@@ -6341,22 +4736,26 @@
 			"license": "MIT",
 			"peer": true
 		},
-		"node_modules/fast-content-type-parse": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/fast-content-type-parse/-/fast-content-type-parse-3.0.0.tgz",
-			"integrity": "sha512-ZvLdcY8P+N8mGQJahJV5G4U88CSvT1rP8ApL6uETe88MBXrBHAkZlSEySdUlyztF7ccb+Znos3TFqaepHxdhBg==",
-			"funding": [
-				{
-					"type": "github",
-					"url": "https://github.com/sponsors/fastify"
-				},
-				{
-					"type": "opencollective",
-					"url": "https://opencollective.com/fastify"
-				}
-			],
-			"license": "MIT",
-			"peer": true
+		"node_modules/extract-zip": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/extract-zip/-/extract-zip-2.0.1.tgz",
+			"integrity": "sha512-GDhU9ntwuKyGXdZBUgTIe+vXnWj0fppUEtMDL0+idd5Sta8TGpHssn/eusA9mrPr9qNDym6SxAYZjNvCn/9RBg==",
+			"license": "BSD-2-Clause",
+			"peer": true,
+			"dependencies": {
+				"debug": "^4.1.1",
+				"get-stream": "^5.1.0",
+				"yauzl": "^2.10.0"
+			},
+			"bin": {
+				"extract-zip": "cli.js"
+			},
+			"engines": {
+				"node": ">= 10.17.0"
+			},
+			"optionalDependencies": {
+				"@types/yauzl": "^2.9.1"
+			}
 		},
 		"node_modules/fast-deep-equal": {
 			"version": "3.1.3",
@@ -6364,6 +4763,23 @@
 			"integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
 			"license": "MIT",
 			"peer": true
+		},
+		"node_modules/fast-string-truncated-width": {
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/fast-string-truncated-width/-/fast-string-truncated-width-1.2.1.tgz",
+			"integrity": "sha512-Q9acT/+Uu3GwGj+5w/zsGuQjh9O1TyywhIwAxHudtWrgF09nHOPrvTLhQevPbttcxjr/SNN7mJmfOw/B1bXgow==",
+			"license": "MIT",
+			"peer": true
+		},
+		"node_modules/fast-string-width": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/fast-string-width/-/fast-string-width-1.1.0.tgz",
+			"integrity": "sha512-O3fwIVIH5gKB38QNbdg+3760ZmGz0SZMgvwJbA1b2TGXceKE6A2cOlfogh1iw8lr049zPyd7YADHy+B7U4W9bQ==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"fast-string-truncated-width": "^1.2.0"
+			}
 		},
 		"node_modules/fast-uri": {
 			"version": "3.1.0",
@@ -6382,10 +4798,20 @@
 			"license": "BSD-3-Clause",
 			"peer": true
 		},
-		"node_modules/fast-xml-parser": {
-			"version": "5.3.6",
-			"resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.3.6.tgz",
-			"integrity": "sha512-QNI3sAvSvaOiaMl8FYU4trnEzCwiRr8XMWgAHzlrWpTSj+QaCSvOf1h82OEP1s4hiAXhnbXSyFWCf4ldZzZRVA==",
+		"node_modules/fast-wrap-ansi": {
+			"version": "0.1.6",
+			"resolved": "https://registry.npmjs.org/fast-wrap-ansi/-/fast-wrap-ansi-0.1.6.tgz",
+			"integrity": "sha512-HlUwET7a5gqjURj70D5jl7aC3Zmy4weA1SHUfM0JFI0Ptq987NH2TwbBFLoERhfwk+E+eaq4EK3jXoT+R3yp3w==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"fast-string-width": "^1.1.0"
+			}
+		},
+		"node_modules/fast-xml-builder": {
+			"version": "1.1.4",
+			"resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.1.4.tgz",
+			"integrity": "sha512-f2jhpN4Eccy0/Uz9csxh3Nu6q4ErKxf0XIsasomfOihuSUa3/xw6w8dnOtCDgEItQFJG8KyXPzQXzcODDrrbOg==",
 			"funding": [
 				{
 					"type": "github",
@@ -6395,10 +4821,38 @@
 			"license": "MIT",
 			"peer": true,
 			"dependencies": {
-				"strnum": "^2.1.2"
+				"path-expression-matcher": "^1.1.3"
+			}
+		},
+		"node_modules/fast-xml-parser": {
+			"version": "5.5.8",
+			"resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.5.8.tgz",
+			"integrity": "sha512-Z7Fh2nVQSb2d+poDViM063ix2ZGt9jmY1nWhPfHBOK2Hgnb/OW3P4Et3P/81SEej0J7QbWtJqxO05h8QYfK7LQ==",
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/NaturalIntelligence"
+				}
+			],
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"fast-xml-builder": "^1.1.4",
+				"path-expression-matcher": "^1.2.0",
+				"strnum": "^2.2.0"
 			},
 			"bin": {
 				"fxparser": "src/cli/cli.js"
+			}
+		},
+		"node_modules/fd-slicer": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.1.0.tgz",
+			"integrity": "sha512-cE1qsB/VwyQozZ+q1dGxR8LBYNZeofhEdUNGSMbQD3Gw2lAzX9Zb3uIU6Ebc/Fmyjo9AWWfnn0AUCHqtevs/8g==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"pend": "~1.2.0"
 			}
 		},
 		"node_modules/fetch-blob": {
@@ -6426,51 +4880,22 @@
 			}
 		},
 		"node_modules/file-type": {
-			"version": "21.3.0",
-			"resolved": "https://registry.npmjs.org/file-type/-/file-type-21.3.0.tgz",
-			"integrity": "sha512-8kPJMIGz1Yt/aPEwOsrR97ZyZaD1Iqm8PClb1nYFclUCkBi0Ma5IsYNQzvSFS9ib51lWyIw5mIT9rWzI/xjpzA==",
+			"version": "22.0.0",
+			"resolved": "https://registry.npmjs.org/file-type/-/file-type-22.0.0.tgz",
+			"integrity": "sha512-cmBmnYo8Zymabm2+qAP7jTFbKF10bQpYmxoGfuZbRFRcq00BRddJdGNH/P7GA1EMpJy5yQbqa9B7yROb3z8Ziw==",
 			"license": "MIT",
 			"peer": true,
 			"dependencies": {
 				"@tokenizer/inflate": "^0.4.1",
-				"strtok3": "^10.3.4",
-				"token-types": "^6.1.1",
-				"uint8array-extras": "^1.4.0"
+				"strtok3": "^10.3.5",
+				"token-types": "^6.1.2",
+				"uint8array-extras": "^1.5.0"
 			},
 			"engines": {
-				"node": ">=20"
+				"node": ">=22"
 			},
 			"funding": {
 				"url": "https://github.com/sindresorhus/file-type?sponsor=1"
-			}
-		},
-		"node_modules/filename-reserved-regex": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/filename-reserved-regex/-/filename-reserved-regex-3.0.0.tgz",
-			"integrity": "sha512-hn4cQfU6GOT/7cFHXBqeBg2TbrMBgdD0kcjLhvSQYYwm3s4B6cjvBfb7nBALJLAXqmU5xajSa7X2NnUud/VCdw==",
-			"license": "MIT",
-			"peer": true,
-			"engines": {
-				"node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/filenamify": {
-			"version": "6.0.0",
-			"resolved": "https://registry.npmjs.org/filenamify/-/filenamify-6.0.0.tgz",
-			"integrity": "sha512-vqIlNogKeyD3yzrm0yhRMQg8hOVwYcYRfjEoODd49iCprMn4HL85gK3HcykQE53EPIpX3HcAbGA5ELQv216dAQ==",
-			"license": "MIT",
-			"peer": true,
-			"dependencies": {
-				"filename-reserved-regex": "^3.0.0"
-			},
-			"engines": {
-				"node": ">=16"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
 		"node_modules/finalhandler": {
@@ -6506,6 +4931,7 @@
 				}
 			],
 			"license": "MIT",
+			"optional": true,
 			"peer": true,
 			"engines": {
 				"node": ">=4.0"
@@ -6516,41 +4942,12 @@
 				}
 			}
 		},
-		"node_modules/foreground-child": {
-			"version": "3.3.1",
-			"resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.3.1.tgz",
-			"integrity": "sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==",
-			"license": "ISC",
-			"peer": true,
-			"dependencies": {
-				"cross-spawn": "^7.0.6",
-				"signal-exit": "^4.0.1"
-			},
-			"engines": {
-				"node": ">=14"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/isaacs"
-			}
-		},
-		"node_modules/foreground-child/node_modules/signal-exit": {
-			"version": "4.1.0",
-			"resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
-			"integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
-			"license": "ISC",
-			"peer": true,
-			"engines": {
-				"node": ">=14"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/isaacs"
-			}
-		},
 		"node_modules/form-data": {
 			"version": "4.0.5",
 			"resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
 			"integrity": "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==",
 			"license": "MIT",
+			"optional": true,
 			"peer": true,
 			"dependencies": {
 				"asynckit": "^0.4.0",
@@ -6596,55 +4993,6 @@
 				"node": ">= 0.8"
 			}
 		},
-		"node_modules/fs-extra": {
-			"version": "11.3.3",
-			"resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.3.3.tgz",
-			"integrity": "sha512-VWSRii4t0AFm6ixFFmLLx1t7wS1gh+ckoa84aOeapGum0h+EZd1EhEumSB+ZdDLnEPuucsVB9oB7cxJHap6Afg==",
-			"license": "MIT",
-			"peer": true,
-			"dependencies": {
-				"graceful-fs": "^4.2.0",
-				"jsonfile": "^6.0.1",
-				"universalify": "^2.0.0"
-			},
-			"engines": {
-				"node": ">=14.14"
-			}
-		},
-		"node_modules/fs-minipass": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-2.1.0.tgz",
-			"integrity": "sha512-V/JgOLFCS+R6Vcq0slCuaeWEdNC3ouDlJMNIsacH2VtALiu9mV4LPrHc5cDl8k5aw6J8jwgWWpiTo5RYhmIzvg==",
-			"license": "ISC",
-			"peer": true,
-			"dependencies": {
-				"minipass": "^3.0.0"
-			},
-			"engines": {
-				"node": ">= 8"
-			}
-		},
-		"node_modules/fs-minipass/node_modules/minipass": {
-			"version": "3.3.6",
-			"resolved": "https://registry.npmjs.org/minipass/-/minipass-3.3.6.tgz",
-			"integrity": "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==",
-			"license": "ISC",
-			"peer": true,
-			"dependencies": {
-				"yallist": "^4.0.0"
-			},
-			"engines": {
-				"node": ">=8"
-			}
-		},
-		"node_modules/fs.realpath": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-			"integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
-			"license": "ISC",
-			"optional": true,
-			"peer": true
-		},
 		"node_modules/function-bind": {
 			"version": "1.1.2",
 			"resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
@@ -6655,186 +5003,86 @@
 				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
-		"node_modules/gauge": {
-			"version": "4.0.4",
-			"resolved": "https://registry.npmjs.org/gauge/-/gauge-4.0.4.tgz",
-			"integrity": "sha512-f9m+BEN5jkg6a0fZjleidjN51VE1X+mPFQ2DJ0uv1V39oCLCbsGe6yjbBnp7eK7z/+GAon99a3nHuqbuuthyPg==",
-			"deprecated": "This package is no longer supported.",
-			"license": "ISC",
-			"peer": true,
-			"dependencies": {
-				"aproba": "^1.0.3 || ^2.0.0",
-				"color-support": "^1.1.3",
-				"console-control-strings": "^1.1.0",
-				"has-unicode": "^2.0.1",
-				"signal-exit": "^3.0.7",
-				"string-width": "^4.2.3",
-				"strip-ansi": "^6.0.1",
-				"wide-align": "^1.1.5"
-			},
-			"engines": {
-				"node": "^12.13.0 || ^14.15.0 || >=16.0.0"
-			}
-		},
-		"node_modules/gauge/node_modules/ansi-regex": {
-			"version": "5.0.1",
-			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
-			"integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
-			"license": "MIT",
-			"peer": true,
-			"engines": {
-				"node": ">=8"
-			}
-		},
-		"node_modules/gauge/node_modules/strip-ansi": {
-			"version": "6.0.1",
-			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
-			"integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-			"license": "MIT",
-			"peer": true,
-			"dependencies": {
-				"ansi-regex": "^5.0.1"
-			},
-			"engines": {
-				"node": ">=8"
-			}
-		},
 		"node_modules/gaxios": {
-			"version": "7.1.3",
-			"resolved": "https://registry.npmjs.org/gaxios/-/gaxios-7.1.3.tgz",
-			"integrity": "sha512-YGGyuEdVIjqxkxVH1pUTMY/XtmmsApXrCVv5EU25iX6inEPbV+VakJfLealkBtJN69AQmh1eGOdCl9Sm1UP6XQ==",
+			"version": "7.1.4",
+			"resolved": "https://registry.npmjs.org/gaxios/-/gaxios-7.1.4.tgz",
+			"integrity": "sha512-bTIgTsM2bWn3XklZISBTQX7ZSddGW+IO3bMdGaemHZ3tbqExMENHLx6kKZ/KlejgrMtj8q7wBItt51yegqalrA==",
 			"license": "Apache-2.0",
 			"peer": true,
 			"dependencies": {
 				"extend": "^3.0.2",
 				"https-proxy-agent": "^7.0.1",
-				"node-fetch": "^3.3.2",
-				"rimraf": "^5.0.1"
+				"node-fetch": "^3.3.2"
 			},
 			"engines": {
 				"node": ">=18"
-			}
-		},
-		"node_modules/gaxios/node_modules/data-uri-to-buffer": {
-			"version": "4.0.1",
-			"resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-4.0.1.tgz",
-			"integrity": "sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==",
-			"license": "MIT",
-			"peer": true,
-			"engines": {
-				"node": ">= 12"
-			}
-		},
-		"node_modules/gaxios/node_modules/glob": {
-			"version": "10.5.0",
-			"resolved": "https://registry.npmjs.org/glob/-/glob-10.5.0.tgz",
-			"integrity": "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==",
-			"deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
-			"license": "ISC",
-			"peer": true,
-			"dependencies": {
-				"foreground-child": "^3.1.0",
-				"jackspeak": "^3.1.2",
-				"minimatch": "^9.0.4",
-				"minipass": "^7.1.2",
-				"package-json-from-dist": "^1.0.0",
-				"path-scurry": "^1.11.1"
-			},
-			"bin": {
-				"glob": "dist/esm/bin.mjs"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/isaacs"
-			}
-		},
-		"node_modules/gaxios/node_modules/lru-cache": {
-			"version": "10.4.3",
-			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
-			"integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
-			"license": "ISC",
-			"peer": true
-		},
-		"node_modules/gaxios/node_modules/minimatch": {
-			"version": "9.0.6",
-			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.6.tgz",
-			"integrity": "sha512-kQAVowdR33euIqeA0+VZTDqU+qo1IeVY+hrKYtZMio3Pg0P0vuh/kwRylLUddJhB6pf3q/botcOvRtx4IN1wqQ==",
-			"license": "ISC",
-			"peer": true,
-			"dependencies": {
-				"brace-expansion": "^5.0.2"
-			},
-			"engines": {
-				"node": ">=16 || 14 >=14.17"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/isaacs"
-			}
-		},
-		"node_modules/gaxios/node_modules/node-fetch": {
-			"version": "3.3.2",
-			"resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.3.2.tgz",
-			"integrity": "sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==",
-			"license": "MIT",
-			"peer": true,
-			"dependencies": {
-				"data-uri-to-buffer": "^4.0.0",
-				"fetch-blob": "^3.1.4",
-				"formdata-polyfill": "^4.0.10"
-			},
-			"engines": {
-				"node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/node-fetch"
-			}
-		},
-		"node_modules/gaxios/node_modules/path-scurry": {
-			"version": "1.11.1",
-			"resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.11.1.tgz",
-			"integrity": "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==",
-			"license": "BlueOak-1.0.0",
-			"peer": true,
-			"dependencies": {
-				"lru-cache": "^10.2.0",
-				"minipass": "^5.0.0 || ^6.0.2 || ^7.0.0"
-			},
-			"engines": {
-				"node": ">=16 || 14 >=14.18"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/isaacs"
-			}
-		},
-		"node_modules/gaxios/node_modules/rimraf": {
-			"version": "5.0.10",
-			"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-5.0.10.tgz",
-			"integrity": "sha512-l0OE8wL34P4nJH/H2ffoaniAokM2qSmrtXHmlpvYr5AVVX8msAyW0l8NVJFDxlSK4u3Uh/f41cQheDVdnYijwQ==",
-			"license": "ISC",
-			"peer": true,
-			"dependencies": {
-				"glob": "^10.3.7"
-			},
-			"bin": {
-				"rimraf": "dist/esm/bin.mjs"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/isaacs"
 			}
 		},
 		"node_modules/gcp-metadata": {
-			"version": "8.1.2",
-			"resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-8.1.2.tgz",
-			"integrity": "sha512-zV/5HKTfCeKWnxG0Dmrw51hEWFGfcF2xiXqcA3+J90WDuP0SvoiSO5ORvcBsifmx/FoIjgQN3oNOGaQ5PhLFkg==",
+			"version": "6.1.1",
+			"resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-6.1.1.tgz",
+			"integrity": "sha512-a4tiq7E0/5fTjxPAaH4jpjkSv/uCaU2p5KC6HVGrvl0cDjA8iBZv4vv1gyzlmK0ZUKqwpOyQMKzZQe3lTit77A==",
 			"license": "Apache-2.0",
 			"peer": true,
 			"dependencies": {
-				"gaxios": "^7.0.0",
-				"google-logging-utils": "^1.0.0",
+				"gaxios": "^6.1.1",
+				"google-logging-utils": "^0.0.2",
 				"json-bigint": "^1.0.0"
 			},
 			"engines": {
-				"node": ">=18"
+				"node": ">=14"
+			}
+		},
+		"node_modules/gcp-metadata/node_modules/gaxios": {
+			"version": "6.7.1",
+			"resolved": "https://registry.npmjs.org/gaxios/-/gaxios-6.7.1.tgz",
+			"integrity": "sha512-LDODD4TMYx7XXdpwxAVRAIAuB0bzv0s+ywFonY46k126qzQHT9ygyoa9tncmOiQmmDrik65UYsEkv3lbfqQ3yQ==",
+			"license": "Apache-2.0",
+			"peer": true,
+			"dependencies": {
+				"extend": "^3.0.2",
+				"https-proxy-agent": "^7.0.1",
+				"is-stream": "^2.0.0",
+				"node-fetch": "^2.6.9",
+				"uuid": "^9.0.1"
+			},
+			"engines": {
+				"node": ">=14"
+			}
+		},
+		"node_modules/gcp-metadata/node_modules/node-fetch": {
+			"version": "2.7.0",
+			"resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
+			"integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"whatwg-url": "^5.0.0"
+			},
+			"engines": {
+				"node": "4.x || >=6.0.0"
+			},
+			"peerDependencies": {
+				"encoding": "^0.1.0"
+			},
+			"peerDependenciesMeta": {
+				"encoding": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/gcp-metadata/node_modules/uuid": {
+			"version": "9.0.1",
+			"resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
+			"integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
+			"funding": [
+				"https://github.com/sponsors/broofa",
+				"https://github.com/sponsors/ctavan"
+			],
+			"license": "MIT",
+			"peer": true,
+			"bin": {
+				"uuid": "dist/bin/uuid"
 			}
 		},
 		"node_modules/get-caller-file": {
@@ -6899,6 +5147,22 @@
 				"node": ">= 0.4"
 			}
 		},
+		"node_modules/get-stream": {
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz",
+			"integrity": "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"pump": "^3.0.0"
+			},
+			"engines": {
+				"node": ">=8"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
 		"node_modules/get-uri": {
 			"version": "6.0.5",
 			"resolved": "https://registry.npmjs.org/get-uri/-/get-uri-6.0.5.tgz",
@@ -6910,6 +5174,16 @@
 				"data-uri-to-buffer": "^6.0.2",
 				"debug": "^4.3.4"
 			},
+			"engines": {
+				"node": ">= 14"
+			}
+		},
+		"node_modules/get-uri/node_modules/data-uri-to-buffer": {
+			"version": "6.0.2",
+			"resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-6.0.2.tgz",
+			"integrity": "sha512-7hvf7/GW8e86rW0ptuwS3OcBGDjIi6SZva7hCyWC0yYry2cOPmLIjXAUHI6DK2HsnwJd9ifmt57i8eV2n4YNpw==",
+			"license": "MIT",
+			"peer": true,
 			"engines": {
 				"node": ">= 14"
 			}
@@ -6933,28 +5207,79 @@
 			}
 		},
 		"node_modules/google-auth-library": {
-			"version": "10.5.0",
-			"resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-10.5.0.tgz",
-			"integrity": "sha512-7ABviyMOlX5hIVD60YOfHw4/CxOfBhyduaYB+wbFWCWoni4N7SLcV46hrVRktuBbZjFC9ONyqamZITN7q3n32w==",
+			"version": "9.15.1",
+			"resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-9.15.1.tgz",
+			"integrity": "sha512-Jb6Z0+nvECVz+2lzSMt9u98UsoakXxA2HGHMCxh+so3n90XgYWkq5dur19JAJV7ONiJY22yBTyJB1TSkvPq9Ng==",
 			"license": "Apache-2.0",
 			"peer": true,
 			"dependencies": {
 				"base64-js": "^1.3.0",
 				"ecdsa-sig-formatter": "^1.0.11",
-				"gaxios": "^7.0.0",
-				"gcp-metadata": "^8.0.0",
-				"google-logging-utils": "^1.0.0",
-				"gtoken": "^8.0.0",
+				"gaxios": "^6.1.1",
+				"gcp-metadata": "^6.1.0",
+				"gtoken": "^7.0.0",
 				"jws": "^4.0.0"
 			},
 			"engines": {
-				"node": ">=18"
+				"node": ">=14"
+			}
+		},
+		"node_modules/google-auth-library/node_modules/gaxios": {
+			"version": "6.7.1",
+			"resolved": "https://registry.npmjs.org/gaxios/-/gaxios-6.7.1.tgz",
+			"integrity": "sha512-LDODD4TMYx7XXdpwxAVRAIAuB0bzv0s+ywFonY46k126qzQHT9ygyoa9tncmOiQmmDrik65UYsEkv3lbfqQ3yQ==",
+			"license": "Apache-2.0",
+			"peer": true,
+			"dependencies": {
+				"extend": "^3.0.2",
+				"https-proxy-agent": "^7.0.1",
+				"is-stream": "^2.0.0",
+				"node-fetch": "^2.6.9",
+				"uuid": "^9.0.1"
+			},
+			"engines": {
+				"node": ">=14"
+			}
+		},
+		"node_modules/google-auth-library/node_modules/node-fetch": {
+			"version": "2.7.0",
+			"resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
+			"integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"whatwg-url": "^5.0.0"
+			},
+			"engines": {
+				"node": "4.x || >=6.0.0"
+			},
+			"peerDependencies": {
+				"encoding": "^0.1.0"
+			},
+			"peerDependenciesMeta": {
+				"encoding": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/google-auth-library/node_modules/uuid": {
+			"version": "9.0.1",
+			"resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
+			"integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
+			"funding": [
+				"https://github.com/sponsors/broofa",
+				"https://github.com/sponsors/ctavan"
+			],
+			"license": "MIT",
+			"peer": true,
+			"bin": {
+				"uuid": "dist/bin/uuid"
 			}
 		},
 		"node_modules/google-logging-utils": {
-			"version": "1.1.3",
-			"resolved": "https://registry.npmjs.org/google-logging-utils/-/google-logging-utils-1.1.3.tgz",
-			"integrity": "sha512-eAmLkjDjAFCVXg7A1unxHsLf961m6y17QFqXqAXGj/gVkKFrEICfStRfwUlGNfeCEjNRa32JEWOUTlYXPyyKvA==",
+			"version": "0.0.2",
+			"resolved": "https://registry.npmjs.org/google-logging-utils/-/google-logging-utils-0.0.2.tgz",
+			"integrity": "sha512-NEgUnEcBiP5HrPzufUkBzJOD/Sxsco3rLNo1F1TNf7ieU8ryUzBhqba8r756CjLX7rn3fHl6iLEwPYuqpoKgQQ==",
 			"license": "Apache-2.0",
 			"peer": true,
 			"engines": {
@@ -6981,34 +5306,70 @@
 			"license": "ISC",
 			"peer": true
 		},
-		"node_modules/grammy": {
-			"version": "1.40.0",
-			"resolved": "https://registry.npmjs.org/grammy/-/grammy-1.40.0.tgz",
-			"integrity": "sha512-ssuE7fc1AwqlUxHr931OCVW3fU+oFDjHZGgvIedPKXfTdjXvzP19xifvVGCnPtYVUig1Kz+gwxe4A9M5WdkT4Q==",
-			"license": "MIT",
-			"peer": true,
-			"dependencies": {
-				"@grammyjs/types": "3.24.0",
-				"abort-controller": "^3.0.0",
-				"debug": "^4.4.3",
-				"node-fetch": "^2.7.0"
-			},
-			"engines": {
-				"node": "^12.20.0 || >=14.13.1"
-			}
-		},
 		"node_modules/gtoken": {
-			"version": "8.0.0",
-			"resolved": "https://registry.npmjs.org/gtoken/-/gtoken-8.0.0.tgz",
-			"integrity": "sha512-+CqsMbHPiSTdtSO14O51eMNlrp9N79gmeqmXeouJOhfucAedHw9noVe/n5uJk3tbKE6a+6ZCQg3RPhVhHByAIw==",
+			"version": "7.1.0",
+			"resolved": "https://registry.npmjs.org/gtoken/-/gtoken-7.1.0.tgz",
+			"integrity": "sha512-pCcEwRi+TKpMlxAQObHDQ56KawURgyAf6jtIY046fJ5tIv3zDe/LEIubckAO8fj6JnAxLdmWkUfNyulQ2iKdEw==",
 			"license": "MIT",
 			"peer": true,
 			"dependencies": {
-				"gaxios": "^7.0.0",
+				"gaxios": "^6.0.0",
 				"jws": "^4.0.0"
 			},
 			"engines": {
-				"node": ">=18"
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/gtoken/node_modules/gaxios": {
+			"version": "6.7.1",
+			"resolved": "https://registry.npmjs.org/gaxios/-/gaxios-6.7.1.tgz",
+			"integrity": "sha512-LDODD4TMYx7XXdpwxAVRAIAuB0bzv0s+ywFonY46k126qzQHT9ygyoa9tncmOiQmmDrik65UYsEkv3lbfqQ3yQ==",
+			"license": "Apache-2.0",
+			"peer": true,
+			"dependencies": {
+				"extend": "^3.0.2",
+				"https-proxy-agent": "^7.0.1",
+				"is-stream": "^2.0.0",
+				"node-fetch": "^2.6.9",
+				"uuid": "^9.0.1"
+			},
+			"engines": {
+				"node": ">=14"
+			}
+		},
+		"node_modules/gtoken/node_modules/node-fetch": {
+			"version": "2.7.0",
+			"resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
+			"integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"whatwg-url": "^5.0.0"
+			},
+			"engines": {
+				"node": "4.x || >=6.0.0"
+			},
+			"peerDependencies": {
+				"encoding": "^0.1.0"
+			},
+			"peerDependenciesMeta": {
+				"encoding": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/gtoken/node_modules/uuid": {
+			"version": "9.0.1",
+			"resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
+			"integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
+			"funding": [
+				"https://github.com/sponsors/broofa",
+				"https://github.com/sponsors/ctavan"
+			],
+			"license": "MIT",
+			"peer": true,
+			"bin": {
+				"uuid": "dist/bin/uuid"
 			}
 		},
 		"node_modules/has-flag": {
@@ -7039,6 +5400,7 @@
 			"resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
 			"integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
 			"license": "MIT",
+			"optional": true,
 			"peer": true,
 			"dependencies": {
 				"has-symbols": "^1.0.3"
@@ -7048,26 +5410,6 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/ljharb"
-			}
-		},
-		"node_modules/has-unicode": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
-			"integrity": "sha512-8Rf9Y83NBReMnx0gFzA8JImQACstCYWUplepDa9xprwwtmgEZUF0h/i5xSA625zB/I37EtrswSST6OXxwaaIJQ==",
-			"license": "ISC",
-			"peer": true
-		},
-		"node_modules/hashery": {
-			"version": "1.5.0",
-			"resolved": "https://registry.npmjs.org/hashery/-/hashery-1.5.0.tgz",
-			"integrity": "sha512-nhQ6ExaOIqti2FDWoEMWARUqIKyjr2VcZzXShrI+A3zpeiuPWzx6iPftt44LhP74E5sW36B75N6VHbvRtpvO6Q==",
-			"license": "MIT",
-			"peer": true,
-			"dependencies": {
-				"hookified": "^1.14.0"
-			},
-			"engines": {
-				"node": ">=20"
 			}
 		},
 		"node_modules/hasown": {
@@ -7094,22 +5436,14 @@
 			}
 		},
 		"node_modules/hono": {
-			"version": "4.12.2",
-			"resolved": "https://registry.npmjs.org/hono/-/hono-4.12.2.tgz",
-			"integrity": "sha512-gJnaDHXKDayjt8ue0n8Gs0A007yKXj4Xzb8+cNjZeYsSzzwKc0Lr+OZgYwVfB0pHfUs17EPoLvrOsEaJ9mj+Tg==",
+			"version": "4.12.10",
+			"resolved": "https://registry.npmjs.org/hono/-/hono-4.12.10.tgz",
+			"integrity": "sha512-mx/p18PLy5og9ufies2GOSUqep98Td9q4i/EF6X7yJgAiIopxqdfIO3jbqsi3jRgTgw88jMDEzVKi+V2EF+27w==",
 			"license": "MIT",
-			"optional": true,
 			"peer": true,
 			"engines": {
 				"node": ">=16.9.0"
 			}
-		},
-		"node_modules/hookified": {
-			"version": "1.15.1",
-			"resolved": "https://registry.npmjs.org/hookified/-/hookified-1.15.1.tgz",
-			"integrity": "sha512-MvG/clsADq1GPM2KGo2nyfaWVyn9naPiXrqIe4jYjXNZQt238kWyOGrsyc/DmRAQ+Re6yeo6yX/yoNCG5KAEVg==",
-			"license": "MIT",
-			"peer": true
 		},
 		"node_modules/hosted-git-info": {
 			"version": "9.0.2",
@@ -7268,30 +5602,10 @@
 			"license": "MIT",
 			"peer": true
 		},
-		"node_modules/inflight": {
-			"version": "1.0.6",
-			"resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
-			"integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
-			"deprecated": "This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.",
-			"license": "ISC",
-			"optional": true,
-			"peer": true,
-			"dependencies": {
-				"once": "^1.3.0",
-				"wrappy": "1"
-			}
-		},
 		"node_modules/inherits": {
 			"version": "2.0.4",
 			"resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
 			"integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
-			"license": "ISC",
-			"peer": true
-		},
-		"node_modules/ini": {
-			"version": "1.3.8",
-			"resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
-			"integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
 			"license": "ISC",
 			"peer": true
 		},
@@ -7315,114 +5629,14 @@
 				"node": ">= 10"
 			}
 		},
-		"node_modules/ipull": {
-			"version": "3.9.5",
-			"resolved": "https://registry.npmjs.org/ipull/-/ipull-3.9.5.tgz",
-			"integrity": "sha512-5w/yZB5lXmTfsvNawmvkCjYo4SJNuKQz/av8TC1UiOyfOHyaM+DReqbpU2XpWYfmY+NIUbRRH8PUAWsxaS+IfA==",
-			"license": "MIT",
-			"peer": true,
-			"dependencies": {
-				"@tinyhttp/content-disposition": "^2.2.0",
-				"async-retry": "^1.3.3",
-				"chalk": "^5.3.0",
-				"ci-info": "^4.0.0",
-				"cli-spinners": "^2.9.2",
-				"commander": "^10.0.0",
-				"eventemitter3": "^5.0.1",
-				"filenamify": "^6.0.0",
-				"fs-extra": "^11.1.1",
-				"is-unicode-supported": "^2.0.0",
-				"lifecycle-utils": "^2.0.1",
-				"lodash.debounce": "^4.0.8",
-				"lowdb": "^7.0.1",
-				"pretty-bytes": "^6.1.0",
-				"pretty-ms": "^8.0.0",
-				"sleep-promise": "^9.1.0",
-				"slice-ansi": "^7.1.0",
-				"stdout-update": "^4.0.1",
-				"strip-ansi": "^7.1.0"
-			},
-			"bin": {
-				"ipull": "dist/cli/cli.js"
-			},
-			"engines": {
-				"node": ">=18.0.0"
-			},
-			"funding": {
-				"type": "github",
-				"url": "https://github.com/ido-pluto/ipull?sponsor=1"
-			},
-			"optionalDependencies": {
-				"@reflink/reflink": "^0.1.16"
-			}
-		},
-		"node_modules/ipull/node_modules/lifecycle-utils": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/lifecycle-utils/-/lifecycle-utils-2.1.0.tgz",
-			"integrity": "sha512-AnrXnE2/OF9PHCyFg0RSqsnQTzV991XaZA/buhFDoc58xU7rhSCDgCz/09Lqpsn4MpoPHt7TRAXV1kWZypFVsA==",
-			"license": "MIT",
-			"peer": true
-		},
-		"node_modules/ipull/node_modules/parse-ms": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/parse-ms/-/parse-ms-3.0.0.tgz",
-			"integrity": "sha512-Tpb8Z7r7XbbtBTrM9UhpkzzaMrqA2VXMT3YChzYltwV3P3pM6t8wl7TvpMnSTosz1aQAdVib7kdoys7vYOPerw==",
+		"node_modules/is-network-error": {
+			"version": "1.3.1",
+			"resolved": "https://registry.npmjs.org/is-network-error/-/is-network-error-1.3.1.tgz",
+			"integrity": "sha512-6QCxa49rQbmUWLfk0nuGqzql9U8uaV2H6279bRErPBHe/109hCzsLUBUHfbEtvLIHBd6hyXbgedBSHevm43Edw==",
 			"license": "MIT",
 			"peer": true,
 			"engines": {
-				"node": ">=12"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/ipull/node_modules/pretty-ms": {
-			"version": "8.0.0",
-			"resolved": "https://registry.npmjs.org/pretty-ms/-/pretty-ms-8.0.0.tgz",
-			"integrity": "sha512-ASJqOugUF1bbzI35STMBUpZqdfYKlJugy6JBziGi2EE+AL5JPJGSzvpeVXojxrr0ViUYoToUjb5kjSEGf7Y83Q==",
-			"license": "MIT",
-			"peer": true,
-			"dependencies": {
-				"parse-ms": "^3.0.0"
-			},
-			"engines": {
-				"node": ">=14.16"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/is-electron": {
-			"version": "2.2.2",
-			"resolved": "https://registry.npmjs.org/is-electron/-/is-electron-2.2.2.tgz",
-			"integrity": "sha512-FO/Rhvz5tuw4MCWkpMzHFKWD2LsfHzIb7i6MdPYZ/KW7AlxawyLkqdy+jPZP1WubqEADE3O4FUENlJHDfQASRg==",
-			"license": "MIT",
-			"peer": true
-		},
-		"node_modules/is-fullwidth-code-point": {
-			"version": "5.1.0",
-			"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-5.1.0.tgz",
-			"integrity": "sha512-5XHYaSyiqADb4RnZ1Bdad6cPp8Toise4TzEjcOYDHZkTCbKgiUl7WTUCpNWHuxmDt91wnsZBc9xinNzopv3JMQ==",
-			"license": "MIT",
-			"peer": true,
-			"dependencies": {
-				"get-east-asian-width": "^1.3.1"
-			},
-			"engines": {
-				"node": ">=18"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/is-interactive": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/is-interactive/-/is-interactive-2.0.0.tgz",
-			"integrity": "sha512-qP1vozQRI+BMOPcjFzrjXuQvdak2pHNUMZoeG2eRbiSqyvbEf/wQtEOTOX1guk6E3t36RkaqiSt8A/6YElNxLQ==",
-			"license": "MIT",
-			"peer": true,
-			"engines": {
-				"node": ">=12"
+				"node": ">=16"
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
@@ -7448,19 +5662,6 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
-		"node_modules/is-unicode-supported": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-2.1.0.tgz",
-			"integrity": "sha512-mE00Gnza5EEB3Ds0HfMyllZzbBrmLOX3vfWoj9A9PEnTfratQ/BcaJOuMhnkhjXvb2+FkY3VuHqtAGpTPmglFQ==",
-			"license": "MIT",
-			"peer": true,
-			"engines": {
-				"node": ">=18"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
 		"node_modules/isarray": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
@@ -7469,30 +5670,11 @@
 			"peer": true
 		},
 		"node_modules/isexe": {
-			"version": "3.1.5",
-			"resolved": "https://registry.npmjs.org/isexe/-/isexe-3.1.5.tgz",
-			"integrity": "sha512-6B3tLtFqtQS4ekarvLVMZ+X+VlvQekbe4taUkf/rhVO3d/h0M2rfARm/pXLcPEsjjMsFgrFgSrhQIxcSVrBz8w==",
-			"license": "BlueOak-1.0.0",
-			"peer": true,
-			"engines": {
-				"node": ">=18"
-			}
-		},
-		"node_modules/jackspeak": {
-			"version": "3.4.3",
-			"resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-3.4.3.tgz",
-			"integrity": "sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==",
-			"license": "BlueOak-1.0.0",
-			"peer": true,
-			"dependencies": {
-				"@isaacs/cliui": "^8.0.2"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/isaacs"
-			},
-			"optionalDependencies": {
-				"@pkgjs/parseargs": "^0.11.0"
-			}
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+			"integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+			"license": "ISC",
+			"peer": true
 		},
 		"node_modules/jiti": {
 			"version": "2.6.1",
@@ -7502,6 +5684,16 @@
 			"peer": true,
 			"bin": {
 				"jiti": "lib/jiti-cli.mjs"
+			}
+		},
+		"node_modules/jose": {
+			"version": "6.2.2",
+			"resolved": "https://registry.npmjs.org/jose/-/jose-6.2.2.tgz",
+			"integrity": "sha512-d7kPDd34KO/YnzaDOlikGpOurfF0ByC2sEV4cANCtdqLlTfBlw2p14O/5d/zv40gJPbIQxfES3nSx1/oYNyuZQ==",
+			"license": "MIT",
+			"peer": true,
+			"funding": {
+				"url": "https://github.com/sponsors/panva"
 			}
 		},
 		"node_modules/json-bigint": {
@@ -7535,11 +5727,11 @@
 			"license": "MIT",
 			"peer": true
 		},
-		"node_modules/json-with-bigint": {
-			"version": "3.5.3",
-			"resolved": "https://registry.npmjs.org/json-with-bigint/-/json-with-bigint-3.5.3.tgz",
-			"integrity": "sha512-QObKu6nxy7NsxqR0VK4rkXnsNr5L9ElJaGEg+ucJ6J7/suoKZ0n+p76cu9aCqowytxEbwYNzvrMerfMkXneF5A==",
-			"license": "MIT",
+		"node_modules/json-schema-typed": {
+			"version": "8.0.2",
+			"resolved": "https://registry.npmjs.org/json-schema-typed/-/json-schema-typed-8.0.2.tgz",
+			"integrity": "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==",
+			"license": "BSD-2-Clause",
 			"peer": true
 		},
 		"node_modules/json5": {
@@ -7553,42 +5745,6 @@
 			},
 			"engines": {
 				"node": ">=6"
-			}
-		},
-		"node_modules/jsonfile": {
-			"version": "6.2.0",
-			"resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.2.0.tgz",
-			"integrity": "sha512-FGuPw30AdOIUTRMC2OMRtQV+jkVj2cfPqSeWXv1NEAJ1qZ5zb1X6z1mFhbfOB/iy3ssJCD+3KuZ8r8C3uVFlAg==",
-			"license": "MIT",
-			"peer": true,
-			"dependencies": {
-				"universalify": "^2.0.0"
-			},
-			"optionalDependencies": {
-				"graceful-fs": "^4.1.6"
-			}
-		},
-		"node_modules/jsonwebtoken": {
-			"version": "9.0.3",
-			"resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-9.0.3.tgz",
-			"integrity": "sha512-MT/xP0CrubFRNLNKvxJ2BYfy53Zkm++5bX9dtuPbqAeQpTVe0MQTFhao8+Cp//EmJp244xt6Drw/GVEGCUj40g==",
-			"license": "MIT",
-			"peer": true,
-			"dependencies": {
-				"jws": "^4.0.1",
-				"lodash.includes": "^4.3.0",
-				"lodash.isboolean": "^3.0.3",
-				"lodash.isinteger": "^4.0.4",
-				"lodash.isnumber": "^3.0.3",
-				"lodash.isplainobject": "^4.0.6",
-				"lodash.isstring": "^4.0.1",
-				"lodash.once": "^4.0.0",
-				"ms": "^2.1.1",
-				"semver": "^7.5.4"
-			},
-			"engines": {
-				"node": ">=12",
-				"npm": ">=6"
 			}
 		},
 		"node_modules/jszip": {
@@ -7660,77 +5816,26 @@
 				"safe-buffer": "^5.0.1"
 			}
 		},
-		"node_modules/keyv": {
-			"version": "5.6.0",
-			"resolved": "https://registry.npmjs.org/keyv/-/keyv-5.6.0.tgz",
-			"integrity": "sha512-CYDD3SOtsHtyXeEORYRx2qBtpDJFjRTGXUtmNEMGyzYOKj1TE3tycdlho7kA1Ufx9OYWZzg52QFBGALTirzDSw==",
+		"node_modules/jwt-decode": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/jwt-decode/-/jwt-decode-4.0.0.tgz",
+			"integrity": "sha512-+KJGIyHgkGuIq3IEBNftfhW/LfWhXUIY6OmyVWjliu5KH1y0fw7VQ8YndE2O4qZdMSd9SqbnC8GOcZEy0Om7sA==",
 			"license": "MIT",
 			"peer": true,
-			"dependencies": {
-				"@keyv/serialize": "^1.1.1"
+			"engines": {
+				"node": ">=18"
 			}
 		},
 		"node_modules/koffi": {
-			"version": "2.15.1",
-			"resolved": "https://registry.npmjs.org/koffi/-/koffi-2.15.1.tgz",
-			"integrity": "sha512-mnc0C0crx/xMSljb5s9QbnLrlFHprioFO1hkXyuSuO/QtbpLDa0l/uM21944UfQunMKmp3/r789DTDxVyyH6aA==",
+			"version": "2.15.5",
+			"resolved": "https://registry.npmjs.org/koffi/-/koffi-2.15.5.tgz",
+			"integrity": "sha512-4/35/oOpnH9tzrpWAC3ObjAERBSe0Q0Dh2NP1eBBPRGpohEj4vFw2+7tej9W9MTExvk0vtF0PjMqIGG4rf6feQ==",
 			"hasInstallScript": true,
 			"license": "MIT",
+			"optional": true,
 			"peer": true,
 			"funding": {
 				"url": "https://liberapay.com/Koromix"
-			}
-		},
-		"node_modules/libsignal": {
-			"name": "@whiskeysockets/libsignal-node",
-			"version": "2.0.1",
-			"resolved": "git+ssh://git@github.com/whiskeysockets/libsignal-node.git#1c30d7d7e76a3b0aa120b04dc6a26f5a12dccf67",
-			"license": "GPL-3.0",
-			"peer": true,
-			"dependencies": {
-				"curve25519-js": "^0.0.4",
-				"protobufjs": "6.8.8"
-			}
-		},
-		"node_modules/libsignal/node_modules/@types/node": {
-			"version": "10.17.60",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.60.tgz",
-			"integrity": "sha512-F0KIgDJfy2nA3zMLmWGKxcH2ZVEtCZXHHdOQs2gSaQ27+lNeEfGxzkIw90aXswATX7AZ33tahPbzy6KAfUreVw==",
-			"license": "MIT",
-			"peer": true
-		},
-		"node_modules/libsignal/node_modules/long": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/long/-/long-4.0.0.tgz",
-			"integrity": "sha512-XsP+KhQif4bjX1kbuSiySJFNAehNxgLb6hPRGJ9QsUr8ajHkuXGdrHmFUTUUXhDwVX2R5bY4JNZEwbUiMhV+MA==",
-			"license": "Apache-2.0",
-			"peer": true
-		},
-		"node_modules/libsignal/node_modules/protobufjs": {
-			"version": "6.8.8",
-			"resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-6.8.8.tgz",
-			"integrity": "sha512-AAmHtD5pXgZfi7GMpllpO3q1Xw1OYldr+dMUlAnffGTAhqkg72WdmSY71uKBF/JuyiKs8psYbtKrhi0ASCD8qw==",
-			"hasInstallScript": true,
-			"license": "BSD-3-Clause",
-			"peer": true,
-			"dependencies": {
-				"@protobufjs/aspromise": "^1.1.2",
-				"@protobufjs/base64": "^1.1.2",
-				"@protobufjs/codegen": "^2.0.4",
-				"@protobufjs/eventemitter": "^1.1.0",
-				"@protobufjs/fetch": "^1.1.0",
-				"@protobufjs/float": "^1.0.2",
-				"@protobufjs/inquire": "^1.1.0",
-				"@protobufjs/path": "^1.1.2",
-				"@protobufjs/pool": "^1.1.0",
-				"@protobufjs/utf8": "^1.1.0",
-				"@types/long": "^4.0.0",
-				"@types/node": "^10.1.0",
-				"long": "^4.0.0"
-			},
-			"bin": {
-				"pbjs": "bin/pbjs",
-				"pbts": "bin/pbts"
 			}
 		},
 		"node_modules/lie": {
@@ -7742,13 +5847,6 @@
 			"dependencies": {
 				"immediate": "~3.0.5"
 			}
-		},
-		"node_modules/lifecycle-utils": {
-			"version": "3.1.1",
-			"resolved": "https://registry.npmjs.org/lifecycle-utils/-/lifecycle-utils-3.1.1.tgz",
-			"integrity": "sha512-gNd3OvhFNjHykJE3uGntz7UuPzWlK9phrIdXxU9Adis0+ExkwnZibfxCJWiWWZ+a6VbKiZrb+9D9hCQWd4vjTg==",
-			"license": "MIT",
-			"peer": true
 		},
 		"node_modules/linkedom": {
 			"version": "0.18.12",
@@ -7785,98 +5883,18 @@
 				"uc.micro": "^2.0.0"
 			}
 		},
-		"node_modules/lodash.debounce": {
-			"version": "4.0.8",
-			"resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-4.0.8.tgz",
-			"integrity": "sha512-FT1yDzDYEoYWhnSGnpE/4Kj1fLZkDFyqRb7fNt6FdYOSxlUWAtp42Eh6Wb0rGIv/m9Bgo7x4GhQbm5Ys4SG5ow==",
-			"license": "MIT",
-			"peer": true
-		},
-		"node_modules/lodash.identity": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/lodash.identity/-/lodash.identity-3.0.0.tgz",
-			"integrity": "sha512-AupTIzdLQxJS5wIYUQlgGyk2XRTfGXA+MCghDHqZk0pzUNYvd3EESS6dkChNauNYVIutcb0dfHw1ri9Q1yPV8Q==",
-			"license": "MIT",
-			"peer": true
-		},
-		"node_modules/lodash.includes": {
-			"version": "4.3.0",
-			"resolved": "https://registry.npmjs.org/lodash.includes/-/lodash.includes-4.3.0.tgz",
-			"integrity": "sha512-W3Bx6mdkRTGtlJISOvVD/lbqjTlPPUDTMnlXZFnVwi9NKJ6tiAk6LVdlhZMm17VZisqhKcgzpO5Wz91PCt5b0w==",
-			"license": "MIT",
-			"peer": true
-		},
-		"node_modules/lodash.isboolean": {
-			"version": "3.0.3",
-			"resolved": "https://registry.npmjs.org/lodash.isboolean/-/lodash.isboolean-3.0.3.tgz",
-			"integrity": "sha512-Bz5mupy2SVbPHURB98VAcw+aHh4vRV5IPNhILUCsOzRmsTmSQ17jIuqopAentWoehktxGd9e/hbIXq980/1QJg==",
-			"license": "MIT",
-			"peer": true
-		},
-		"node_modules/lodash.isinteger": {
-			"version": "4.0.4",
-			"resolved": "https://registry.npmjs.org/lodash.isinteger/-/lodash.isinteger-4.0.4.tgz",
-			"integrity": "sha512-DBwtEWN2caHQ9/imiNeEA5ys1JoRtRfY3d7V9wkqtbycnAmTvRRmbHKDV4a0EYc678/dia0jrte4tjYwVBaZUA==",
-			"license": "MIT",
-			"peer": true
-		},
-		"node_modules/lodash.isnumber": {
-			"version": "3.0.3",
-			"resolved": "https://registry.npmjs.org/lodash.isnumber/-/lodash.isnumber-3.0.3.tgz",
-			"integrity": "sha512-QYqzpfwO3/CWf3XP+Z+tkQsfaLL/EnUlXWVkIk5FUPc4sBdTehEqZONuyRt2P67PXAk+NXmTBcc97zw9t1FQrw==",
-			"license": "MIT",
-			"peer": true
-		},
-		"node_modules/lodash.isplainobject": {
-			"version": "4.0.6",
-			"resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
-			"integrity": "sha512-oSXzaWypCMHkPC3NvBEaPHf0KsA5mvPrOPgQWDsbg8n7orZ290M0BmC/jgRZ4vcJ6DTAhjrsSYgdsW/F+MFOBA==",
-			"license": "MIT",
-			"peer": true
-		},
-		"node_modules/lodash.isstring": {
-			"version": "4.0.1",
-			"resolved": "https://registry.npmjs.org/lodash.isstring/-/lodash.isstring-4.0.1.tgz",
-			"integrity": "sha512-0wJxfxH1wgO3GrbuP+dTTk7op+6L41QCXbGINEmD+ny/G/eCqGzxyCsh7159S+mgDDcoarnBw6PC1PS5+wUGgw==",
-			"license": "MIT",
-			"peer": true
-		},
-		"node_modules/lodash.merge": {
-			"version": "4.6.2",
-			"resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
-			"integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
-			"license": "MIT",
-			"peer": true
-		},
-		"node_modules/lodash.once": {
-			"version": "4.1.1",
-			"resolved": "https://registry.npmjs.org/lodash.once/-/lodash.once-4.1.1.tgz",
-			"integrity": "sha512-Sb487aTOCr9drQVL8pIxOzVhafOjZN9UU54hiN8PU3uAiSV7lx1yYNpbNmex2PK6dSJoNTSJUUswT651yww3Mg==",
-			"license": "MIT",
-			"peer": true
-		},
-		"node_modules/lodash.pickby": {
-			"version": "4.6.0",
-			"resolved": "https://registry.npmjs.org/lodash.pickby/-/lodash.pickby-4.6.0.tgz",
-			"integrity": "sha512-AZV+GsS/6ckvPOVQPXSiFFacKvKB4kOQu6ynt9wz0F3LO4R9Ij4K1ddYsIytDpSgLz88JHd9P+oaLeej5/Sl7Q==",
-			"license": "MIT",
-			"peer": true
-		},
-		"node_modules/log-symbols": {
-			"version": "7.0.1",
-			"resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-7.0.1.tgz",
-			"integrity": "sha512-ja1E3yCr9i/0hmBVaM0bfwDjnGy8I/s6PP4DFp+yP+a+mrHO4Rm7DtmnqROTUkHIkqffC84YY7AeqX6oFk0WFg==",
+		"node_modules/loglevel": {
+			"version": "1.9.2",
+			"resolved": "https://registry.npmjs.org/loglevel/-/loglevel-1.9.2.tgz",
+			"integrity": "sha512-HgMmCqIJSAKqo68l0rS2AanEWfkxaZ5wNiEFb5ggm08lDs9Xl2KxBlX3PTcaD2chBM1gXAYf491/M2Rv8Jwayg==",
 			"license": "MIT",
 			"peer": true,
-			"dependencies": {
-				"is-unicode-supported": "^2.0.0",
-				"yoctocolors": "^2.1.1"
-			},
 			"engines": {
-				"node": ">=18"
+				"node": ">= 0.6.0"
 			},
 			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
+				"type": "tidelift",
+				"url": "https://tidelift.com/funding/github/npm/loglevel"
 			}
 		},
 		"node_modules/long": {
@@ -7886,58 +5904,14 @@
 			"license": "Apache-2.0",
 			"peer": true
 		},
-		"node_modules/lowdb": {
-			"version": "7.0.1",
-			"resolved": "https://registry.npmjs.org/lowdb/-/lowdb-7.0.1.tgz",
-			"integrity": "sha512-neJAj8GwF0e8EpycYIDFqEPcx9Qz4GUho20jWFR7YiFeXzF1YMLdxB36PypcTSPMA+4+LvgyMacYhlr18Zlymw==",
-			"license": "MIT",
-			"peer": true,
-			"dependencies": {
-				"steno": "^4.0.2"
-			},
-			"engines": {
-				"node": ">=18"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/typicode"
-			}
-		},
 		"node_modules/lru-cache": {
-			"version": "11.2.6",
-			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.2.6.tgz",
-			"integrity": "sha512-ESL2CrkS/2wTPfuend7Zhkzo2u0daGJ/A2VucJOgQ/C48S/zB8MMeMHSGKYpXhIjbPxfuezITkaBH1wqv00DDQ==",
+			"version": "11.3.2",
+			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.3.2.tgz",
+			"integrity": "sha512-wgWa6FWQ3QRRJbIjbsldRJZxdxYngT/dO0I5Ynmlnin8qy7tC6xYzbcJjtN4wHLXtkbVwHzk0C+OejVw1XM+DQ==",
 			"license": "BlueOak-1.0.0",
 			"peer": true,
 			"engines": {
 				"node": "20 || >=22"
-			}
-		},
-		"node_modules/make-dir": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.1.0.tgz",
-			"integrity": "sha512-g3FeP20LNwhALb/6Cz6Dd4F2ngze0jz7tbzrD2wAV+o9FeNHe4rL+yK2md0J/fiSf1sa1ADhXqi5+oVwOM/eGw==",
-			"license": "MIT",
-			"optional": true,
-			"peer": true,
-			"dependencies": {
-				"semver": "^6.0.0"
-			},
-			"engines": {
-				"node": ">=8"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/make-dir/node_modules/semver": {
-			"version": "6.3.1",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
-			"integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
-			"license": "ISC",
-			"optional": true,
-			"peer": true,
-			"bin": {
-				"semver": "bin/semver.js"
 			}
 		},
 		"node_modules/markdown-it": {
@@ -7981,6 +5955,66 @@
 				"node": ">= 0.4"
 			}
 		},
+		"node_modules/matrix-events-sdk": {
+			"version": "0.0.1",
+			"resolved": "https://registry.npmjs.org/matrix-events-sdk/-/matrix-events-sdk-0.0.1.tgz",
+			"integrity": "sha512-1QEOsXO+bhyCroIe2/A5OwaxHvBm7EsSQ46DEDn8RBIfQwN5HWBpFvyWWR4QY0KHPPnnJdI99wgRiAl7Ad5qaA==",
+			"license": "Apache-2.0",
+			"peer": true
+		},
+		"node_modules/matrix-js-sdk": {
+			"version": "41.3.0-rc.0",
+			"resolved": "https://registry.npmjs.org/matrix-js-sdk/-/matrix-js-sdk-41.3.0-rc.0.tgz",
+			"integrity": "sha512-HTGqU6ZWAB9Dl3U9wUQDbk0aq77a6JFVdATTRX3Yy9eLytcK3RSLI6bPwFBrKgV2qRz+gy7bfsqXVDWTXng7jA==",
+			"license": "Apache-2.0",
+			"peer": true,
+			"dependencies": {
+				"@babel/runtime": "^7.12.5",
+				"@matrix-org/matrix-sdk-crypto-wasm": "^18.0.0",
+				"another-json": "^0.2.0",
+				"bs58": "^6.0.0",
+				"content-type": "^1.0.4",
+				"jwt-decode": "^4.0.0",
+				"loglevel": "^1.9.2",
+				"matrix-events-sdk": "0.0.1",
+				"matrix-widget-api": "^1.16.1",
+				"oidc-client-ts": "^3.0.1",
+				"p-retry": "7",
+				"sdp-transform": "^3.0.0",
+				"unhomoglyph": "^1.0.6",
+				"uuid": "13"
+			},
+			"engines": {
+				"node": ">=22.0.0"
+			}
+		},
+		"node_modules/matrix-js-sdk/node_modules/p-retry": {
+			"version": "7.1.1",
+			"resolved": "https://registry.npmjs.org/p-retry/-/p-retry-7.1.1.tgz",
+			"integrity": "sha512-J5ApzjyRkkf601HpEeykoiCvzHQjWxPAHhyjFcEUP2SWq0+35NKh8TLhpLw+Dkq5TZBFvUM6UigdE9hIVYTl5w==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"is-network-error": "^1.1.0"
+			},
+			"engines": {
+				"node": ">=20"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/matrix-widget-api": {
+			"version": "1.17.0",
+			"resolved": "https://registry.npmjs.org/matrix-widget-api/-/matrix-widget-api-1.17.0.tgz",
+			"integrity": "sha512-5FHoo3iEP3Bdlv5jsYPWOqj+pGdFQNLWnJLiB0V7Ygne7bb+Gsj3ibyFyHWC6BVw+Z+tSW4ljHpO17I9TwStwQ==",
+			"license": "Apache-2.0",
+			"peer": true,
+			"dependencies": {
+				"@types/events": "^3.0.0",
+				"events": "^3.2.0"
+			}
+		},
 		"node_modules/mdurl": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/mdurl/-/mdurl-2.0.0.tgz",
@@ -7996,16 +6030,6 @@
 			"peer": true,
 			"engines": {
 				"node": ">= 0.8"
-			}
-		},
-		"node_modules/memory-stream": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/memory-stream/-/memory-stream-1.0.0.tgz",
-			"integrity": "sha512-Wm13VcsPIMdG96dzILfij09PvuS3APtcKNh7M28FsCA/w6+1mjR7hhPmfFNoilX9xU7wTdhsH5lJAm6XNzdtww==",
-			"license": "MIT",
-			"peer": true,
-			"dependencies": {
-				"readable-stream": "^3.4.0"
 			}
 		},
 		"node_modules/merge-descriptors": {
@@ -8026,6 +6050,7 @@
 			"resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
 			"integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
 			"license": "MIT",
+			"optional": true,
 			"peer": true,
 			"engines": {
 				"node": ">= 0.6"
@@ -8036,6 +6061,7 @@
 			"resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
 			"integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
 			"license": "MIT",
+			"optional": true,
 			"peer": true,
 			"dependencies": {
 				"mime-db": "1.52.0"
@@ -8044,43 +6070,20 @@
 				"node": ">= 0.6"
 			}
 		},
-		"node_modules/mimic-function": {
-			"version": "5.0.1",
-			"resolved": "https://registry.npmjs.org/mimic-function/-/mimic-function-5.0.1.tgz",
-			"integrity": "sha512-VP79XUPxV2CigYP3jWwAUFSku2aKqBH7uTAapFWCBqutsbmDo96KY5o8uh6U+/YSIn5OxJnXp73beVkpqMIGhA==",
-			"license": "MIT",
-			"peer": true,
-			"engines": {
-				"node": ">=18"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
 		"node_modules/minimatch": {
-			"version": "10.2.2",
-			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.2.tgz",
-			"integrity": "sha512-+G4CpNBxa5MprY+04MbgOw1v7So6n5JY166pFi9KfYwT78fxScCeSNQSNzp6dpPSW2rONOps6Ocam1wFhCgoVw==",
+			"version": "10.2.5",
+			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
+			"integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
 			"license": "BlueOak-1.0.0",
 			"peer": true,
 			"dependencies": {
-				"brace-expansion": "^5.0.2"
+				"brace-expansion": "^5.0.5"
 			},
 			"engines": {
 				"node": "18 || 20 || >=22"
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/isaacs"
-			}
-		},
-		"node_modules/minimist": {
-			"version": "1.2.8",
-			"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
-			"integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
-			"license": "MIT",
-			"peer": true,
-			"funding": {
-				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
 		"node_modules/minipass": {
@@ -8094,43 +6097,27 @@
 			}
 		},
 		"node_modules/minizlib": {
-			"version": "2.1.2",
-			"resolved": "https://registry.npmjs.org/minizlib/-/minizlib-2.1.2.tgz",
-			"integrity": "sha512-bAxsR8BVfj60DWXHE3u30oHzfl4G7khkSuPW+qvpd7jFRHm7dLxOjUk1EHACJ/hxLY8phGJ0YhYHZo7jil7Qdg==",
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/minizlib/-/minizlib-3.1.0.tgz",
+			"integrity": "sha512-KZxYo1BUkWD2TVFLr0MQoM8vUUigWD3LlD83a/75BqC+4qE0Hb1Vo5v1FgcfaNXvfXzr+5EhQ6ing/CaBijTlw==",
 			"license": "MIT",
 			"peer": true,
 			"dependencies": {
-				"minipass": "^3.0.0",
-				"yallist": "^4.0.0"
+				"minipass": "^7.1.2"
 			},
 			"engines": {
-				"node": ">= 8"
+				"node": ">= 18"
 			}
 		},
-		"node_modules/minizlib/node_modules/minipass": {
-			"version": "3.3.6",
-			"resolved": "https://registry.npmjs.org/minipass/-/minipass-3.3.6.tgz",
-			"integrity": "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==",
-			"license": "ISC",
-			"peer": true,
-			"dependencies": {
-				"yallist": "^4.0.0"
-			},
-			"engines": {
-				"node": ">=8"
-			}
-		},
-		"node_modules/mkdirp": {
-			"version": "1.0.4",
-			"resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
-			"integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
+		"node_modules/mri": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/mri/-/mri-1.2.0.tgz",
+			"integrity": "sha512-tzzskb3bG8LvYGFF/mDTpq3jpI6Q9wc3LEmBaghu+DdCssd1FakN7Bc0hVNmEyGq1bq3RgfkCb3cmQLpNPOroA==",
 			"license": "MIT",
+			"optional": true,
 			"peer": true,
-			"bin": {
-				"mkdirp": "bin/cmd.js"
-			},
 			"engines": {
-				"node": ">=10"
+				"node": ">=4"
 			}
 		},
 		"node_modules/ms": {
@@ -8139,38 +6126,6 @@
 			"integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
 			"license": "MIT",
 			"peer": true
-		},
-		"node_modules/music-metadata": {
-			"version": "11.12.1",
-			"resolved": "https://registry.npmjs.org/music-metadata/-/music-metadata-11.12.1.tgz",
-			"integrity": "sha512-j++ltLxHDb5VCXET9FzQ8bnueiLHwQKgCO7vcbkRH/3F7fRjPkv6qncGEJ47yFhmemcYtgvsOAlcQ1dRBTkDjg==",
-			"funding": [
-				{
-					"type": "github",
-					"url": "https://github.com/sponsors/Borewit"
-				},
-				{
-					"type": "buymeacoffee",
-					"url": "https://buymeacoffee.com/borewit"
-				}
-			],
-			"license": "MIT",
-			"peer": true,
-			"dependencies": {
-				"@borewit/text-codec": "^0.2.1",
-				"@tokenizer/token": "^0.3.0",
-				"content-type": "^1.0.5",
-				"debug": "^4.4.3",
-				"file-type": "^21.3.0",
-				"media-typer": "^1.1.0",
-				"strtok3": "^10.3.4",
-				"token-types": "^6.1.2",
-				"uint8array-extras": "^1.5.0",
-				"win-guid": "^0.2.1"
-			},
-			"engines": {
-				"node": ">=18"
-			}
 		},
 		"node_modules/mz": {
 			"version": "2.7.0",
@@ -8184,25 +6139,6 @@
 				"thenify-all": "^1.0.0"
 			}
 		},
-		"node_modules/nanoid": {
-			"version": "5.1.6",
-			"resolved": "https://registry.npmjs.org/nanoid/-/nanoid-5.1.6.tgz",
-			"integrity": "sha512-c7+7RQ+dMB5dPwwCp4ee1/iV/q2P6aK1mTZcfr1BTuVlyW9hJYiMPybJCcnBlQtuSmTIWNeazm/zqNoZSSElBg==",
-			"funding": [
-				{
-					"type": "github",
-					"url": "https://github.com/sponsors/ai"
-				}
-			],
-			"license": "MIT",
-			"peer": true,
-			"bin": {
-				"nanoid": "bin/nanoid.js"
-			},
-			"engines": {
-				"node": "^18 || >=20"
-			}
-		},
 		"node_modules/negotiator": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz",
@@ -8214,31 +6150,14 @@
 			}
 		},
 		"node_modules/netmask": {
-			"version": "2.0.2",
-			"resolved": "https://registry.npmjs.org/netmask/-/netmask-2.0.2.tgz",
-			"integrity": "sha512-dBpDMdxv9Irdq66304OLfEmQ9tbNRFnFTuZiLo+bD+r332bBmMJ8GBLXklIXXgxd3+v9+KUnZaUR5PJMa75Gsg==",
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/netmask/-/netmask-2.1.0.tgz",
+			"integrity": "sha512-z9sZrk6wyf8/NDKKqe+Tyl58XtgkYrV4kgt1O8xrzYvpl1LvPacPo0imMLHfpStk3kgCIq1ksJ2bmJn9hue2lQ==",
 			"license": "MIT",
 			"peer": true,
 			"engines": {
 				"node": ">= 0.4.0"
 			}
-		},
-		"node_modules/node-addon-api": {
-			"version": "8.5.0",
-			"resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-8.5.0.tgz",
-			"integrity": "sha512-/bRZty2mXUIFY/xU5HLvveNHlswNJej+RnxBjOMkidWfwZzgTbPG1E3K5TOxRLOR+5hX7bSofy8yf1hZevMS8A==",
-			"license": "MIT",
-			"peer": true,
-			"engines": {
-				"node": "^18 || ^20 || >= 21"
-			}
-		},
-		"node_modules/node-api-headers": {
-			"version": "1.8.0",
-			"resolved": "https://registry.npmjs.org/node-api-headers/-/node-api-headers-1.8.0.tgz",
-			"integrity": "sha512-jfnmiKWjRAGbdD1yQS28bknFM1tbHC1oucyuMPjmkEs+kpiu76aRs40WlTmBmyEgzDM76ge1DQ7XJ3R5deiVjQ==",
-			"license": "MIT",
-			"peer": true
 		},
 		"node_modules/node-domexception": {
 			"version": "1.0.0",
@@ -8261,6 +6180,20 @@
 				"node": ">=10.5.0"
 			}
 		},
+		"node_modules/node-downloader-helper": {
+			"version": "2.1.11",
+			"resolved": "https://registry.npmjs.org/node-downloader-helper/-/node-downloader-helper-2.1.11.tgz",
+			"integrity": "sha512-882fH2C9AWdiPCwz/2beq5t8FGMZK9Dx8TJUOIxzMCbvG7XUKM5BuJwN5f0NKo4SCQK6jR4p2TPm54mYGdGchQ==",
+			"license": "MIT",
+			"optional": true,
+			"peer": true,
+			"bin": {
+				"ndh": "bin/ndh"
+			},
+			"engines": {
+				"node": ">=14.18"
+			}
+		},
 		"node_modules/node-edge-tts": {
 			"version": "1.2.10",
 			"resolved": "https://registry.npmjs.org/node-edge-tts/-/node-edge-tts-1.2.10.tgz",
@@ -8277,97 +6210,22 @@
 			}
 		},
 		"node_modules/node-fetch": {
-			"version": "2.7.0",
-			"resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
-			"integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
+			"version": "3.3.2",
+			"resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.3.2.tgz",
+			"integrity": "sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==",
 			"license": "MIT",
 			"peer": true,
 			"dependencies": {
-				"whatwg-url": "^5.0.0"
+				"data-uri-to-buffer": "^4.0.0",
+				"fetch-blob": "^3.1.4",
+				"formdata-polyfill": "^4.0.10"
 			},
 			"engines": {
-				"node": "4.x || >=6.0.0"
-			},
-			"peerDependencies": {
-				"encoding": "^0.1.0"
-			},
-			"peerDependenciesMeta": {
-				"encoding": {
-					"optional": true
-				}
-			}
-		},
-		"node_modules/node-llama-cpp": {
-			"version": "3.15.1",
-			"resolved": "https://registry.npmjs.org/node-llama-cpp/-/node-llama-cpp-3.15.1.tgz",
-			"integrity": "sha512-/fBNkuLGR2Q8xj2eeV12KXKZ9vCS2+o6aP11lW40pB9H6f0B3wOALi/liFrjhHukAoiH6C9wFTPzv6039+5DRA==",
-			"hasInstallScript": true,
-			"license": "MIT",
-			"peer": true,
-			"dependencies": {
-				"@huggingface/jinja": "^0.5.3",
-				"async-retry": "^1.3.3",
-				"bytes": "^3.1.2",
-				"chalk": "^5.4.1",
-				"chmodrp": "^1.0.2",
-				"cmake-js": "^7.4.0",
-				"cross-spawn": "^7.0.6",
-				"env-var": "^7.5.0",
-				"filenamify": "^6.0.0",
-				"fs-extra": "^11.3.0",
-				"ignore": "^7.0.4",
-				"ipull": "^3.9.2",
-				"is-unicode-supported": "^2.1.0",
-				"lifecycle-utils": "^3.0.1",
-				"log-symbols": "^7.0.0",
-				"nanoid": "^5.1.5",
-				"node-addon-api": "^8.3.1",
-				"octokit": "^5.0.3",
-				"ora": "^8.2.0",
-				"pretty-ms": "^9.2.0",
-				"proper-lockfile": "^4.1.2",
-				"semver": "^7.7.1",
-				"simple-git": "^3.27.0",
-				"slice-ansi": "^7.1.0",
-				"stdout-update": "^4.0.1",
-				"strip-ansi": "^7.1.0",
-				"validate-npm-package-name": "^6.0.0",
-				"which": "^5.0.0",
-				"yargs": "^17.7.2"
-			},
-			"bin": {
-				"nlc": "dist/cli/cli.js",
-				"node-llama-cpp": "dist/cli/cli.js"
-			},
-			"engines": {
-				"node": ">=20.0.0"
+				"node": "^12.20.0 || ^14.13.1 || >=16.0.0"
 			},
 			"funding": {
-				"type": "github",
-				"url": "https://github.com/sponsors/giladgd"
-			},
-			"optionalDependencies": {
-				"@node-llama-cpp/linux-arm64": "3.15.1",
-				"@node-llama-cpp/linux-armv7l": "3.15.1",
-				"@node-llama-cpp/linux-x64": "3.15.1",
-				"@node-llama-cpp/linux-x64-cuda": "3.15.1",
-				"@node-llama-cpp/linux-x64-cuda-ext": "3.15.1",
-				"@node-llama-cpp/linux-x64-vulkan": "3.15.1",
-				"@node-llama-cpp/mac-arm64-metal": "3.15.1",
-				"@node-llama-cpp/mac-x64": "3.15.1",
-				"@node-llama-cpp/win-arm64": "3.15.1",
-				"@node-llama-cpp/win-x64": "3.15.1",
-				"@node-llama-cpp/win-x64-cuda": "3.15.1",
-				"@node-llama-cpp/win-x64-cuda-ext": "3.15.1",
-				"@node-llama-cpp/win-x64-vulkan": "3.15.1"
-			},
-			"peerDependencies": {
-				"typescript": ">=5.0.0"
-			},
-			"peerDependenciesMeta": {
-				"typescript": {
-					"optional": true
-				}
+				"type": "opencollective",
+				"url": "https://opencollective.com/node-fetch"
 			}
 		},
 		"node_modules/node-readable-to-web-readable-stream": {
@@ -8377,40 +6235,6 @@
 			"license": "MIT",
 			"optional": true,
 			"peer": true
-		},
-		"node_modules/nopt": {
-			"version": "5.0.0",
-			"resolved": "https://registry.npmjs.org/nopt/-/nopt-5.0.0.tgz",
-			"integrity": "sha512-Tbj67rffqceeLpcRXrT7vKAN8CwfPeIBgM7E6iBkmKLV7bEMwpGgYLGv0jACUsECaa/vuxP0IjEont6umdMgtQ==",
-			"license": "ISC",
-			"optional": true,
-			"peer": true,
-			"dependencies": {
-				"abbrev": "1"
-			},
-			"bin": {
-				"nopt": "bin/nopt.js"
-			},
-			"engines": {
-				"node": ">=6"
-			}
-		},
-		"node_modules/npmlog": {
-			"version": "6.0.2",
-			"resolved": "https://registry.npmjs.org/npmlog/-/npmlog-6.0.2.tgz",
-			"integrity": "sha512-/vBvz5Jfr9dT/aFWd0FIRf+T/Q2WBsLENygUaFUqstqsycmZAP/t5BvFJTK0viFmSUxiUKTUplWy5vt+rvKIxg==",
-			"deprecated": "This package is no longer supported.",
-			"license": "ISC",
-			"peer": true,
-			"dependencies": {
-				"are-we-there-yet": "^3.0.0",
-				"console-control-strings": "^1.1.0",
-				"gauge": "^4.0.3",
-				"set-blocking": "^2.0.0"
-			},
-			"engines": {
-				"node": "^12.13.0 || ^14.15.0 || >=16.0.0"
-			}
 		},
 		"node_modules/nth-check": {
 			"version": "2.1.1",
@@ -8448,37 +6272,17 @@
 				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
-		"node_modules/octokit": {
-			"version": "5.0.5",
-			"resolved": "https://registry.npmjs.org/octokit/-/octokit-5.0.5.tgz",
-			"integrity": "sha512-4+/OFSqOjoyULo7eN7EA97DE0Xydj/PW5aIckxqQIoFjFwqXKuFCvXUJObyJfBF9Khu4RL/jlDRI9FPaMGfPnw==",
-			"license": "MIT",
+		"node_modules/oidc-client-ts": {
+			"version": "3.5.0",
+			"resolved": "https://registry.npmjs.org/oidc-client-ts/-/oidc-client-ts-3.5.0.tgz",
+			"integrity": "sha512-l2q8l9CTCTOlbX+AnK4p3M+4CEpKpyQhle6blQkdFhm0IsBqsxm15bYaSa11G7pWdsYr6epdsRZxJpCyCRbT8A==",
+			"license": "Apache-2.0",
 			"peer": true,
 			"dependencies": {
-				"@octokit/app": "^16.1.2",
-				"@octokit/core": "^7.0.6",
-				"@octokit/oauth-app": "^8.0.3",
-				"@octokit/plugin-paginate-graphql": "^6.0.0",
-				"@octokit/plugin-paginate-rest": "^14.0.0",
-				"@octokit/plugin-rest-endpoint-methods": "^17.0.0",
-				"@octokit/plugin-retry": "^8.0.3",
-				"@octokit/plugin-throttling": "^11.0.3",
-				"@octokit/request-error": "^7.0.2",
-				"@octokit/types": "^16.0.0",
-				"@octokit/webhooks": "^14.0.0"
+				"jwt-decode": "^4.0.0"
 			},
 			"engines": {
-				"node": ">= 20"
-			}
-		},
-		"node_modules/on-exit-leak-free": {
-			"version": "2.1.2",
-			"resolved": "https://registry.npmjs.org/on-exit-leak-free/-/on-exit-leak-free-2.1.2.tgz",
-			"integrity": "sha512-0eJJY6hXLGf1udHwfNftBqH+g73EU4B504nZeKpz1sYRKafAghwxEJunB2O7rDZkL4PGfsMVnTXZ2EjibbqcsA==",
-			"license": "MIT",
-			"peer": true,
-			"engines": {
-				"node": ">=14.0.0"
+				"node": ">=18"
 			}
 		},
 		"node_modules/on-finished": {
@@ -8504,26 +6308,10 @@
 				"wrappy": "1"
 			}
 		},
-		"node_modules/onetime": {
-			"version": "7.0.0",
-			"resolved": "https://registry.npmjs.org/onetime/-/onetime-7.0.0.tgz",
-			"integrity": "sha512-VXJjc87FScF88uafS3JllDgvAm+c/Slfz06lorj2uAY34rlUu0Nt+v8wreiImcrgAjjIHp1rXpTDlLOGw29WwQ==",
-			"license": "MIT",
-			"peer": true,
-			"dependencies": {
-				"mimic-function": "^5.0.0"
-			},
-			"engines": {
-				"node": ">=18"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
 		"node_modules/openai": {
-			"version": "6.10.0",
-			"resolved": "https://registry.npmjs.org/openai/-/openai-6.10.0.tgz",
-			"integrity": "sha512-ITxOGo7rO3XRMiKA5l7tQ43iNNu+iXGFAcf2t+aWVzzqRaS0i7m1K2BhxNdaveB+5eENhO0VY1FkiZzhBk4v3A==",
+			"version": "6.26.0",
+			"resolved": "https://registry.npmjs.org/openai/-/openai-6.26.0.tgz",
+			"integrity": "sha512-zd23dbWTjiJ6sSAX6s0HrCZi41JwTA1bQVs0wLQPZ2/5o2gxOJA5wh7yOAUgwYybfhDXyhwlpeQf7Mlgx8EOCA==",
 			"license": "Apache-2.0",
 			"peer": true,
 			"bin": {
@@ -8543,44 +6331,41 @@
 			}
 		},
 		"node_modules/openclaw": {
-			"version": "2026.2.22",
-			"resolved": "https://registry.npmjs.org/openclaw/-/openclaw-2026.2.22.tgz",
-			"integrity": "sha512-Bd+0qKfXL5sjzxnyjAVywIkGgl5riY2HOqWUA829+VRIih3TRLYOVXaO7rHb9getXR5jSWwiLliNloPXzcrfxw==",
+			"version": "2026.4.5",
+			"resolved": "https://registry.npmjs.org/openclaw/-/openclaw-2026.4.5.tgz",
+			"integrity": "sha512-/yebPOLx2gk15qd+aNcEzfYRqyfsd0VfMqus+v0dEQNw9KLlB4/1N5YKq9JXJPdhjrmAIj2Qa0yfdzhx5B6F2w==",
+			"hasInstallScript": true,
 			"license": "MIT",
 			"peer": true,
 			"dependencies": {
-				"@agentclientprotocol/sdk": "0.14.1",
-				"@aws-sdk/client-bedrock": "^3.995.0",
-				"@buape/carbon": "0.0.0-beta-20260216184201",
-				"@clack/prompts": "^1.0.1",
-				"@discordjs/voice": "^0.19.0",
-				"@grammyjs/runner": "^2.0.3",
-				"@grammyjs/transformer-throttler": "^1.2.1",
-				"@homebridge/ciao": "^1.3.5",
-				"@larksuiteoapi/node-sdk": "^1.59.0",
+				"@agentclientprotocol/sdk": "0.18.0",
+				"@anthropic-ai/vertex-sdk": "^0.14.4",
+				"@aws-sdk/client-bedrock": "3.1023.0",
+				"@aws-sdk/client-bedrock-runtime": "3.1023.0",
+				"@aws-sdk/credential-provider-node": "3.972.29",
+				"@clack/prompts": "^1.2.0",
+				"@homebridge/ciao": "^1.3.6",
 				"@line/bot-sdk": "^10.6.0",
 				"@lydell/node-pty": "1.2.0-beta.3",
-				"@mariozechner/pi-agent-core": "0.54.1",
-				"@mariozechner/pi-ai": "0.54.1",
-				"@mariozechner/pi-coding-agent": "0.54.1",
-				"@mariozechner/pi-tui": "0.54.1",
+				"@mariozechner/pi-agent-core": "0.65.0",
+				"@mariozechner/pi-ai": "0.65.0",
+				"@mariozechner/pi-coding-agent": "0.65.0",
+				"@mariozechner/pi-tui": "0.65.0",
+				"@matrix-org/matrix-sdk-crypto-wasm": "18.0.0",
+				"@modelcontextprotocol/sdk": "1.29.0",
 				"@mozilla/readability": "^0.6.0",
-				"@sinclair/typebox": "0.34.48",
-				"@slack/bolt": "^4.6.0",
-				"@slack/web-api": "^7.14.1",
-				"@whiskeysockets/baileys": "7.0.0-rc.9",
+				"@sinclair/typebox": "0.34.49",
 				"ajv": "^8.18.0",
 				"chalk": "^5.6.2",
 				"chokidar": "^5.0.0",
 				"cli-highlight": "^2.1.11",
 				"commander": "^14.0.3",
 				"croner": "^10.0.1",
-				"discord-api-types": "^0.38.40",
-				"dotenv": "^17.3.1",
+				"dotenv": "^17.4.0",
 				"express": "^5.2.1",
-				"file-type": "^21.3.0",
-				"grammy": "^1.40.0",
-				"https-proxy-agent": "^7.0.6",
+				"file-type": "22.0.0",
+				"gaxios": "7.1.4",
+				"hono": "4.12.10",
 				"ipaddr.js": "^2.3.0",
 				"jiti": "^2.6.1",
 				"json5": "^2.2.3",
@@ -8588,43 +6373,40 @@
 				"linkedom": "^0.18.12",
 				"long": "^5.3.2",
 				"markdown-it": "^14.1.1",
+				"matrix-js-sdk": "41.3.0-rc.0",
 				"node-edge-tts": "^1.2.10",
-				"opusscript": "^0.0.8",
 				"osc-progress": "^0.3.0",
-				"pdfjs-dist": "^5.4.624",
-				"playwright-core": "1.58.2",
+				"pdfjs-dist": "^5.6.205",
+				"playwright-core": "1.59.1",
 				"qrcode-terminal": "^0.12.0",
 				"sharp": "^0.34.5",
-				"sqlite-vec": "0.1.7-alpha.2",
-				"tar": "7.5.9",
+				"sqlite-vec": "0.1.9",
+				"tar": "7.5.13",
 				"tslog": "^4.10.2",
-				"undici": "^7.22.0",
-				"ws": "^8.19.0",
-				"yaml": "^2.8.2",
+				"undici": "^8.0.1",
+				"uuid": "^13.0.0",
+				"ws": "^8.20.0",
+				"yaml": "^2.8.3",
 				"zod": "^4.3.6"
 			},
 			"bin": {
 				"openclaw": "openclaw.mjs"
 			},
 			"engines": {
-				"node": ">=22.12.0"
+				"node": ">=22.14.0"
 			},
 			"optionalDependencies": {
-				"@discordjs/opus": "^0.10.0"
+				"@matrix-org/matrix-sdk-crypto-nodejs": "^0.4.0",
+				"openshell": "0.1.0"
 			},
 			"peerDependencies": {
 				"@napi-rs/canvas": "^0.1.89",
-				"node-llama-cpp": "3.15.1"
-			}
-		},
-		"node_modules/openclaw/node_modules/chownr": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/chownr/-/chownr-3.0.0.tgz",
-			"integrity": "sha512-+IxzY9BZOQd/XuYPRmrvEVjF/nqj5kgT4kEq7VofrDoM1MxoRjEWkrCC3EtLi59TVawxTAn+orJwFQcrqEN1+g==",
-			"license": "BlueOak-1.0.0",
-			"peer": true,
-			"engines": {
-				"node": ">=18"
+				"node-llama-cpp": "3.18.1"
+			},
+			"peerDependenciesMeta": {
+				"node-llama-cpp": {
+					"optional": true
+				}
 			}
 		},
 		"node_modules/openclaw/node_modules/commander": {
@@ -8637,130 +6419,36 @@
 				"node": ">=20"
 			}
 		},
-		"node_modules/openclaw/node_modules/minizlib": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/minizlib/-/minizlib-3.1.0.tgz",
-			"integrity": "sha512-KZxYo1BUkWD2TVFLr0MQoM8vUUigWD3LlD83a/75BqC+4qE0Hb1Vo5v1FgcfaNXvfXzr+5EhQ6ing/CaBijTlw==",
+		"node_modules/openshell": {
+			"version": "0.1.0",
+			"resolved": "https://registry.npmjs.org/openshell/-/openshell-0.1.0.tgz",
+			"integrity": "sha512-B7jLewH+d73hraWcrSFgNOjvd+frW5JPejkTpqgj2EJBjX/Yk1Y4blgP5pDl4FwrBxfmwsTKR08Uwgrdo+xpSg==",
 			"license": "MIT",
+			"optional": true,
 			"peer": true,
 			"dependencies": {
-				"minipass": "^7.1.2"
+				"dotenv": "^16.5.0",
+				"telegraf": "^4.16.3"
 			},
-			"engines": {
-				"node": ">= 18"
-			}
-		},
-		"node_modules/openclaw/node_modules/tar": {
-			"version": "7.5.9",
-			"resolved": "https://registry.npmjs.org/tar/-/tar-7.5.9.tgz",
-			"integrity": "sha512-BTLcK0xsDh2+PUe9F6c2TlRp4zOOBMTkoQHQIWSIzI0R7KG46uEwq4OPk2W7bZcprBMsuaeFsqwYr7pjh6CuHg==",
-			"license": "BlueOak-1.0.0",
-			"peer": true,
-			"dependencies": {
-				"@isaacs/fs-minipass": "^4.0.0",
-				"chownr": "^3.0.0",
-				"minipass": "^7.1.2",
-				"minizlib": "^3.1.0",
-				"yallist": "^5.0.0"
+			"bin": {
+				"openshell": "bin/openshell.js"
 			},
 			"engines": {
 				"node": ">=18"
 			}
 		},
-		"node_modules/openclaw/node_modules/yallist": {
-			"version": "5.0.0",
-			"resolved": "https://registry.npmjs.org/yallist/-/yallist-5.0.0.tgz",
-			"integrity": "sha512-YgvUTfwqyc7UXVMrB+SImsVYSmTS8X/tSrtdNZMImM+n7+QTriRXyXim0mBrTXNeqzVF0KWGgHPeiyViFFrNDw==",
-			"license": "BlueOak-1.0.0",
-			"peer": true,
-			"engines": {
-				"node": ">=18"
-			}
-		},
-		"node_modules/opusscript": {
-			"version": "0.0.8",
-			"resolved": "https://registry.npmjs.org/opusscript/-/opusscript-0.0.8.tgz",
-			"integrity": "sha512-VSTi1aWFuCkRCVq+tx/BQ5q9fMnQ9pVZ3JU4UHKqTkf0ED3fKEPdr+gKAAl3IA2hj9rrP6iyq3hlcJq3HELtNQ==",
-			"license": "MIT",
-			"peer": true
-		},
-		"node_modules/ora": {
-			"version": "8.2.0",
-			"resolved": "https://registry.npmjs.org/ora/-/ora-8.2.0.tgz",
-			"integrity": "sha512-weP+BZ8MVNnlCm8c0Qdc1WSWq4Qn7I+9CJGm7Qali6g44e/PUzbjNqJX5NJ9ljlNMosfJvg1fKEGILklK9cwnw==",
-			"license": "MIT",
-			"peer": true,
-			"dependencies": {
-				"chalk": "^5.3.0",
-				"cli-cursor": "^5.0.0",
-				"cli-spinners": "^2.9.2",
-				"is-interactive": "^2.0.0",
-				"is-unicode-supported": "^2.0.0",
-				"log-symbols": "^6.0.0",
-				"stdin-discarder": "^0.2.2",
-				"string-width": "^7.2.0",
-				"strip-ansi": "^7.1.0"
-			},
-			"engines": {
-				"node": ">=18"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/ora/node_modules/emoji-regex": {
-			"version": "10.6.0",
-			"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.6.0.tgz",
-			"integrity": "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==",
-			"license": "MIT",
-			"peer": true
-		},
-		"node_modules/ora/node_modules/log-symbols": {
-			"version": "6.0.0",
-			"resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-6.0.0.tgz",
-			"integrity": "sha512-i24m8rpwhmPIS4zscNzK6MSEhk0DUWa/8iYQWxhffV8jkI4Phvs3F+quL5xvS0gdQR0FyTCMMH33Y78dDTzzIw==",
-			"license": "MIT",
-			"peer": true,
-			"dependencies": {
-				"chalk": "^5.3.0",
-				"is-unicode-supported": "^1.3.0"
-			},
-			"engines": {
-				"node": ">=18"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/ora/node_modules/log-symbols/node_modules/is-unicode-supported": {
-			"version": "1.3.0",
-			"resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-1.3.0.tgz",
-			"integrity": "sha512-43r2mRvz+8JRIKnWJ+3j8JtjRKZ6GmjzfaE/qiBJnikNnYv/6bagRJ1kUhNk8R5EX/GkobD+r+sfxCPJsiKBLQ==",
-			"license": "MIT",
+		"node_modules/openshell/node_modules/dotenv": {
+			"version": "16.6.1",
+			"resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.6.1.tgz",
+			"integrity": "sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow==",
+			"license": "BSD-2-Clause",
+			"optional": true,
 			"peer": true,
 			"engines": {
 				"node": ">=12"
 			},
 			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/ora/node_modules/string-width": {
-			"version": "7.2.0",
-			"resolved": "https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz",
-			"integrity": "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==",
-			"license": "MIT",
-			"peer": true,
-			"dependencies": {
-				"emoji-regex": "^10.3.0",
-				"get-east-asian-width": "^1.0.0",
-				"strip-ansi": "^7.1.0"
-			},
-			"engines": {
-				"node": ">=18"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
+				"url": "https://dotenvx.com"
 			}
 		},
 		"node_modules/osc-progress": {
@@ -8772,40 +6460,6 @@
 			"engines": {
 				"node": ">=20"
 			}
-		},
-		"node_modules/p-finally": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
-			"integrity": "sha512-LICb2p9CB7FS+0eR1oqWnHhp0FljGLZCWBE9aix0Uye9W8LTQPwMTYVGWQWIw9RdQiDg4+epXQODwIYJtSJaow==",
-			"license": "MIT",
-			"peer": true,
-			"engines": {
-				"node": ">=4"
-			}
-		},
-		"node_modules/p-queue": {
-			"version": "6.6.2",
-			"resolved": "https://registry.npmjs.org/p-queue/-/p-queue-6.6.2.tgz",
-			"integrity": "sha512-RwFpb72c/BhQLEXIZ5K2e+AhgNVmIejGlTgiB9MzZ0e93GRvqZ7uSi0dvRF7/XIXDeNkra2fNHBxTyPDGySpjQ==",
-			"license": "MIT",
-			"peer": true,
-			"dependencies": {
-				"eventemitter3": "^4.0.4",
-				"p-timeout": "^3.2.0"
-			},
-			"engines": {
-				"node": ">=8"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/p-queue/node_modules/eventemitter3": {
-			"version": "4.0.7",
-			"resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.7.tgz",
-			"integrity": "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==",
-			"license": "MIT",
-			"peer": true
 		},
 		"node_modules/p-retry": {
 			"version": "4.6.2",
@@ -8822,16 +6476,14 @@
 			}
 		},
 		"node_modules/p-timeout": {
-			"version": "3.2.0",
-			"resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-3.2.0.tgz",
-			"integrity": "sha512-rhIwUycgwwKcP9yTOOFK/AKsAopjjCakVqLHePO3CC6Mir1Z99xT+R63jZxAT5lFZLa2inS5h+ZS2GvR99/FBg==",
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-4.1.0.tgz",
+			"integrity": "sha512-+/wmHtzJuWii1sXn3HCuH/FTwGhrp4tmJTxSKJbfS+vkipci6osxXM5mY0jUiRzWKMTgUT8l7HFbeSwZAynqHw==",
 			"license": "MIT",
+			"optional": true,
 			"peer": true,
-			"dependencies": {
-				"p-finally": "^1.0.0"
-			},
 			"engines": {
-				"node": ">=8"
+				"node": ">=10"
 			}
 		},
 		"node_modules/pac-proxy-agent": {
@@ -8868,32 +6520,12 @@
 				"node": ">= 14"
 			}
 		},
-		"node_modules/package-json-from-dist": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz",
-			"integrity": "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==",
-			"license": "BlueOak-1.0.0",
-			"peer": true
-		},
 		"node_modules/pako": {
 			"version": "1.0.11",
 			"resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
 			"integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==",
 			"license": "(MIT AND Zlib)",
 			"peer": true
-		},
-		"node_modules/parse-ms": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/parse-ms/-/parse-ms-4.0.0.tgz",
-			"integrity": "sha512-TXfryirbmq34y8QBwgqCVLi+8oA3oWx2eAnSn62ITyEhEYaWRlVZ2DvMM9eZbMs/RfxPu/PK/aBLyGj4IrqMHw==",
-			"license": "MIT",
-			"peer": true,
-			"engines": {
-				"node": ">=18"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
 		},
 		"node_modules/parse5": {
 			"version": "5.1.1",
@@ -8936,15 +6568,20 @@
 			"license": "MIT",
 			"peer": true
 		},
-		"node_modules/path-is-absolute": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-			"integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==",
+		"node_modules/path-expression-matcher": {
+			"version": "1.4.0",
+			"resolved": "https://registry.npmjs.org/path-expression-matcher/-/path-expression-matcher-1.4.0.tgz",
+			"integrity": "sha512-s4DQMxIdhj3jLFWd9LxHOplj4p9yQ4ffMGowFf3cpEgrrJjEhN0V5nxw4Ye1EViAGDoL4/1AeO6qHpqYPOzE4Q==",
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/NaturalIntelligence"
+				}
+			],
 			"license": "MIT",
-			"optional": true,
 			"peer": true,
 			"engines": {
-				"node": ">=0.10.0"
+				"node": ">=14.0.0"
 			}
 		},
 		"node_modules/path-key": {
@@ -8975,9 +6612,9 @@
 			}
 		},
 		"node_modules/path-to-regexp": {
-			"version": "8.3.0",
-			"resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.3.0.tgz",
-			"integrity": "sha512-7jdwVIRtsP8MYpdXSwOS0YdD0Du+qOoF/AEPIt88PcCFrZCzx41oxku1jD88hZBwbNUIEfpqvuhjFaMAqMTWnA==",
+			"version": "8.4.2",
+			"resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.4.2.tgz",
+			"integrity": "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==",
 			"license": "MIT",
 			"peer": true,
 			"funding": {
@@ -8986,70 +6623,40 @@
 			}
 		},
 		"node_modules/pdfjs-dist": {
-			"version": "5.4.624",
-			"resolved": "https://registry.npmjs.org/pdfjs-dist/-/pdfjs-dist-5.4.624.tgz",
-			"integrity": "sha512-sm6TxKTtWv1Oh6n3C6J6a8odejb5uO4A4zo/2dgkHuC0iu8ZMAXOezEODkVaoVp8nX1Xzr+0WxFJJmUr45hQzg==",
+			"version": "5.6.205",
+			"resolved": "https://registry.npmjs.org/pdfjs-dist/-/pdfjs-dist-5.6.205.tgz",
+			"integrity": "sha512-tlUj+2IDa7G1SbvBNN74UHRLJybZDWYom+k6p5KIZl7huBvsA4APi6mKL+zCxd3tLjN5hOOEE9Tv7VdzO88pfg==",
 			"license": "Apache-2.0",
 			"peer": true,
 			"engines": {
-				"node": ">=20.16.0 || >=22.3.0"
+				"node": ">=20.19.0 || >=22.13.0 || >=24"
 			},
 			"optionalDependencies": {
-				"@napi-rs/canvas": "^0.1.88",
+				"@napi-rs/canvas": "^0.1.96",
 				"node-readable-to-web-readable-stream": "^0.4.2"
 			}
 		},
-		"node_modules/picocolors": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
-			"integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
-			"license": "ISC",
-			"peer": true
-		},
-		"node_modules/pino": {
-			"version": "9.14.0",
-			"resolved": "https://registry.npmjs.org/pino/-/pino-9.14.0.tgz",
-			"integrity": "sha512-8OEwKp5juEvb/MjpIc4hjqfgCNysrS94RIOMXYvpYCdm/jglrKEiAYmiumbmGhCvs+IcInsphYDFwqrjr7398w==",
-			"license": "MIT",
-			"peer": true,
-			"dependencies": {
-				"@pinojs/redact": "^0.4.0",
-				"atomic-sleep": "^1.0.0",
-				"on-exit-leak-free": "^2.1.0",
-				"pino-abstract-transport": "^2.0.0",
-				"pino-std-serializers": "^7.0.0",
-				"process-warning": "^5.0.0",
-				"quick-format-unescaped": "^4.0.3",
-				"real-require": "^0.2.0",
-				"safe-stable-stringify": "^2.3.1",
-				"sonic-boom": "^4.0.1",
-				"thread-stream": "^3.0.0"
-			},
-			"bin": {
-				"pino": "bin.js"
-			}
-		},
-		"node_modules/pino-abstract-transport": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/pino-abstract-transport/-/pino-abstract-transport-2.0.0.tgz",
-			"integrity": "sha512-F63x5tizV6WCh4R6RHyi2Ml+M70DNRXt/+HANowMflpgGFMAym/VKm6G7ZOQRjqN7XbGxK1Lg9t6ZrtzOaivMw==",
-			"license": "MIT",
-			"peer": true,
-			"dependencies": {
-				"split2": "^4.0.0"
-			}
-		},
-		"node_modules/pino-std-serializers": {
-			"version": "7.1.0",
-			"resolved": "https://registry.npmjs.org/pino-std-serializers/-/pino-std-serializers-7.1.0.tgz",
-			"integrity": "sha512-BndPH67/JxGExRgiX1dX0w1FvZck5Wa4aal9198SrRhZjH3GxKQUKIBnYJTdj2HDN3UQAS06HlfcSbQj2OHmaw==",
+		"node_modules/pend": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
+			"integrity": "sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg==",
 			"license": "MIT",
 			"peer": true
+		},
+		"node_modules/pkce-challenge": {
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/pkce-challenge/-/pkce-challenge-5.0.1.tgz",
+			"integrity": "sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==",
+			"license": "MIT",
+			"peer": true,
+			"engines": {
+				"node": ">=16.20.0"
+			}
 		},
 		"node_modules/playwright-core": {
-			"version": "1.58.2",
-			"resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.58.2.tgz",
-			"integrity": "sha512-yZkEtftgwS8CsfYo7nm0KE8jsvm6i/PTgVtB8DL726wNf6H2IMsDuxCpJj59KDaxCtSnrWan2AeDqM7JBaultg==",
+			"version": "1.59.1",
+			"resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.59.1.tgz",
+			"integrity": "sha512-HBV/RJg81z5BiiZ9yPzIiClYV/QMsDCKUyogwH9p3MCP6IYjUFu/MActgYAvK0oWyV9NlwM3GLBjADyWgydVyg==",
 			"license": "Apache-2.0",
 			"peer": true,
 			"bin": {
@@ -9059,83 +6666,10 @@
 				"node": ">=18"
 			}
 		},
-		"node_modules/pretty-bytes": {
-			"version": "6.1.1",
-			"resolved": "https://registry.npmjs.org/pretty-bytes/-/pretty-bytes-6.1.1.tgz",
-			"integrity": "sha512-mQUvGU6aUFQ+rNvTIAcZuWGRT9a6f6Yrg9bHs4ImKF+HZCEK+plBvnAZYSIQztknZF2qnzNtr6F8s0+IuptdlQ==",
-			"license": "MIT",
-			"peer": true,
-			"engines": {
-				"node": "^14.13.1 || >=16.0.0"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/pretty-ms": {
-			"version": "9.3.0",
-			"resolved": "https://registry.npmjs.org/pretty-ms/-/pretty-ms-9.3.0.tgz",
-			"integrity": "sha512-gjVS5hOP+M3wMm5nmNOucbIrqudzs9v/57bWRHQWLYklXqoXKrVfYW2W9+glfGsqtPgpiz5WwyEEB+ksXIx3gQ==",
-			"license": "MIT",
-			"peer": true,
-			"dependencies": {
-				"parse-ms": "^4.0.0"
-			},
-			"engines": {
-				"node": ">=18"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/prism-media": {
-			"version": "1.3.5",
-			"resolved": "https://registry.npmjs.org/prism-media/-/prism-media-1.3.5.tgz",
-			"integrity": "sha512-IQdl0Q01m4LrkN1EGIE9lphov5Hy7WWlH6ulf5QdGePLlPas9p2mhgddTEHrlaXYjjFToM1/rWuwF37VF4taaA==",
-			"license": "Apache-2.0",
-			"peer": true,
-			"peerDependencies": {
-				"@discordjs/opus": ">=0.8.0 <1.0.0",
-				"ffmpeg-static": "^5.0.2 || ^4.2.7 || ^3.0.0 || ^2.4.0",
-				"node-opus": "^0.3.3",
-				"opusscript": "^0.0.8"
-			},
-			"peerDependenciesMeta": {
-				"@discordjs/opus": {
-					"optional": true
-				},
-				"ffmpeg-static": {
-					"optional": true
-				},
-				"node-opus": {
-					"optional": true
-				},
-				"opusscript": {
-					"optional": true
-				}
-			}
-		},
 		"node_modules/process-nextick-args": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
 			"integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
-			"license": "MIT",
-			"peer": true
-		},
-		"node_modules/process-warning": {
-			"version": "5.0.0",
-			"resolved": "https://registry.npmjs.org/process-warning/-/process-warning-5.0.0.tgz",
-			"integrity": "sha512-a39t9ApHNx2L4+HBnQKqxxHNs1r7KF+Intd8Q/g1bUh6q0WIp9voPXJ/x0j+ZL45KF1pJd9+q2jLIRMfvEshkA==",
-			"funding": [
-				{
-					"type": "github",
-					"url": "https://github.com/sponsors/fastify"
-				},
-				{
-					"type": "opencollective",
-					"url": "https://opencollective.com/fastify"
-				}
-			],
 			"license": "MIT",
 			"peer": true
 		},
@@ -9247,6 +6781,17 @@
 			"license": "MIT",
 			"peer": true
 		},
+		"node_modules/pump": {
+			"version": "3.0.4",
+			"resolved": "https://registry.npmjs.org/pump/-/pump-3.0.4.tgz",
+			"integrity": "sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"end-of-stream": "^1.1.0",
+				"once": "^1.3.1"
+			}
+		},
 		"node_modules/punycode.js": {
 			"version": "2.3.1",
 			"resolved": "https://registry.npmjs.org/punycode.js/-/punycode.js-2.3.1.tgz",
@@ -9255,19 +6800,6 @@
 			"peer": true,
 			"engines": {
 				"node": ">=6"
-			}
-		},
-		"node_modules/qified": {
-			"version": "0.6.0",
-			"resolved": "https://registry.npmjs.org/qified/-/qified-0.6.0.tgz",
-			"integrity": "sha512-tsSGN1x3h569ZSU1u6diwhltLyfUWDp3YbFHedapTmpBl0B3P6U3+Qptg7xu+v+1io1EwhdPyyRHYbEw0KN2FA==",
-			"license": "MIT",
-			"peer": true,
-			"dependencies": {
-				"hookified": "^1.14.0"
-			},
-			"engines": {
-				"node": ">=20"
 			}
 		},
 		"node_modules/qrcode-terminal": {
@@ -9295,13 +6827,6 @@
 				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
-		"node_modules/quick-format-unescaped": {
-			"version": "4.0.4",
-			"resolved": "https://registry.npmjs.org/quick-format-unescaped/-/quick-format-unescaped-4.0.4.tgz",
-			"integrity": "sha512-tYC1Q1hgyRuHgloV/YXs2w15unPVh8qfu/qCTfhTYamaw7fyhumKa2yGpdSo87vY32rIclj+4fWYQXUMs9EHvg==",
-			"license": "MIT",
-			"peer": true
-		},
 		"node_modules/range-parser": {
 			"version": "1.2.1",
 			"resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
@@ -9328,37 +6853,6 @@
 				"node": ">= 0.10"
 			}
 		},
-		"node_modules/rc": {
-			"version": "1.2.8",
-			"resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
-			"integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
-			"license": "(BSD-2-Clause OR MIT OR Apache-2.0)",
-			"peer": true,
-			"dependencies": {
-				"deep-extend": "^0.6.0",
-				"ini": "~1.3.0",
-				"minimist": "^1.2.0",
-				"strip-json-comments": "~2.0.1"
-			},
-			"bin": {
-				"rc": "cli.js"
-			}
-		},
-		"node_modules/readable-stream": {
-			"version": "3.6.2",
-			"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
-			"integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
-			"license": "MIT",
-			"peer": true,
-			"dependencies": {
-				"inherits": "^2.0.3",
-				"string_decoder": "^1.1.1",
-				"util-deprecate": "^1.0.1"
-			},
-			"engines": {
-				"node": ">= 6"
-			}
-		},
 		"node_modules/readdirp": {
 			"version": "5.0.0",
 			"resolved": "https://registry.npmjs.org/readdirp/-/readdirp-5.0.0.tgz",
@@ -9371,16 +6865,6 @@
 			"funding": {
 				"type": "individual",
 				"url": "https://paulmillr.com/funding/"
-			}
-		},
-		"node_modules/real-require": {
-			"version": "0.2.0",
-			"resolved": "https://registry.npmjs.org/real-require/-/real-require-0.2.0.tgz",
-			"integrity": "sha512-57frrGM/OCTLqLOAh0mhVA9VBMHd+9U7Zb2THMGdBUoZVOtGbJzjxsYGDJ3A9AYYCP4hn6y1TVbaOfzWtm5GFg==",
-			"license": "MIT",
-			"peer": true,
-			"engines": {
-				"node": ">= 12.13.0"
 			}
 		},
 		"node_modules/require-directory": {
@@ -9403,36 +6887,6 @@
 				"node": ">=0.10.0"
 			}
 		},
-		"node_modules/restore-cursor": {
-			"version": "5.1.0",
-			"resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-5.1.0.tgz",
-			"integrity": "sha512-oMA2dcrw6u0YfxJQXm342bFKX/E4sG9rbTzO9ptUcR/e8A33cHuvStiYOwH7fszkZlZ1z/ta9AAoPk2F4qIOHA==",
-			"license": "MIT",
-			"peer": true,
-			"dependencies": {
-				"onetime": "^7.0.0",
-				"signal-exit": "^4.1.0"
-			},
-			"engines": {
-				"node": ">=18"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/restore-cursor/node_modules/signal-exit": {
-			"version": "4.1.0",
-			"resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
-			"integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
-			"license": "ISC",
-			"peer": true,
-			"engines": {
-				"node": ">=14"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/isaacs"
-			}
-		},
 		"node_modules/retry": {
 			"version": "0.13.1",
 			"resolved": "https://registry.npmjs.org/retry/-/retry-0.13.1.tgz",
@@ -9441,81 +6895,6 @@
 			"peer": true,
 			"engines": {
 				"node": ">= 4"
-			}
-		},
-		"node_modules/rimraf": {
-			"version": "3.0.2",
-			"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
-			"integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
-			"deprecated": "Rimraf versions prior to v4 are no longer supported",
-			"license": "ISC",
-			"optional": true,
-			"peer": true,
-			"dependencies": {
-				"glob": "^7.1.3"
-			},
-			"bin": {
-				"rimraf": "bin.js"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/isaacs"
-			}
-		},
-		"node_modules/rimraf/node_modules/balanced-match": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
-			"integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
-			"license": "MIT",
-			"optional": true,
-			"peer": true
-		},
-		"node_modules/rimraf/node_modules/brace-expansion": {
-			"version": "1.1.12",
-			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-			"integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
-			"license": "MIT",
-			"optional": true,
-			"peer": true,
-			"dependencies": {
-				"balanced-match": "^1.0.0",
-				"concat-map": "0.0.1"
-			}
-		},
-		"node_modules/rimraf/node_modules/glob": {
-			"version": "7.2.3",
-			"resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
-			"integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
-			"deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
-			"license": "ISC",
-			"optional": true,
-			"peer": true,
-			"dependencies": {
-				"fs.realpath": "^1.0.0",
-				"inflight": "^1.0.4",
-				"inherits": "2",
-				"minimatch": "^3.1.1",
-				"once": "^1.3.0",
-				"path-is-absolute": "^1.0.0"
-			},
-			"engines": {
-				"node": "*"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/isaacs"
-			}
-		},
-		"node_modules/rimraf/node_modules/minimatch": {
-			"version": "3.1.3",
-			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.3.tgz",
-			"integrity": "sha512-M2GCs7Vk83NxkUyQV1bkABc4yxgz9kILhHImZiBPAZ9ybuvCb0/H7lEl5XvIg3g+9d4eNotkZA5IWwYl0tibaA==",
-			"license": "ISC",
-			"optional": true,
-			"peer": true,
-			"dependencies": {
-				"brace-expansion": "^1.1.7"
-			},
-			"engines": {
-				"node": "*"
 			}
 		},
 		"node_modules/router": {
@@ -9556,14 +6935,15 @@
 			"license": "MIT",
 			"peer": true
 		},
-		"node_modules/safe-stable-stringify": {
-			"version": "2.5.0",
-			"resolved": "https://registry.npmjs.org/safe-stable-stringify/-/safe-stable-stringify-2.5.0.tgz",
-			"integrity": "sha512-b3rppTKm9T+PsVCBEOUR46GWI7fdOs00VKZ1+9c1EWDaDMvjQc6tUwuFyIprgGgTcWoVHSKrU8H31ZHA2e0RHA==",
+		"node_modules/safe-compare": {
+			"version": "1.1.4",
+			"resolved": "https://registry.npmjs.org/safe-compare/-/safe-compare-1.1.4.tgz",
+			"integrity": "sha512-b9wZ986HHCo/HbKrRpBJb2kqXMK9CEWIE1egeEvZsYn69ay3kdfl9nG3RyOcR+jInTDf7a86WQ1d4VJX7goSSQ==",
 			"license": "MIT",
+			"optional": true,
 			"peer": true,
-			"engines": {
-				"node": ">=10"
+			"dependencies": {
+				"buffer-alloc": "^1.2.0"
 			}
 		},
 		"node_modules/safer-buffer": {
@@ -9572,6 +6952,27 @@
 			"integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
 			"license": "MIT",
 			"peer": true
+		},
+		"node_modules/sandwich-stream": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/sandwich-stream/-/sandwich-stream-2.0.2.tgz",
+			"integrity": "sha512-jLYV0DORrzY3xaz/S9ydJL6Iz7essZeAfnAavsJ+zsJGZ1MOnsS52yRjU3uF3pJa/lla7+wisp//fxOwOH8SKQ==",
+			"license": "Apache-2.0",
+			"optional": true,
+			"peer": true,
+			"engines": {
+				"node": ">= 0.10"
+			}
+		},
+		"node_modules/sdp-transform": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/sdp-transform/-/sdp-transform-3.0.0.tgz",
+			"integrity": "sha512-gfYVRGxjHkGF2NPeUWHw5u6T/KGFtS5/drPms73gaSuMaVHKCY3lpLnGDfswVQO0kddeePoti09AwhYP4zA8dQ==",
+			"license": "MIT",
+			"peer": true,
+			"bin": {
+				"sdp-verify": "checker.js"
+			}
 		},
 		"node_modules/semver": {
 			"version": "7.7.4",
@@ -9659,13 +7060,6 @@
 				"type": "opencollective",
 				"url": "https://opencollective.com/express"
 			}
-		},
-		"node_modules/set-blocking": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
-			"integrity": "sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw==",
-			"license": "ISC",
-			"peer": true
 		},
 		"node_modules/setimmediate": {
 			"version": "1.0.5",
@@ -9832,52 +7226,12 @@
 			"license": "ISC",
 			"peer": true
 		},
-		"node_modules/simple-git": {
-			"version": "3.32.2",
-			"resolved": "https://registry.npmjs.org/simple-git/-/simple-git-3.32.2.tgz",
-			"integrity": "sha512-n/jhNmvYh8dwyfR6idSfpXrFazuyd57jwNMzgjGnKZV/1lTh0HKvPq20v4AQ62rP+l19bWjjXPTCdGHMt0AdrQ==",
-			"license": "MIT",
-			"peer": true,
-			"dependencies": {
-				"@kwsites/file-exists": "^1.1.1",
-				"@kwsites/promise-deferred": "^1.1.1",
-				"debug": "^4.4.0"
-			},
-			"funding": {
-				"type": "github",
-				"url": "https://github.com/steveukx/git-js?sponsor=1"
-			}
-		},
 		"node_modules/sisteransi": {
 			"version": "1.0.5",
 			"resolved": "https://registry.npmjs.org/sisteransi/-/sisteransi-1.0.5.tgz",
 			"integrity": "sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==",
 			"license": "MIT",
 			"peer": true
-		},
-		"node_modules/sleep-promise": {
-			"version": "9.1.0",
-			"resolved": "https://registry.npmjs.org/sleep-promise/-/sleep-promise-9.1.0.tgz",
-			"integrity": "sha512-UHYzVpz9Xn8b+jikYSD6bqvf754xL2uBUzDFwiU6NcdZeifPr6UfgU43xpkPu67VMS88+TI2PSI7Eohgqf2fKA==",
-			"license": "MIT",
-			"peer": true
-		},
-		"node_modules/slice-ansi": {
-			"version": "7.1.2",
-			"resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-7.1.2.tgz",
-			"integrity": "sha512-iOBWFgUX7caIZiuutICxVgX1SdxwAVFFKwt1EvMYYec/NWO5meOJ6K5uQxhrYBdQJne4KxiqZc+KptFOWFSI9w==",
-			"license": "MIT",
-			"peer": true,
-			"dependencies": {
-				"ansi-styles": "^6.2.1",
-				"is-fullwidth-code-point": "^5.0.0"
-			},
-			"engines": {
-				"node": ">=18"
-			},
-			"funding": {
-				"url": "https://github.com/chalk/slice-ansi?sponsor=1"
-			}
 		},
 		"node_modules/smart-buffer": {
 			"version": "4.2.0",
@@ -9920,16 +7274,6 @@
 				"node": ">= 14"
 			}
 		},
-		"node_modules/sonic-boom": {
-			"version": "4.2.1",
-			"resolved": "https://registry.npmjs.org/sonic-boom/-/sonic-boom-4.2.1.tgz",
-			"integrity": "sha512-w6AxtubXa2wTXAUsZMMWERrsIRAdrK0Sc+FUytWvYAhBJLyuI4llrMIC1DtlNSdI99EI86KZum2MMq3EAZlF9Q==",
-			"license": "MIT",
-			"peer": true,
-			"dependencies": {
-				"atomic-sleep": "^1.0.0"
-			}
-		},
 		"node_modules/source-map": {
 			"version": "0.6.1",
 			"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
@@ -9951,34 +7295,24 @@
 				"source-map": "^0.6.0"
 			}
 		},
-		"node_modules/split2": {
-			"version": "4.2.0",
-			"resolved": "https://registry.npmjs.org/split2/-/split2-4.2.0.tgz",
-			"integrity": "sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==",
-			"license": "ISC",
-			"peer": true,
-			"engines": {
-				"node": ">= 10.x"
-			}
-		},
 		"node_modules/sqlite-vec": {
-			"version": "0.1.7-alpha.2",
-			"resolved": "https://registry.npmjs.org/sqlite-vec/-/sqlite-vec-0.1.7-alpha.2.tgz",
-			"integrity": "sha512-rNgRCv+4V4Ed3yc33Qr+nNmjhtrMnnHzXfLVPeGb28Dx5mmDL3Ngw/Wk8vhCGjj76+oC6gnkmMG8y73BZWGBwQ==",
+			"version": "0.1.9",
+			"resolved": "https://registry.npmjs.org/sqlite-vec/-/sqlite-vec-0.1.9.tgz",
+			"integrity": "sha512-L7XJWRIBNvR9O5+vh1FQ+IGkh/3D2AzVksW5gdtk28m78Hy8skFD0pqReKH1Yp0/BUKRGcffgKvyO/EON5JXpA==",
 			"license": "MIT OR Apache",
 			"peer": true,
 			"optionalDependencies": {
-				"sqlite-vec-darwin-arm64": "0.1.7-alpha.2",
-				"sqlite-vec-darwin-x64": "0.1.7-alpha.2",
-				"sqlite-vec-linux-arm64": "0.1.7-alpha.2",
-				"sqlite-vec-linux-x64": "0.1.7-alpha.2",
-				"sqlite-vec-windows-x64": "0.1.7-alpha.2"
+				"sqlite-vec-darwin-arm64": "0.1.9",
+				"sqlite-vec-darwin-x64": "0.1.9",
+				"sqlite-vec-linux-arm64": "0.1.9",
+				"sqlite-vec-linux-x64": "0.1.9",
+				"sqlite-vec-windows-x64": "0.1.9"
 			}
 		},
 		"node_modules/sqlite-vec-darwin-arm64": {
-			"version": "0.1.7-alpha.2",
-			"resolved": "https://registry.npmjs.org/sqlite-vec-darwin-arm64/-/sqlite-vec-darwin-arm64-0.1.7-alpha.2.tgz",
-			"integrity": "sha512-raIATOqFYkeCHhb/t3r7W7Cf2lVYdf4J3ogJ6GFc8PQEgHCPEsi+bYnm2JT84MzLfTlSTIdxr4/NKv+zF7oLPw==",
+			"version": "0.1.9",
+			"resolved": "https://registry.npmjs.org/sqlite-vec-darwin-arm64/-/sqlite-vec-darwin-arm64-0.1.9.tgz",
+			"integrity": "sha512-jSsZpE42OfBkGL/ItyJTVCUwl6o6Ka3U5rc4j+UBDIQzC1ulSSKMEhQLthsOnF/MdAf1MuAkYhkdKmmcjaIZQg==",
 			"cpu": [
 				"arm64"
 			],
@@ -9990,9 +7324,9 @@
 			"peer": true
 		},
 		"node_modules/sqlite-vec-darwin-x64": {
-			"version": "0.1.7-alpha.2",
-			"resolved": "https://registry.npmjs.org/sqlite-vec-darwin-x64/-/sqlite-vec-darwin-x64-0.1.7-alpha.2.tgz",
-			"integrity": "sha512-jeZEELsQjjRsVojsvU5iKxOvkaVuE+JYC8Y4Ma8U45aAERrDYmqZoHvgSG7cg1PXL3bMlumFTAmHynf1y4pOzA==",
+			"version": "0.1.9",
+			"resolved": "https://registry.npmjs.org/sqlite-vec-darwin-x64/-/sqlite-vec-darwin-x64-0.1.9.tgz",
+			"integrity": "sha512-KDlVyqQT7pnOhU1ymB9gs7dMbSoVmKHitT+k1/xkjarcX8bBqPxWrGlK/R+C5WmWkfvWwyq5FfXfiBYCBs6PlA==",
 			"cpu": [
 				"x64"
 			],
@@ -10004,9 +7338,9 @@
 			"peer": true
 		},
 		"node_modules/sqlite-vec-linux-arm64": {
-			"version": "0.1.7-alpha.2",
-			"resolved": "https://registry.npmjs.org/sqlite-vec-linux-arm64/-/sqlite-vec-linux-arm64-0.1.7-alpha.2.tgz",
-			"integrity": "sha512-6Spj4Nfi7tG13jsUG+W7jnT0bCTWbyPImu2M8nWp20fNrd1SZ4g3CSlDAK8GBdavX7wRlbBHCZ+BDa++rbDewA==",
+			"version": "0.1.9",
+			"resolved": "https://registry.npmjs.org/sqlite-vec-linux-arm64/-/sqlite-vec-linux-arm64-0.1.9.tgz",
+			"integrity": "sha512-5wXVJ9c9kR4CHm/wVqXb/R+XUHTdpZ4nWbPHlS+gc9qQFVHs92Km4bPnCKX4rtcPMzvNis+SIzMJR1SCEwpuUw==",
 			"cpu": [
 				"arm64"
 			],
@@ -10018,9 +7352,9 @@
 			"peer": true
 		},
 		"node_modules/sqlite-vec-linux-x64": {
-			"version": "0.1.7-alpha.2",
-			"resolved": "https://registry.npmjs.org/sqlite-vec-linux-x64/-/sqlite-vec-linux-x64-0.1.7-alpha.2.tgz",
-			"integrity": "sha512-IcgrbHaDccTVhXDf8Orwdc2+hgDLAFORl6OBUhcvlmwswwBP1hqBTSEhovClG4NItwTOBNgpwOoQ7Qp3VDPWLg==",
+			"version": "0.1.9",
+			"resolved": "https://registry.npmjs.org/sqlite-vec-linux-x64/-/sqlite-vec-linux-x64-0.1.9.tgz",
+			"integrity": "sha512-w3tCH8xK2finW8fQJ/m8uqKodXUZ9KAuAar2UIhz4BHILfpE0WM/MTGCRfa7RjYbrYim5Luk3guvMOGI7T7JQA==",
 			"cpu": [
 				"x64"
 			],
@@ -10032,9 +7366,9 @@
 			"peer": true
 		},
 		"node_modules/sqlite-vec-windows-x64": {
-			"version": "0.1.7-alpha.2",
-			"resolved": "https://registry.npmjs.org/sqlite-vec-windows-x64/-/sqlite-vec-windows-x64-0.1.7-alpha.2.tgz",
-			"integrity": "sha512-TRP6hTjAcwvQ6xpCZvjP00pdlda8J38ArFy1lMYhtQWXiIBmWnhMaMbq4kaeCYwvTTddfidatRS+TJrwIKB/oQ==",
+			"version": "0.1.9",
+			"resolved": "https://registry.npmjs.org/sqlite-vec-windows-x64/-/sqlite-vec-windows-x64-0.1.9.tgz",
+			"integrity": "sha512-y3gEIyy/17bq2QFPQOWLE68TYWcRZkBQVA2XLrTPHNTOp55xJi/BBBmOm40tVMDMjtP+Elpk6UBUXdaq+46b0Q==",
 			"cpu": [
 				"x64"
 			],
@@ -10062,83 +7396,6 @@
 			"license": "MIT",
 			"peer": true
 		},
-		"node_modules/stdin-discarder": {
-			"version": "0.2.2",
-			"resolved": "https://registry.npmjs.org/stdin-discarder/-/stdin-discarder-0.2.2.tgz",
-			"integrity": "sha512-UhDfHmA92YAlNnCfhmq0VeNL5bDbiZGg7sZ2IvPsXubGkiNa9EC+tUTsjBRsYUAz87btI6/1wf4XoVvQ3uRnmQ==",
-			"license": "MIT",
-			"peer": true,
-			"engines": {
-				"node": ">=18"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/stdout-update": {
-			"version": "4.0.1",
-			"resolved": "https://registry.npmjs.org/stdout-update/-/stdout-update-4.0.1.tgz",
-			"integrity": "sha512-wiS21Jthlvl1to+oorePvcyrIkiG/6M3D3VTmDUlJm7Cy6SbFhKkAvX+YBuHLxck/tO3mrdpC/cNesigQc3+UQ==",
-			"license": "MIT",
-			"peer": true,
-			"dependencies": {
-				"ansi-escapes": "^6.2.0",
-				"ansi-styles": "^6.2.1",
-				"string-width": "^7.1.0",
-				"strip-ansi": "^7.1.0"
-			},
-			"engines": {
-				"node": ">=16.0.0"
-			}
-		},
-		"node_modules/stdout-update/node_modules/emoji-regex": {
-			"version": "10.6.0",
-			"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.6.0.tgz",
-			"integrity": "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==",
-			"license": "MIT",
-			"peer": true
-		},
-		"node_modules/stdout-update/node_modules/string-width": {
-			"version": "7.2.0",
-			"resolved": "https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz",
-			"integrity": "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==",
-			"license": "MIT",
-			"peer": true,
-			"dependencies": {
-				"emoji-regex": "^10.3.0",
-				"get-east-asian-width": "^1.0.0",
-				"strip-ansi": "^7.1.0"
-			},
-			"engines": {
-				"node": ">=18"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/steno": {
-			"version": "4.0.2",
-			"resolved": "https://registry.npmjs.org/steno/-/steno-4.0.2.tgz",
-			"integrity": "sha512-yhPIQXjrlt1xv7dyPQg2P17URmXbuM5pdGkpiMB3RenprfiBlvK415Lctfe0eshk90oA7/tNq7WEiMK8RSP39A==",
-			"license": "MIT",
-			"peer": true,
-			"engines": {
-				"node": ">=18"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/typicode"
-			}
-		},
-		"node_modules/string_decoder": {
-			"version": "1.3.0",
-			"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
-			"integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
-			"license": "MIT",
-			"peer": true,
-			"dependencies": {
-				"safe-buffer": "~5.2.0"
-			}
-		},
 		"node_modules/string-width": {
 			"version": "4.2.3",
 			"resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
@@ -10149,55 +7406,6 @@
 				"emoji-regex": "^8.0.0",
 				"is-fullwidth-code-point": "^3.0.0",
 				"strip-ansi": "^6.0.1"
-			},
-			"engines": {
-				"node": ">=8"
-			}
-		},
-		"node_modules/string-width-cjs": {
-			"name": "string-width",
-			"version": "4.2.3",
-			"resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
-			"integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
-			"license": "MIT",
-			"peer": true,
-			"dependencies": {
-				"emoji-regex": "^8.0.0",
-				"is-fullwidth-code-point": "^3.0.0",
-				"strip-ansi": "^6.0.1"
-			},
-			"engines": {
-				"node": ">=8"
-			}
-		},
-		"node_modules/string-width-cjs/node_modules/ansi-regex": {
-			"version": "5.0.1",
-			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
-			"integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
-			"license": "MIT",
-			"peer": true,
-			"engines": {
-				"node": ">=8"
-			}
-		},
-		"node_modules/string-width-cjs/node_modules/is-fullwidth-code-point": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
-			"integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
-			"license": "MIT",
-			"peer": true,
-			"engines": {
-				"node": ">=8"
-			}
-		},
-		"node_modules/string-width-cjs/node_modules/strip-ansi": {
-			"version": "6.0.1",
-			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
-			"integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-			"license": "MIT",
-			"peer": true,
-			"dependencies": {
-				"ansi-regex": "^5.0.1"
 			},
 			"engines": {
 				"node": ">=8"
@@ -10237,13 +7445,13 @@
 			}
 		},
 		"node_modules/strip-ansi": {
-			"version": "7.1.2",
-			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.2.tgz",
-			"integrity": "sha512-gmBGslpoQJtgnMAvOVqGZpEz9dyoKTCzy2nfz/n8aIFhN/jCE/rCmcxabB6jOOHV+0WNnylOxaxBQPSvcWklhA==",
+			"version": "7.2.0",
+			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+			"integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
 			"license": "MIT",
 			"peer": true,
 			"dependencies": {
-				"ansi-regex": "^6.0.1"
+				"ansi-regex": "^6.2.2"
 			},
 			"engines": {
 				"node": ">=12"
@@ -10252,44 +7460,10 @@
 				"url": "https://github.com/chalk/strip-ansi?sponsor=1"
 			}
 		},
-		"node_modules/strip-ansi-cjs": {
-			"name": "strip-ansi",
-			"version": "6.0.1",
-			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
-			"integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-			"license": "MIT",
-			"peer": true,
-			"dependencies": {
-				"ansi-regex": "^5.0.1"
-			},
-			"engines": {
-				"node": ">=8"
-			}
-		},
-		"node_modules/strip-ansi-cjs/node_modules/ansi-regex": {
-			"version": "5.0.1",
-			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
-			"integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
-			"license": "MIT",
-			"peer": true,
-			"engines": {
-				"node": ">=8"
-			}
-		},
-		"node_modules/strip-json-comments": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
-			"integrity": "sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==",
-			"license": "MIT",
-			"peer": true,
-			"engines": {
-				"node": ">=0.10.0"
-			}
-		},
 		"node_modules/strnum": {
-			"version": "2.1.2",
-			"resolved": "https://registry.npmjs.org/strnum/-/strnum-2.1.2.tgz",
-			"integrity": "sha512-l63NF9y/cLROq/yqKXSLtcMeeyOfnSQlfMSlzFt/K73oIaD8DGaQWd7Z34X9GPiKqP5rbSh84Hl4bOlLcjiSrQ==",
+			"version": "2.2.3",
+			"resolved": "https://registry.npmjs.org/strnum/-/strnum-2.2.3.tgz",
+			"integrity": "sha512-oKx6RUCuHfT3oyVjtnrmn19H1SiCqgJSg+54XqURKp5aCMbrXrhLjRN9TjuwMjiYstZ0MzDrHqkGZ5dFTKd+zg==",
 			"funding": [
 				{
 					"type": "github",
@@ -10300,9 +7474,9 @@
 			"peer": true
 		},
 		"node_modules/strtok3": {
-			"version": "10.3.4",
-			"resolved": "https://registry.npmjs.org/strtok3/-/strtok3-10.3.4.tgz",
-			"integrity": "sha512-KIy5nylvC5le1OdaaoCJ07L+8iQzJHGH6pWDuzS+d07Cu7n1MZ2x26P8ZKIWfbK02+XIL8Mp4RkWeqdUCrDMfg==",
+			"version": "10.3.5",
+			"resolved": "https://registry.npmjs.org/strtok3/-/strtok3-10.3.5.tgz",
+			"integrity": "sha512-ki4hZQfh5rX0QDLLkOCj+h+CVNkqmp/CMf8v8kZpkNVK6jGQooMytqzLZYUVYIZcFZ6yDB70EfD8POcFXiF5oA==",
 			"license": "MIT",
 			"peer": true,
 			"dependencies": {
@@ -10330,32 +7504,66 @@
 			}
 		},
 		"node_modules/tar": {
-			"version": "6.2.1",
-			"resolved": "https://registry.npmjs.org/tar/-/tar-6.2.1.tgz",
-			"integrity": "sha512-DZ4yORTwrbTj/7MZYq2w+/ZFdI6OZ/f9SFHR+71gIVUZhOQPHzVCLpvRnPgyaMpfWxxk/4ONva3GQSyNIKRv6A==",
-			"deprecated": "Old versions of tar are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
-			"license": "ISC",
+			"version": "7.5.13",
+			"resolved": "https://registry.npmjs.org/tar/-/tar-7.5.13.tgz",
+			"integrity": "sha512-tOG/7GyXpFevhXVh8jOPJrmtRpOTsYqUIkVdVooZYJS/z8WhfQUX8RJILmeuJNinGAMSu1veBr4asSHFt5/hng==",
+			"license": "BlueOak-1.0.0",
 			"peer": true,
 			"dependencies": {
-				"chownr": "^2.0.0",
-				"fs-minipass": "^2.0.0",
-				"minipass": "^5.0.0",
-				"minizlib": "^2.1.1",
-				"mkdirp": "^1.0.3",
-				"yallist": "^4.0.0"
+				"@isaacs/fs-minipass": "^4.0.0",
+				"chownr": "^3.0.0",
+				"minipass": "^7.1.2",
+				"minizlib": "^3.1.0",
+				"yallist": "^5.0.0"
 			},
 			"engines": {
-				"node": ">=10"
+				"node": ">=18"
 			}
 		},
-		"node_modules/tar/node_modules/minipass": {
-			"version": "5.0.0",
-			"resolved": "https://registry.npmjs.org/minipass/-/minipass-5.0.0.tgz",
-			"integrity": "sha512-3FnjYuehv9k6ovOEbyOswadCDPX1piCfhV8ncmYtHOjuPwylVWsghTLo7rabjC3Rx5xD4HDx8Wm1xnMF7S5qFQ==",
-			"license": "ISC",
+		"node_modules/telegraf": {
+			"version": "4.16.3",
+			"resolved": "https://registry.npmjs.org/telegraf/-/telegraf-4.16.3.tgz",
+			"integrity": "sha512-yjEu2NwkHlXu0OARWoNhJlIjX09dRktiMQFsM678BAH/PEPVwctzL67+tvXqLCRQQvm3SDtki2saGO9hLlz68w==",
+			"license": "MIT",
+			"optional": true,
 			"peer": true,
+			"dependencies": {
+				"@telegraf/types": "^7.1.0",
+				"abort-controller": "^3.0.0",
+				"debug": "^4.3.4",
+				"mri": "^1.2.0",
+				"node-fetch": "^2.7.0",
+				"p-timeout": "^4.1.0",
+				"safe-compare": "^1.1.4",
+				"sandwich-stream": "^2.0.2"
+			},
+			"bin": {
+				"telegraf": "lib/cli.mjs"
+			},
 			"engines": {
-				"node": ">=8"
+				"node": "^12.20.0 || >=14.13.1"
+			}
+		},
+		"node_modules/telegraf/node_modules/node-fetch": {
+			"version": "2.7.0",
+			"resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
+			"integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
+			"license": "MIT",
+			"optional": true,
+			"peer": true,
+			"dependencies": {
+				"whatwg-url": "^5.0.0"
+			},
+			"engines": {
+				"node": "4.x || >=6.0.0"
+			},
+			"peerDependencies": {
+				"encoding": "^0.1.0"
+			},
+			"peerDependenciesMeta": {
+				"encoding": {
+					"optional": true
+				}
 			}
 		},
 		"node_modules/thenify": {
@@ -10379,26 +7587,6 @@
 			},
 			"engines": {
 				"node": ">=0.8"
-			}
-		},
-		"node_modules/thread-stream": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/thread-stream/-/thread-stream-3.1.0.tgz",
-			"integrity": "sha512-OqyPZ9u96VohAyMfJykzmivOrY2wfMSf3C5TtFJVgN+Hm6aj+voFhlK+kZEIv2FBh1X6Xp3DlnCOfEQ3B2J86A==",
-			"license": "MIT",
-			"peer": true,
-			"dependencies": {
-				"real-require": "^0.2.0"
-			}
-		},
-		"node_modules/toad-cache": {
-			"version": "3.7.0",
-			"resolved": "https://registry.npmjs.org/toad-cache/-/toad-cache-3.7.0.tgz",
-			"integrity": "sha512-/m8M+2BJUpoJdgAHoG+baCwBT+tf2VraSfkBgl0Y00qIWt41DJ8R5B8nsEw0I58YwF5IZH6z24/2TobDKnqSWw==",
-			"license": "MIT",
-			"peer": true,
-			"engines": {
-				"node": ">=12"
 			}
 		},
 		"node_modules/toidentifier": {
@@ -10462,16 +7650,6 @@
 			},
 			"funding": {
 				"url": "https://github.com/fullstack-build/tslog?sponsor=1"
-			}
-		},
-		"node_modules/tsscmp": {
-			"version": "1.0.6",
-			"resolved": "https://registry.npmjs.org/tsscmp/-/tsscmp-1.0.6.tgz",
-			"integrity": "sha512-LxhtAkPDTkVCMQjt2h6eBVY28KCjikZqZfMcC15YBeNjkgUpdCfBu5HoiOTDu86v6smE8yOjyEktJ8hlbANHQA==",
-			"license": "MIT",
-			"peer": true,
-			"engines": {
-				"node": ">=0.6.x"
 			}
 		},
 		"node_modules/type-is": {
@@ -10544,13 +7722,13 @@
 			}
 		},
 		"node_modules/undici": {
-			"version": "7.22.0",
-			"resolved": "https://registry.npmjs.org/undici/-/undici-7.22.0.tgz",
-			"integrity": "sha512-RqslV2Us5BrllB+JeiZnK4peryVTndy9Dnqq62S3yYRRTj0tFQCwEniUy2167skdGOy3vqRzEvl1Dm4sV2ReDg==",
+			"version": "8.0.2",
+			"resolved": "https://registry.npmjs.org/undici/-/undici-8.0.2.tgz",
+			"integrity": "sha512-B9MeU5wuFhkFAuNeA19K2GDFcQXZxq33fL0nRy2Aq30wdufZbyyvxW3/ChaeipXVfy/wUweZyzovQGk39+9k2w==",
 			"license": "MIT",
 			"peer": true,
 			"engines": {
-				"node": ">=20.18.1"
+				"node": ">=22.19.0"
 			}
 		},
 		"node_modules/undici-types": {
@@ -10560,29 +7738,12 @@
 			"license": "MIT",
 			"peer": true
 		},
-		"node_modules/universal-github-app-jwt": {
-			"version": "2.2.2",
-			"resolved": "https://registry.npmjs.org/universal-github-app-jwt/-/universal-github-app-jwt-2.2.2.tgz",
-			"integrity": "sha512-dcmbeSrOdTnsjGjUfAlqNDJrhxXizjAz94ija9Qw8YkZ1uu0d+GoZzyH+Jb9tIIqvGsadUfwg+22k5aDqqwzbw==",
+		"node_modules/unhomoglyph": {
+			"version": "1.0.6",
+			"resolved": "https://registry.npmjs.org/unhomoglyph/-/unhomoglyph-1.0.6.tgz",
+			"integrity": "sha512-7uvcWI3hWshSADBu4JpnyYbTVc7YlhF5GDW/oPD5AxIxl34k4wXR3WDkPnzLxkN32LiTCTKMQLtKVZiwki3zGg==",
 			"license": "MIT",
 			"peer": true
-		},
-		"node_modules/universal-user-agent": {
-			"version": "7.0.3",
-			"resolved": "https://registry.npmjs.org/universal-user-agent/-/universal-user-agent-7.0.3.tgz",
-			"integrity": "sha512-TmnEAEAsBJVZM/AADELsK76llnwcf9vMKuPz8JflO1frO8Lchitr0fNaN9d+Ap0BjKtqWqd/J17qeDnXh8CL2A==",
-			"license": "ISC",
-			"peer": true
-		},
-		"node_modules/universalify": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
-			"integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
-			"license": "MIT",
-			"peer": true,
-			"engines": {
-				"node": ">= 10.0.0"
-			}
 		},
 		"node_modules/unpipe": {
 			"version": "1.0.0",
@@ -10594,13 +7755,6 @@
 				"node": ">= 0.8"
 			}
 		},
-		"node_modules/url-join": {
-			"version": "4.0.1",
-			"resolved": "https://registry.npmjs.org/url-join/-/url-join-4.0.1.tgz",
-			"integrity": "sha512-jk1+QP6ZJqyOiuEI9AEWQfju/nB2Pw466kbA0LEZljHwKeMgd9WrAEgEGxjPDD2+TNbbb37rTyhEfrCXfuKXnA==",
-			"license": "MIT",
-			"peer": true
-		},
 		"node_modules/util-deprecate": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
@@ -10608,14 +7762,18 @@
 			"license": "MIT",
 			"peer": true
 		},
-		"node_modules/validate-npm-package-name": {
-			"version": "6.0.2",
-			"resolved": "https://registry.npmjs.org/validate-npm-package-name/-/validate-npm-package-name-6.0.2.tgz",
-			"integrity": "sha512-IUoow1YUtvoBBC06dXs8bR8B9vuA3aJfmQNKMoaPG/OFsPmoQvw8xh+6Ye25Gx9DQhoEom3Pcu9MKHerm/NpUQ==",
-			"license": "ISC",
+		"node_modules/uuid": {
+			"version": "13.0.0",
+			"resolved": "https://registry.npmjs.org/uuid/-/uuid-13.0.0.tgz",
+			"integrity": "sha512-XQegIaBTVUjSHliKqcnFqYypAd4S+WCYt5NIeRs6w/UAry7z8Y9j5ZwRRL4kzq9U3sD6v+85er9FvkEaBpji2w==",
+			"funding": [
+				"https://github.com/sponsors/broofa",
+				"https://github.com/sponsors/ctavan"
+			],
+			"license": "MIT",
 			"peer": true,
-			"engines": {
-				"node": "^18.17.0 || >=20.5.0"
+			"bin": {
+				"uuid": "dist-node/bin/uuid"
 			}
 		},
 		"node_modules/vary": {
@@ -10657,37 +7815,20 @@
 			}
 		},
 		"node_modules/which": {
-			"version": "5.0.0",
-			"resolved": "https://registry.npmjs.org/which/-/which-5.0.0.tgz",
-			"integrity": "sha512-JEdGzHwwkrbWoGOlIHqQ5gtprKGOenpDHpxE9zVR1bWbOtYRyPPHMe9FaP6x61CmNaTThSkb0DAJte5jD+DmzQ==",
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+			"integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
 			"license": "ISC",
 			"peer": true,
 			"dependencies": {
-				"isexe": "^3.1.1"
+				"isexe": "^2.0.0"
 			},
 			"bin": {
-				"node-which": "bin/which.js"
+				"node-which": "bin/node-which"
 			},
 			"engines": {
-				"node": "^18.17.0 || >=20.5.0"
+				"node": ">= 8"
 			}
-		},
-		"node_modules/wide-align": {
-			"version": "1.1.5",
-			"resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.5.tgz",
-			"integrity": "sha512-eDMORYaPNZ4sQIuuYPDHdQvf4gyCF9rEEV/yPxGfwPkRodwEgiMUUXTx/dex+Me0wxx53S+NgUHaP7y3MGlDmg==",
-			"license": "ISC",
-			"peer": true,
-			"dependencies": {
-				"string-width": "^1.0.2 || 2 || 3 || 4"
-			}
-		},
-		"node_modules/win-guid": {
-			"version": "0.2.1",
-			"resolved": "https://registry.npmjs.org/win-guid/-/win-guid-0.2.1.tgz",
-			"integrity": "sha512-gEIQU4mkgl2OPeoNrWflcJFJ3Ae2BPd4eCsHHA/XikslkIVms/nHhvnvzIZV7VLmBvtFlDOzLt9rrZT+n6D67A==",
-			"license": "MIT",
-			"peer": true
 		},
 		"node_modules/wrap-ansi": {
 			"version": "7.0.0",
@@ -10707,64 +7848,6 @@
 				"url": "https://github.com/chalk/wrap-ansi?sponsor=1"
 			}
 		},
-		"node_modules/wrap-ansi-cjs": {
-			"name": "wrap-ansi",
-			"version": "7.0.0",
-			"resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
-			"integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
-			"license": "MIT",
-			"peer": true,
-			"dependencies": {
-				"ansi-styles": "^4.0.0",
-				"string-width": "^4.1.0",
-				"strip-ansi": "^6.0.0"
-			},
-			"engines": {
-				"node": ">=10"
-			},
-			"funding": {
-				"url": "https://github.com/chalk/wrap-ansi?sponsor=1"
-			}
-		},
-		"node_modules/wrap-ansi-cjs/node_modules/ansi-regex": {
-			"version": "5.0.1",
-			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
-			"integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
-			"license": "MIT",
-			"peer": true,
-			"engines": {
-				"node": ">=8"
-			}
-		},
-		"node_modules/wrap-ansi-cjs/node_modules/ansi-styles": {
-			"version": "4.3.0",
-			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-			"integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-			"license": "MIT",
-			"peer": true,
-			"dependencies": {
-				"color-convert": "^2.0.1"
-			},
-			"engines": {
-				"node": ">=8"
-			},
-			"funding": {
-				"url": "https://github.com/chalk/ansi-styles?sponsor=1"
-			}
-		},
-		"node_modules/wrap-ansi-cjs/node_modules/strip-ansi": {
-			"version": "6.0.1",
-			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
-			"integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-			"license": "MIT",
-			"peer": true,
-			"dependencies": {
-				"ansi-regex": "^5.0.1"
-			},
-			"engines": {
-				"node": ">=8"
-			}
-		},
 		"node_modules/wrap-ansi/node_modules/ansi-regex": {
 			"version": "5.0.1",
 			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
@@ -10773,22 +7856,6 @@
 			"peer": true,
 			"engines": {
 				"node": ">=8"
-			}
-		},
-		"node_modules/wrap-ansi/node_modules/ansi-styles": {
-			"version": "4.3.0",
-			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-			"integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-			"license": "MIT",
-			"peer": true,
-			"dependencies": {
-				"color-convert": "^2.0.1"
-			},
-			"engines": {
-				"node": ">=8"
-			},
-			"funding": {
-				"url": "https://github.com/chalk/ansi-styles?sponsor=1"
 			}
 		},
 		"node_modules/wrap-ansi/node_modules/strip-ansi": {
@@ -10812,9 +7879,9 @@
 			"peer": true
 		},
 		"node_modules/ws": {
-			"version": "8.19.0",
-			"resolved": "https://registry.npmjs.org/ws/-/ws-8.19.0.tgz",
-			"integrity": "sha512-blAT2mjOEIi0ZzruJfIhb3nps74PRWTCz1IjglWEEpQl5XS/UNama6u2/rjFkDDouqr4L67ry+1aGIALViWjDg==",
+			"version": "8.20.0",
+			"resolved": "https://registry.npmjs.org/ws/-/ws-8.20.0.tgz",
+			"integrity": "sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==",
 			"license": "MIT",
 			"peer": true,
 			"engines": {
@@ -10844,16 +7911,19 @@
 			}
 		},
 		"node_modules/yallist": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-			"integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-			"license": "ISC",
-			"peer": true
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/yallist/-/yallist-5.0.0.tgz",
+			"integrity": "sha512-YgvUTfwqyc7UXVMrB+SImsVYSmTS8X/tSrtdNZMImM+n7+QTriRXyXim0mBrTXNeqzVF0KWGgHPeiyViFFrNDw==",
+			"license": "BlueOak-1.0.0",
+			"peer": true,
+			"engines": {
+				"node": ">=18"
+			}
 		},
 		"node_modules/yaml": {
-			"version": "2.8.2",
-			"resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.2.tgz",
-			"integrity": "sha512-mplynKqc1C2hTVYxd0PU2xQAc22TI1vShAYGksCCfxbn/dFwnHTNi1bvYsBTkhdUNtGIf5xNOg938rrSSYvS9A==",
+			"version": "2.8.3",
+			"resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.3.tgz",
+			"integrity": "sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg==",
 			"license": "ISC",
 			"peer": true,
 			"bin": {
@@ -10895,6 +7965,17 @@
 				"node": ">=12"
 			}
 		},
+		"node_modules/yauzl": {
+			"version": "2.10.0",
+			"resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.10.0.tgz",
+			"integrity": "sha512-p4a9I6X6nu6IhoGmBqAcbJy1mlC4j27vEPZX9F4L4/vZT3Lyq1VkFHw/V/PUcB9Buo+DG3iHkT0x3Qya58zc3g==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"buffer-crc32": "~0.2.3",
+				"fd-slicer": "~1.1.0"
+			}
+		},
 		"node_modules/yoctocolors": {
 			"version": "2.1.2",
 			"resolved": "https://registry.npmjs.org/yoctocolors/-/yoctocolors-2.1.2.tgz",
@@ -10919,13 +8000,13 @@
 			}
 		},
 		"node_modules/zod-to-json-schema": {
-			"version": "3.25.1",
-			"resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.1.tgz",
-			"integrity": "sha512-pM/SU9d3YAggzi6MtR4h7ruuQlqKtad8e9S0fmxcMi+ueAK5Korys/aWcV9LIIHTVbj01NdzxcnXSN+O74ZIVA==",
+			"version": "3.25.2",
+			"resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.2.tgz",
+			"integrity": "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==",
 			"license": "ISC",
 			"peer": true,
 			"peerDependencies": {
-				"zod": "^3.25 || ^4"
+				"zod": "^3.25.28 || ^4"
 			}
 		}
 	}

--- a/nowledge-mem-openclaw-plugin/package.json
+++ b/nowledge-mem-openclaw-plugin/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@nowledge/openclaw-nowledge-mem",
-	"version": "0.8.0",
+	"version": "0.8.1",
 	"type": "module",
 	"description": "Nowledge Mem memory plugin for OpenClaw, local-first personal knowledge base",
 	"author": {

--- a/nowledge-mem-openclaw-plugin/package.json
+++ b/nowledge-mem-openclaw-plugin/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@nowledge/openclaw-nowledge-mem",
-	"version": "0.7.3",
+	"version": "0.8.0",
 	"type": "module",
 	"description": "Nowledge Mem memory plugin for OpenClaw, local-first personal knowledge base",
 	"author": {
@@ -32,7 +32,7 @@
 		"format": "biome format --write ."
 	},
 	"peerDependencies": {
-		"openclaw": ">=2026.3.7"
+		"openclaw": ">=2026.4.5"
 	},
 	"devDependencies": {
 		"@biomejs/biome": "^1.9.0"

--- a/nowledge-mem-openclaw-plugin/src/client.js
+++ b/nowledge-mem-openclaw-plugin/src/client.js
@@ -396,9 +396,11 @@ export class NowledgeMemClient {
 			eventEnd: m.event_end ?? null,
 			temporalContext: m.temporal_context ?? null,
 			// Thread provenance: links memory to the conversation it was distilled from.
-			// CLI returns `source_thread`, API metadata returns `source_thread_id`.
+			// CLI returns `source_thread` (string), API returns `source_thread: {id, title}` (object).
 			sourceThreadId:
-				m.source_thread ??
+				(typeof m.source_thread === "object" && m.source_thread?.id
+					? String(m.source_thread.id)
+					: typeof m.source_thread === "string" ? m.source_thread : null) ??
 				m.source_thread_id ??
 				m.metadata?.source_thread_id ??
 				null,

--- a/nowledge-mem-openclaw-plugin/src/config.js
+++ b/nowledge-mem-openclaw-plugin/src/config.js
@@ -23,6 +23,9 @@ const ALLOWED_KEYS = new Set([
 	"maxThreadMessageChars",
 	"captureExclude",
 	"captureSkipMarker",
+	"corpusSupplement",
+	"corpusMaxResults",
+	"corpusMinScore",
 	"apiUrl",
 	"apiKey",
 	// Legacy aliases — accepted but not advertised
@@ -197,6 +200,9 @@ function firstDefined(...options) {
  *   NMEM_MAX_CONTEXT_RESULTS   — integer (1-20)
  *   NMEM_RECALL_MIN_SCORE      — integer (0-100)
  *   NMEM_MAX_THREAD_MESSAGE_CHARS — integer (200-20000)
+ *   NMEM_CORPUS_SUPPLEMENT      — true/1/yes to register as MemoryCorpusSupplement
+ *   NMEM_CORPUS_MAX_RESULTS    — integer (1-20)
+ *   NMEM_CORPUS_MIN_SCORE      — integer (0-100)
  *   NMEM_API_URL               — remote server URL
  *   NMEM_API_KEY               — API key (never logged)
  */
@@ -345,6 +351,49 @@ export function parseConfig(raw, logger) {
 	const apiKey = ak.value;
 	_sources.apiKey = ak.source;
 
+	// --- corpusSupplement: file > pluginConfig > env > default ---
+	const cs = firstDefined(
+		{ value: pickBool(resolvedFile, "corpusSupplement"), source: "file" },
+		{
+			value: pickBool(resolvedPlugin, "corpusSupplement"),
+			source: "pluginConfig",
+		},
+		{
+			value: envBool("NMEM_CORPUS_SUPPLEMENT"),
+			source: "env",
+		},
+		{ value: false, source: "default" },
+	);
+	const corpusSupplement = cs.value;
+	_sources.corpusSupplement = cs.source;
+
+	// --- corpusMaxResults: file > pluginConfig > env > default ---
+	const cmr = firstDefined(
+		{ value: pickNum(resolvedFile, "corpusMaxResults"), source: "file" },
+		{
+			value: pickNum(resolvedPlugin, "corpusMaxResults"),
+			source: "pluginConfig",
+		},
+		{ value: envInt("NMEM_CORPUS_MAX_RESULTS"), source: "env" },
+		{ value: 5, source: "default" },
+	);
+	const corpusMaxResults = Math.min(20, Math.max(1, Math.trunc(cmr.value)));
+	_sources.corpusMaxResults = cmr.source;
+
+	// --- corpusMinScore: file > pluginConfig > env > default ---
+	const cmsEnv = envInt("NMEM_CORPUS_MIN_SCORE");
+	const cms = firstDefined(
+		{ value: pickNum(resolvedFile, "corpusMinScore"), source: "file" },
+		{
+			value: pickNum(resolvedPlugin, "corpusMinScore"),
+			source: "pluginConfig",
+		},
+		{ value: cmsEnv, source: "env" },
+		{ value: 0, source: "default" },
+	);
+	const corpusMinScore = Math.min(100, Math.max(0, Math.trunc(cms.value)));
+	_sources.corpusMinScore = cms.source;
+
 	// --- captureExclude: file > pluginConfig > default ---
 	const captureExclude = (() => {
 		const fromFile = Array.isArray(resolvedFile.captureExclude)
@@ -391,6 +440,9 @@ export function parseConfig(raw, logger) {
 		maxThreadMessageChars,
 		captureExclude,
 		captureSkipMarker,
+		corpusSupplement,
+		corpusMaxResults,
+		corpusMinScore,
 		apiUrl,
 		apiKey,
 		_sources,

--- a/nowledge-mem-openclaw-plugin/src/context-engine.js
+++ b/nowledge-mem-openclaw-plugin/src/context-engine.js
@@ -25,6 +25,7 @@ import { BASE_GUIDANCE, SESSION_CONTEXT_GUIDANCE } from "./hooks/behavioral.js";
 import {
 	appendOrCreateThread,
 	hasSkipMarker,
+	isCronCaptureSessionKey,
 	matchesExcludePattern,
 	triageAndDistill,
 } from "./hooks/capture.js";
@@ -350,6 +351,11 @@ export function createNowledgeMemContextEngineFactory(client, cfg, logger) {
 
 				// Normalize sessionKey consistently with hook handlers
 				const normalizedKey = String(sessionKey || sessionId || "");
+
+				if (isCronCaptureSessionKey(normalizedKey)) {
+					logger.debug?.(`ce: skipped cron session ${normalizedKey}`);
+					return;
+				}
 
 				// Capture exclusion: pattern-based and marker-based filters
 				if (matchesExcludePattern(normalizedKey, cfg.captureExclude)) {

--- a/nowledge-mem-openclaw-plugin/src/context-engine.js
+++ b/nowledge-mem-openclaw-plugin/src/context-engine.js
@@ -170,7 +170,7 @@ export function createNowledgeMemContextEngineFactory(client, cfg, logger) {
 			info: {
 				id: "nowledge-mem",
 				name: "Nowledge Mem",
-				version: "0.7.0",
+				version: "0.8.0",
 				ownsCompaction: false,
 			},
 
@@ -235,7 +235,8 @@ export function createNowledgeMemContextEngineFactory(client, cfg, logger) {
 				}
 
 				// 3. Recalled memories (when sessionContext enabled)
-				if (cfg.sessionContext) {
+				// Skipped when corpus supplement handles search-based recall via memory-core.
+				if (cfg.sessionContext && !cfg.corpusSupplement) {
 					const query = buildAssembleSearchQuery(prompt, messages);
 					if (query) {
 						try {

--- a/nowledge-mem-openclaw-plugin/src/corpus-supplement.js
+++ b/nowledge-mem-openclaw-plugin/src/corpus-supplement.js
@@ -1,0 +1,167 @@
+/**
+ * MemoryCorpusSupplement implementation for OpenClaw's memory-core recall pipeline.
+ *
+ * When registered, Nowledge Mem's knowledge graph becomes searchable through
+ * memory-core's native `memory_search` tool and its dreaming promotion pipeline.
+ * This means memories stored in Nowledge Mem participate in OpenClaw's recall
+ * scoring, temporal decay, and short-term-to-long-term promotion — without the
+ * user needing to explicitly call Nowledge Mem tools.
+ *
+ * Enable via config: `corpusSupplement: true`
+ *
+ * Designed to coexist with the plugin's own tools and hooks:
+ * - Working Memory injection: still handled by the recall hook / CE (only we know about WM)
+ * - Search-based recall: handled by this supplement when active, by hooks/CE when not
+ *
+ * Error handling: both search() and get() catch all errors and return [] / null.
+ * Supplement failures must never break OpenClaw's recall pipeline.
+ */
+
+/** Max snippet length in search results (matches memory-search.js truncation). */
+const SNIPPET_MAX_CHARS = 700;
+
+/**
+ * Parse a memory ID from a path or bare ID string.
+ * Handles `nowledgemem://memory/<id>` URIs and bare alphanumeric IDs.
+ */
+function parseMemoryId(pathValue) {
+	const value = String(pathValue || "").trim();
+	if (!value) return null;
+
+	const fromDeeplink = value.match(
+		/^nowledgemem:\/\/memory\/([a-zA-Z0-9_-]+)$/u,
+	);
+	if (fromDeeplink) return fromDeeplink[1];
+
+	if (/^[a-zA-Z0-9_-]{8,}$/u.test(value)) {
+		return value;
+	}
+
+	return null;
+}
+
+/**
+ * Slice lines from text content with 1-based line indexing.
+ */
+function sliceLines(text, from, lines) {
+	const allLines = String(text || "").split(/\r?\n/u);
+	const start = Math.max(1, Math.trunc(Number(from) || 1));
+	const maxLines = Math.max(1, Math.trunc(Number(lines) || allLines.length));
+	const startIdx = start - 1;
+	const endIdx = Math.min(allLines.length, startIdx + maxLines);
+	const selected = allLines.slice(startIdx, endIdx);
+	return {
+		text: selected.join("\n"),
+		startLine: start,
+		endLine: Math.max(start, start + selected.length - 1),
+		totalLines: allLines.length,
+	};
+}
+
+/**
+ * Create a MemoryCorpusSupplement backed by the Nowledge Mem knowledge graph.
+ *
+ * @param {import('./client.js').NowledgeMemClient} client
+ * @param {object} cfg  Parsed plugin config (corpusMaxResults, corpusMinScore)
+ * @param {object} logger
+ * @returns {{ search: Function, get: Function }}
+ */
+export function createNowledgeMemCorpusSupplement(client, cfg, logger) {
+	const maxResults = cfg.corpusMaxResults ?? 5;
+	const minScore = (cfg.corpusMinScore ?? 0) / 100; // config is 0-100, API is 0-1
+
+	return {
+		/**
+		 * Search Nowledge Mem's knowledge graph for memories matching the query.
+		 * Called by memory-core's recall pipeline on every turn.
+		 */
+		async search({ query, maxResults: requestedMax }) {
+			try {
+				const limit = Math.min(20, Math.max(1, requestedMax ?? maxResults));
+				const results = await client.search(query, limit);
+
+				const filtered =
+					minScore > 0
+						? results.filter((r) => (r.score ?? 0) >= minScore)
+						: results;
+
+				return filtered.map((m) => {
+					const snippet = String(m.content || "").slice(0, SNIPPET_MAX_CHARS);
+					const lineCount = Math.max(1, snippet.split(/\r?\n/u).length);
+					const result = {
+						corpus: "nowledge-mem",
+						path: `nowledgemem://memory/${m.id}`,
+						score: Number(m.score ?? 0),
+						snippet,
+						title: m.title || undefined,
+						kind: m.labels?.[0] || undefined,
+						id: m.id,
+						startLine: 1,
+						endLine: lineCount,
+						provenanceLabel: "Nowledge Mem",
+						source: "nowledge-mem",
+						sourceType: "knowledge-graph",
+					};
+					return result;
+				});
+			} catch (err) {
+				logger.warn?.(
+					`corpus-supplement: search failed: ${err instanceof Error ? err.message : err}`,
+				);
+				return [];
+			}
+		},
+
+		/**
+		 * Retrieve a specific memory by path or ID.
+		 * Called when memory-core's agent requests full content for a search result.
+		 */
+		async get({ lookup, fromLine, lineCount }) {
+			try {
+				// Handle Working Memory alias
+				const lowerLookup = String(lookup || "")
+					.trim()
+					.toLowerCase();
+				if (lowerLookup === "memory.md" || lowerLookup === "memory") {
+					const wm = await client.readWorkingMemory();
+					if (!wm.available) return null;
+					const slice = sliceLines(wm.content, fromLine, lineCount);
+					return {
+						corpus: "nowledge-mem",
+						path: "nowledgemem://working-memory",
+						title: "Working Memory",
+						content: slice.text,
+						fromLine: slice.startLine,
+						lineCount: slice.endLine - slice.startLine + 1,
+						provenanceLabel: "Nowledge Mem",
+						sourceType: "working-memory",
+					};
+				}
+
+				const memoryId = parseMemoryId(lookup);
+				if (!memoryId) return null;
+
+				const memory = await client.getMemory(memoryId);
+				if (!memory) return null;
+				const slice = sliceLines(memory.content ?? "", fromLine, lineCount);
+
+				return {
+					corpus: "nowledge-mem",
+					path: `nowledgemem://memory/${memoryId}`,
+					title: memory.title || undefined,
+					content: slice.text,
+					fromLine: slice.startLine,
+					lineCount: slice.endLine - slice.startLine + 1,
+					id: memoryId,
+					provenanceLabel: "Nowledge Mem",
+					sourceType: "knowledge-graph",
+				};
+			} catch (err) {
+				logger.warn?.(
+					`corpus-supplement: get failed: ${err instanceof Error ? err.message : err}`,
+				);
+				return null;
+			}
+		},
+	};
+}

--- a/nowledge-mem-openclaw-plugin/src/hooks/capture.js
+++ b/nowledge-mem-openclaw-plugin/src/hooks/capture.js
@@ -79,6 +79,25 @@ export function matchesExcludePattern(sessionKey, patterns) {
 }
 
 /**
+ * OpenClaw cron / isolated-agent sessions use store keys like
+ * `agent:<agentId>:cron:<jobId...>` (see `toAgentStoreSessionKey` + cron runner).
+ * Some code paths also emit bare `cron:<suffix>` keys (legacy / delivery).
+ *
+ * Mirrors OpenClaw `isCronSessionKey` in sessions/session-key-utils.ts, plus the
+ * bare `cron:` prefix. Always skip thread sync for these — they are automation,
+ * not user dialogue.
+ */
+export function isCronCaptureSessionKey(sessionKey) {
+	const raw = String(sessionKey || "").trim().toLowerCase();
+	if (!raw) return false;
+	if (raw.startsWith("cron:")) return true;
+	const parts = raw.split(":").filter(Boolean);
+	if (parts.length < 3 || parts[0] !== "agent") return false;
+	const rest = parts.slice(2).join(":");
+	return rest.startsWith("cron:");
+}
+
+/**
  * Check if any message contains the skip marker text.
  * Scans both raw message content and nested message objects.
  *
@@ -471,8 +490,13 @@ export function buildAgentEndCaptureHandler(client, cfg, logger) {
 		if (!event?.success) return;
 		if (ctx?.trigger === "heartbeat") return;
 
-		// Layer 1: pattern-based exclusion (e.g. cron jobs, subagent sessions)
 		const sessionKey = String(ctx?.sessionKey || ctx?.sessionId || "");
+		if (isCronCaptureSessionKey(sessionKey)) {
+			logger.debug?.(`capture: skipped cron session ${sessionKey}`);
+			return;
+		}
+
+		// Pattern-based exclusion (e.g. subagent sessions, custom jobs)
 		if (matchesExcludePattern(sessionKey, cfg.captureExclude)) {
 			logger.debug?.(`capture: skipped excluded session ${sessionKey}`);
 			return;
@@ -515,8 +539,12 @@ export function buildBeforeResetCaptureHandler(client, cfg, logger) {
 		if (ceState.active) return;
 		if (ctx?.trigger === "heartbeat") return;
 
-		// Layer 1: pattern-based exclusion
 		const sessionKey = String(ctx?.sessionKey || ctx?.sessionId || "");
+		if (isCronCaptureSessionKey(sessionKey)) {
+			logger.debug?.(`capture: skipped cron session ${sessionKey}`);
+			return;
+		}
+
 		if (matchesExcludePattern(sessionKey, cfg.captureExclude)) {
 			logger.debug?.(`capture: skipped excluded session ${sessionKey}`);
 			return;

--- a/nowledge-mem-openclaw-plugin/src/hooks/capture.js
+++ b/nowledge-mem-openclaw-plugin/src/hooks/capture.js
@@ -1,19 +1,7 @@
 import { createHash } from "node:crypto";
 import { readFile } from "node:fs/promises";
+import { isCronSessionKey } from "openclaw/plugin-sdk/routing";
 import { ceState } from "../ce-state.js";
-
-/**
- * Detect agent-scoped cron session keys (`agent:<id>:cron:...`).
- * Mirrors OpenClaw's internal `isCronSessionKey` (which parses the
- * `agent:<agentId>:<rest>` format and checks if `<rest>` starts with `cron:`).
- * Inlined because `openclaw/plugin-sdk/routing` is not exported in the
- * package's `exports` map (ERR_PACKAGE_PATH_NOT_EXPORTED).
- */
-function isCronSessionKey(sessionKey) {
-	const parts = String(sessionKey ?? "").trim().toLowerCase().split(":").filter(Boolean);
-	if (parts.length < 3 || parts[0] !== "agent") return false;
-	return parts.slice(2).join(":").startsWith("cron:");
-}
 
 export const DEFAULT_MAX_MESSAGE_CHARS = 800;
 export const MAX_DISTILL_MESSAGE_CHARS = 2000;
@@ -94,10 +82,12 @@ export function matchesExcludePattern(sessionKey, patterns) {
 /**
  * Whether automatic thread capture should skip this OpenClaw session.
  *
- * - Agent-scoped cron keys (`agent:<id>:cron:...`) are detected by
- *   `isCronSessionKey` (inlined from OpenClaw's session-key-utils).
- * - Bare `cron:*` keys are also excluded: some internal paths (e.g. delivery /
- *   failure bookkeeping) use that shape without the `agent:` prefix.
+ * - Agent-scoped cron / isolated-agent keys are classified by
+ *   `isCronSessionKey` from `openclaw/plugin-sdk/routing` (same implementation
+ *   the gateway uses). Requires OpenClaw >=2026.3.22.
+ * - Bare `cron:*` keys are still excluded: some internal paths (e.g. delivery /
+ *   failure bookkeeping) use that shape without the `agent:` prefix, and
+ *   `isCronSessionKey` only parses agent-scoped keys.
  */
 export function isCronCaptureSessionKey(sessionKey) {
 	const raw = String(sessionKey || "")

--- a/nowledge-mem-openclaw-plugin/src/hooks/capture.js
+++ b/nowledge-mem-openclaw-plugin/src/hooks/capture.js
@@ -1,5 +1,6 @@
 import { createHash } from "node:crypto";
 import { readFile } from "node:fs/promises";
+import { isCronSessionKey } from "openclaw/plugin-sdk/routing";
 import { ceState } from "../ce-state.js";
 
 export const DEFAULT_MAX_MESSAGE_CHARS = 800;
@@ -79,22 +80,22 @@ export function matchesExcludePattern(sessionKey, patterns) {
 }
 
 /**
- * OpenClaw cron / isolated-agent sessions use store keys like
- * `agent:<agentId>:cron:<jobId...>` (see `toAgentStoreSessionKey` + cron runner).
- * Some code paths also emit bare `cron:<suffix>` keys (legacy / delivery).
+ * Whether automatic thread capture should skip this OpenClaw session.
  *
- * Mirrors OpenClaw `isCronSessionKey` in sessions/session-key-utils.ts, plus the
- * bare `cron:` prefix. Always skip thread sync for these — they are automation,
- * not user dialogue.
+ * - Agent-scoped cron / isolated-agent keys are classified by the host via
+ *   `isCronSessionKey` from `openclaw/plugin-sdk/routing` (same implementation
+ *   the gateway uses). Keeps plugin behavior aligned when OpenClaw evolves key rules.
+ * - Bare `cron:*` keys are still excluded: some internal paths (e.g. delivery /
+ *   failure bookkeeping) use that shape without the `agent:` prefix, and
+ *   `isCronSessionKey` only parses agent-scoped keys.
  */
 export function isCronCaptureSessionKey(sessionKey) {
-	const raw = String(sessionKey || "").trim().toLowerCase();
+	const raw = String(sessionKey || "")
+		.trim()
+		.toLowerCase();
 	if (!raw) return false;
 	if (raw.startsWith("cron:")) return true;
-	const parts = raw.split(":").filter(Boolean);
-	if (parts.length < 3 || parts[0] !== "agent") return false;
-	const rest = parts.slice(2).join(":");
-	return rest.startsWith("cron:");
+	return isCronSessionKey(raw);
 }
 
 /**

--- a/nowledge-mem-openclaw-plugin/src/hooks/capture.js
+++ b/nowledge-mem-openclaw-plugin/src/hooks/capture.js
@@ -1,7 +1,19 @@
 import { createHash } from "node:crypto";
 import { readFile } from "node:fs/promises";
-import { isCronSessionKey } from "openclaw/plugin-sdk/routing";
 import { ceState } from "../ce-state.js";
+
+/**
+ * Detect agent-scoped cron session keys (`agent:<id>:cron:...`).
+ * Mirrors OpenClaw's internal `isCronSessionKey` (which parses the
+ * `agent:<agentId>:<rest>` format and checks if `<rest>` starts with `cron:`).
+ * Inlined because `openclaw/plugin-sdk/routing` is not exported in the
+ * package's `exports` map (ERR_PACKAGE_PATH_NOT_EXPORTED).
+ */
+function isCronSessionKey(sessionKey) {
+	const parts = String(sessionKey ?? "").trim().toLowerCase().split(":").filter(Boolean);
+	if (parts.length < 3 || parts[0] !== "agent") return false;
+	return parts.slice(2).join(":").startsWith("cron:");
+}
 
 export const DEFAULT_MAX_MESSAGE_CHARS = 800;
 export const MAX_DISTILL_MESSAGE_CHARS = 2000;
@@ -82,12 +94,10 @@ export function matchesExcludePattern(sessionKey, patterns) {
 /**
  * Whether automatic thread capture should skip this OpenClaw session.
  *
- * - Agent-scoped cron / isolated-agent keys are classified by the host via
- *   `isCronSessionKey` from `openclaw/plugin-sdk/routing` (same implementation
- *   the gateway uses). Keeps plugin behavior aligned when OpenClaw evolves key rules.
- * - Bare `cron:*` keys are still excluded: some internal paths (e.g. delivery /
- *   failure bookkeeping) use that shape without the `agent:` prefix, and
- *   `isCronSessionKey` only parses agent-scoped keys.
+ * - Agent-scoped cron keys (`agent:<id>:cron:...`) are detected by
+ *   `isCronSessionKey` (inlined from OpenClaw's session-key-utils).
+ * - Bare `cron:*` keys are also excluded: some internal paths (e.g. delivery /
+ *   failure bookkeeping) use that shape without the `agent:` prefix.
  */
 export function isCronCaptureSessionKey(sessionKey) {
 	const raw = String(sessionKey || "")

--- a/nowledge-mem-openclaw-plugin/src/hooks/recall.js
+++ b/nowledge-mem-openclaw-plugin/src/hooks/recall.js
@@ -180,15 +180,18 @@ export function buildRecalledKnowledgeBlock(
 export function buildRecallHandler(client, cfg, logger) {
 	const minScore = (cfg.recallMinScore ?? 0) / 100; // config is 0-100, API is 0-1
 
+	// When corpus supplement is active, memory-core's recall pipeline searches
+	// Nowledge Mem via the supplement. We still inject Working Memory (only we
+	// know about WM), but skip our own search-based recall to avoid duplicates.
+	const skipSearchRecall = cfg.corpusSupplement;
+
 	return async (event) => {
 		if (ceState.active) return;
 
-		const searchQuery = buildSearchQuery(event);
-		if (!searchQuery) return;
-
 		const sections = [];
 
-		// 1. Working Memory — daily context, not a static profile
+		// 1. Working Memory — daily context, not a static profile.
+		// Always injected regardless of search query (WM is independent of user message).
 		try {
 			const wm = await client.readWorkingMemory();
 			if (wm.available) {
@@ -200,22 +203,26 @@ export function buildRecallHandler(client, cfg, logger) {
 			logger.error(`recall: working memory read failed: ${err}`);
 		}
 
-		// 2. Relevant memories — enriched with scoring signals and labels
-		try {
-			const results = await client.searchRich(
-				searchQuery,
-				cfg.maxContextResults,
-			);
-			// Filter by minimum score if configured
-			const filtered =
-				minScore > 0
-					? results.filter((r) => (r.score ?? 0) >= minScore)
-					: results;
-			if (filtered.length > 0) {
-				sections.push(buildRecalledKnowledgeBlock(filtered));
+		// 2. Relevant memories — enriched with scoring signals and labels.
+		// Skipped when corpus supplement handles search-based recall via memory-core.
+		const searchQuery = buildSearchQuery(event);
+		if (!skipSearchRecall && searchQuery) {
+			try {
+				const results = await client.searchRich(
+					searchQuery,
+					cfg.maxContextResults,
+				);
+				// Filter by minimum score if configured
+				const filtered =
+					minScore > 0
+						? results.filter((r) => (r.score ?? 0) >= minScore)
+						: results;
+				if (filtered.length > 0) {
+					sections.push(buildRecalledKnowledgeBlock(filtered));
+				}
+			} catch (err) {
+				logger.error(`recall: search failed: ${err}`);
 			}
-		} catch (err) {
-			logger.error(`recall: search failed: ${err}`);
 		}
 
 		if (sections.length === 0) return;

--- a/nowledge-mem-openclaw-plugin/src/index.js
+++ b/nowledge-mem-openclaw-plugin/src/index.js
@@ -94,9 +94,10 @@ export default {
 					"nowledge-mem: registered as MemoryCorpusSupplement for memory-core recall",
 				);
 			} catch (err) {
-				// OpenClaw < corpus supplement support — degrade gracefully
-				logger.debug?.(
-					`nowledge-mem: corpus supplement registration unavailable (${err})`,
+				// OpenClaw < corpus supplement support — fall back to normal recall
+				cfg.corpusSupplement = false;
+				logger.info?.(
+					`nowledge-mem: corpus supplement unavailable, falling back to normal recall (${err})`,
 				);
 			}
 		}

--- a/nowledge-mem-openclaw-plugin/src/index.js
+++ b/nowledge-mem-openclaw-plugin/src/index.js
@@ -7,6 +7,7 @@ import {
 } from "./commands/slash.js";
 import { isDefaultApiUrl, parseConfig } from "./config.js";
 import { createNowledgeMemContextEngineFactory } from "./context-engine.js";
+import { createNowledgeMemCorpusSupplement } from "./corpus-supplement.js";
 import { buildBehavioralHook } from "./hooks/behavioral.js";
 import {
 	buildAgentEndCaptureHandler,
@@ -80,6 +81,26 @@ export default {
 			);
 		}
 
+		// --- Corpus Supplement (when memory-core is the memory slot) ---
+		// Makes Nowledge Mem's knowledge graph searchable through memory-core's
+		// recall pipeline and dreaming promotion. Memories participate in
+		// temporal decay scoring and short-term-to-long-term promotion.
+		if (cfg.corpusSupplement) {
+			try {
+				api.registerMemoryCorpusSupplement(
+					createNowledgeMemCorpusSupplement(client, cfg, logger),
+				);
+				logger.info(
+					"nowledge-mem: registered as MemoryCorpusSupplement for memory-core recall",
+				);
+			} catch (err) {
+				// OpenClaw < corpus supplement support — degrade gracefully
+				logger.debug?.(
+					`nowledge-mem: corpus supplement registration unavailable (${err})`,
+				);
+			}
+		}
+
 		// --- Hooks (fallback when CE is not active) ---
 		// Each hook checks ceState.active and returns early when the CE handles
 		// the same lifecycle through assemble/afterTurn.
@@ -120,7 +141,7 @@ export default {
 
 		const remoteMode = !isDefaultApiUrl(cfg.apiUrl);
 		logger.info(
-			`nowledge-mem: initialized (context=${cfg.sessionContext}, digest=${cfg.sessionDigest}, mode=${remoteMode ? `remote → ${cfg.apiUrl}` : "local"})`,
+			`nowledge-mem: initialized (context=${cfg.sessionContext}, digest=${cfg.sessionDigest}, corpus=${cfg.corpusSupplement}, mode=${remoteMode ? `remote → ${cfg.apiUrl}` : "local"})`,
 		);
 	},
 };

--- a/nowledge-mem-openclaw-plugin/src/spawn-env.js
+++ b/nowledge-mem-openclaw-plugin/src/spawn-env.js
@@ -7,8 +7,8 @@ const LOCAL_API_URL = "http://127.0.0.1:14242";
  */
 export function buildNmemSpawnEnv({ apiUrl, apiKey } = {}) {
 	const env = { ...process.env };
-	env.NMEM_API_URL = undefined;
-	env.NMEM_API_KEY = undefined;
+	delete env.NMEM_API_URL;
+	delete env.NMEM_API_KEY;
 	if (apiUrl && apiUrl !== LOCAL_API_URL) {
 		env.NMEM_API_URL = apiUrl;
 	}

--- a/nowledge-mem-openclaw-plugin/src/tools/memory-get.js
+++ b/nowledge-mem-openclaw-plugin/src/tools/memory-get.js
@@ -135,9 +135,13 @@ export function createMemoryGetTool(client, logger) {
 					safeParams.lines,
 				);
 
-				// Thread provenance: link to the source conversation
+				// Thread provenance: link to the source conversation.
+				// API returns source_thread as {id, title} object; CLI returns a string.
+				const rawSt = memory.source_thread;
 				const sourceThreadId =
-					memory.source_thread ??
+					(typeof rawSt === "object" && rawSt?.id
+						? String(rawSt.id)
+						: typeof rawSt === "string" ? rawSt : null) ??
 					memory.source_thread_id ??
 					memory.metadata?.source_thread_id ??
 					null;

--- a/nowledge-mem-openclaw-plugin/src/tools/status.js
+++ b/nowledge-mem-openclaw-plugin/src/tools/status.js
@@ -59,19 +59,32 @@ export function createStatusTool(client, _logger, cfg, runtimeInfo = {}) {
 				lines.push(`Plugin trust: ${pluginId} (allowlisted)`);
 			}
 
-			// 0b. Memory slot check — detect misconfiguration early
+			// 0b. Memory slot check — show current mode and options
 			const memorySlot = runtimeInfo.memorySlot;
 			details.memorySlot = memorySlot ?? "(unknown)";
 			if (memorySlot && memorySlot !== "openclaw-nowledge-mem") {
-				lines.push(
-					`⚠ Memory slot: "${memorySlot}" — Nowledge Mem is NOT the active memory plugin.`,
-				);
-				lines.push(
-					"  Only memory_search and memory_get will work. Other tools (save, connections, timeline, etc.) are inactive.",
-				);
-				lines.push(
-					'  Fix: run "openclaw plugins install @nowledge/openclaw-nowledge-mem" or set plugins.slots.memory to "openclaw-nowledge-mem" in your config.',
-				);
+				const corpusOn = cfg.corpusSupplement === true;
+				if (corpusOn) {
+					lines.push(
+						`Memory slot: "${memorySlot}" + corpus supplement active`,
+					);
+					lines.push(
+						"  Nowledge Mem feeds into memory-core's recall and dreaming pipeline. All tools available.",
+					);
+				} else {
+					lines.push(
+						`ℹ Memory slot: "${memorySlot}"`,
+					);
+					lines.push(
+						"  Two options:",
+					);
+					lines.push(
+						'  - Full mode: set plugins.slots.memory to "openclaw-nowledge-mem" for the complete tool surface',
+					);
+					lines.push(
+						"  - Dual mode: set corpusSupplement: true to feed your cross-tool knowledge into memory-core's recall and dreaming",
+					);
+				}
 				lines.push("");
 			} else if (memorySlot === "openclaw-nowledge-mem") {
 				lines.push("Memory slot: openclaw-nowledge-mem (active)");


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Corpus‑supplement integration for OpenClaw dreaming with three new settings: corpusSupplement, corpusMaxResults, corpusMinScore.
  * Alma memory switched to async HTTP with Bearer auth and improved thread sync to reduce duplicates; live thread append-first behavior.

* **Bug Fixes**
  * Cron/isolated automation sessions are excluded from capture/sync.
  * Prevents duplicate recall when corpus supplement is enabled.
  * Hermes plugin install/import path corrected for discoverability.

* **Chores**
  * Bumped OpenClaw to 0.8.0, Alma to 0.6.14, Hermes to 0.5.1.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk due to switching Alma from sync CLI calls to async HTTP API calls and changing thread ID/sync behavior, which could affect persistence and recall correctness if API assumptions differ. OpenClaw adds a new optional corpus-supplement integration into memory-core’s recall/dreaming pipeline, which changes how recall is sourced when enabled.
> 
> **Overview**
> **Alma plugin** switches all memory/thread operations from `nmem` CLI `spawnSync` to async HTTP `fetch()` with `Authorization: Bearer`, updates query param mapping (`q`/`labels`/`time_range`), and simplifies tool schemas by removing CLI-only parameters (`contentLimit`, `force`, truncation metadata). Thread syncing is hardened by deriving a stable `alma-{sha1(...)}` thread id, attempting append-before-create on first flush, snapshotting message counts, and flushing buffers on `dispose()` to reduce duplicates across restarts/eviction.
> 
> **OpenClaw plugin** bumps to `0.8.0`, adds optional `corpusSupplement` capability (plus max/min settings) to register a `MemoryCorpusSupplement` for memory-core recall/dreaming and disables duplicate search-based recall when active; it also updates capture behavior/docs to exclude cron/isolated sessions via `isCronSessionKey`.
> 
> **Hermes plugin** fixes plugin discoverability by installing to `~/.hermes/plugins/nowledge-mem/`, migrates old installs, and updates imports to relative; registry/docs/changelogs are updated with version bumps and corrected Codex skill naming.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit caf6f46f3dcfc93273c535d9d3d469ef4631b2e3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->