### PR TITLE
fix(openclaw): harden thread capture and release surfaces

### DIFF
--- a/integrations.json
+++ b/integrations.json
@@ -185,7 +185,7 @@
       "name": "OpenClaw",
       "category": "coding",
       "type": "plugin",
-      "version": "0.8.6",
+      "version": "0.8.7",
       "directory": "nowledge-mem-openclaw-plugin",
       "transport": "cli",
       "capabilities": {

--- a/integrations.json
+++ b/integrations.json
@@ -185,7 +185,7 @@
       "name": "OpenClaw",
       "category": "coding",
       "type": "plugin",
-      "version": "0.8.4",
+      "version": "0.8.5",
       "directory": "nowledge-mem-openclaw-plugin",
       "transport": "cli",
       "capabilities": {

--- a/integrations.json
+++ b/integrations.json
@@ -185,7 +185,7 @@
       "name": "OpenClaw",
       "category": "coding",
       "type": "plugin",
-      "version": "0.8.5",
+      "version": "0.8.6",
       "directory": "nowledge-mem-openclaw-plugin",
       "transport": "cli",
       "capabilities": {
@@ -201,7 +201,7 @@
       },
       "threadSave": {
         "method": "plugin-capture",
-        "note": "Plugin captures interactive sessions via hooks (agent_end, after_compaction, before_reset) and Context Engine afterTurn; persists threads via Nowledge Mem HTTP API with incremental tail sync. Isolated cron/session keys excluded (OpenClaw isCronSessionKey via plugin-sdk/routing). Memory tools still use nmem CLI."
+        "note": "Plugin captures interactive sessions via hooks (agent_end, after_compaction, before_reset) and Context Engine afterTurn; hook capture remains a safety net even when the Context Engine slot is active. Persists threads via Nowledge Mem HTTP API with incremental tail sync. Isolated cron/session keys excluded (OpenClaw isCronSessionKey via plugin-sdk/routing). Memory tools still use nmem CLI."
       },
       "install": {
         "command": "openclaw plugins install clawhub:@nowledge/openclaw-nowledge-mem",

--- a/integrations.json
+++ b/integrations.json
@@ -185,7 +185,7 @@
       "name": "OpenClaw",
       "category": "coding",
       "type": "plugin",
-      "version": "0.8.7",
+      "version": "0.8.8",
       "directory": "nowledge-mem-openclaw-plugin",
       "transport": "cli",
       "capabilities": {

--- a/integrations.json
+++ b/integrations.json
@@ -185,7 +185,7 @@
       "name": "OpenClaw",
       "category": "coding",
       "type": "plugin",
-      "version": "0.8.3",
+      "version": "0.8.4",
       "directory": "nowledge-mem-openclaw-plugin",
       "transport": "cli",
       "capabilities": {

--- a/nowledge-mem-openclaw-plugin/CHANGELOG.md
+++ b/nowledge-mem-openclaw-plugin/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to the Nowledge Mem OpenClaw plugin will be documented in this file.
 
+## [0.8.4] - 2026-04-09
+
+### Fixed
+
+- **Removed `peerDependencies` that could block plugin loading on older OpenClaw hosts.** The 0.8.3 release added `peerDependencies: { "openclaw": ">=2026.4.5" }` for ClawHub publication. OpenClaw's plugin loader may enforce this at install or load time, silently preventing the plugin from registering on hosts below that version. This broke thread auto-sync (and all other plugin functionality) for affected users. The `openclaw.compat.pluginApi` metadata is retained for ClawHub validation only.
+
 ## [0.8.3] - 2026-04-08
 
 ### Added

--- a/nowledge-mem-openclaw-plugin/CHANGELOG.md
+++ b/nowledge-mem-openclaw-plugin/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 All notable changes to the Nowledge Mem OpenClaw plugin will be documented in this file.
 
+## [0.8.6] - 2026-04-09
+
+### Fixed
+
+- **Thread capture no longer depends entirely on the Context Engine path.** When `plugins.slots.contextEngine` points to `nowledge-mem`, behavioral and recall prompt injection still defer to the Context Engine, but capture hooks now remain active as a safety net. Thread append/create is already tail-synced and idempotent, so this backstop avoids missed syncs on sessions where the Context Engine lifecycle does not fire as expected without reintroducing duplicate threads.
+
+### Changed
+
+- **Troubleshooting now distinguishes sandbox mode from capture mode.** A `session_status` label like `direct/non-main` reflects OpenClaw sandbox configuration, not a cron or non-interactive session. The OpenClaw main session key `agent:main:main` remains a normal interactive capture target.
+
 ## [0.8.5] - 2026-04-09
 
 ### Changed

--- a/nowledge-mem-openclaw-plugin/CHANGELOG.md
+++ b/nowledge-mem-openclaw-plugin/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to the Nowledge Mem OpenClaw plugin will be documented in this file.
 
+## [0.8.8] - 2026-04-09
+
+### Fixed
+
+- **Internal OpenClaw control sender wrappers no longer leak into saved thread content.** Messages wrapped with `Sender (untrusted metadata)` for the internal `openclaw-control-ui` source now persist only the user-visible message body, instead of storing the control metadata block in Mem.
+
 ## [0.8.7] - 2026-04-09
 
 ### Fixed

--- a/nowledge-mem-openclaw-plugin/CHANGELOG.md
+++ b/nowledge-mem-openclaw-plugin/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 All notable changes to the Nowledge Mem OpenClaw plugin will be documented in this file.
 
+## [0.8.7] - 2026-04-09
+
+### Fixed
+
+- **One OpenClaw chat now persists as one Mem thread.** Thread identity now prefers the stable OpenClaw `sessionKey` over transient runtime `sessionId`, so Context Engine `afterTurn` capture and hook-based `agent_end` capture append to the same thread instead of creating parallel copies of the same conversation.
+- **Internal OpenClaw helper sessions no longer pollute Mem.** Temporary sessions like `temp:slug-generator` and internal subagent sessions are now excluded from thread auto-sync, keeping the thread list focused on real user conversations.
+- **Stored thread content is cleaner.** The synthetic `/new` or `/reset` startup prompt is no longer persisted as a user message, and OpenClaw control tags like `[[reply_to_current]]` / `[[reply_to:...]]` / `[[audio_as_voice]]` are stripped before capture.
+
 ## [0.8.6] - 2026-04-09
 
 ### Fixed

--- a/nowledge-mem-openclaw-plugin/CHANGELOG.md
+++ b/nowledge-mem-openclaw-plugin/CHANGELOG.md
@@ -11,6 +11,7 @@ All notable changes to the Nowledge Mem OpenClaw plugin will be documented in th
 ### Changed
 
 - **Troubleshooting now distinguishes sandbox mode from capture mode.** A `session_status` label like `direct/non-main` reflects OpenClaw sandbox configuration, not a cron or non-interactive session. The OpenClaw main session key `agent:main:main` remains a normal interactive capture target.
+- **Status now reports Context Engine activity precisely.** `nowledge_mem_status` only reports Context Engine capture as active when registration actually succeeded in the current runtime. If the slot points to `nowledge-mem` but the runtime falls back to hooks-only mode, the status output now says so directly.
 
 ## [0.8.5] - 2026-04-09
 

--- a/nowledge-mem-openclaw-plugin/CHANGELOG.md
+++ b/nowledge-mem-openclaw-plugin/CHANGELOG.md
@@ -4,10 +4,10 @@ All notable changes to the Nowledge Mem OpenClaw plugin will be documented in th
 
 ## [0.8.5] - 2026-04-09
 
-### Fixed
+### Changed
 
-- **Removed the new host-version load gate that `0.8.3` introduced.** The runtime code did not change in `0.8.3`; the regression came from package metadata. Adding `openclaw.install.minHostVersion` made OpenClaw treat the package as host-gated at install and load time. When the host version could not be resolved cleanly in some environments, the plugin was skipped before registration, which made thread auto-sync disappear even though the Mem server was healthy. `openclaw.compat.pluginApi` and `openclaw.build.openclawVersion` remain for ClawHub validation, but the runtime loader no longer sees this package as load-gated.
-- **Removed the unneeded `peerDependencies.openclaw` entry.** It was not the new regression introduced in `0.8.3`, but it also did not provide user value for this standalone plugin package.
+- **Reduced loader coupling in the published package.** `openclaw.install.minHostVersion` and `peerDependencies.openclaw` have been removed. The plugin already uses runtime feature detection and graceful fallback, so those package-level host constraints were unnecessary. `openclaw.compat.pluginApi` and `openclaw.build.openclawVersion` remain for ClawHub validation.
+- **`nowledge_mem_status` now explains capture routing and transport split.** It reports whether thread capture is running through lifecycle hooks or Context Engine `afterTurn`, and makes the transport model explicit: memory tools use the `nmem` CLI, while thread auto-sync uses the Mem HTTP API. This closes the common debugging gap where search works but thread sync does not.
 
 ## [0.8.3] - 2026-04-08
 

--- a/nowledge-mem-openclaw-plugin/CHANGELOG.md
+++ b/nowledge-mem-openclaw-plugin/CHANGELOG.md
@@ -2,11 +2,12 @@
 
 All notable changes to the Nowledge Mem OpenClaw plugin will be documented in this file.
 
-## [0.8.4] - 2026-04-09
+## [0.8.5] - 2026-04-09
 
 ### Fixed
 
-- **Removed `peerDependencies` that could block plugin loading on older OpenClaw hosts.** The 0.8.3 release added `peerDependencies: { "openclaw": ">=2026.4.5" }` for ClawHub publication. OpenClaw's plugin loader may enforce this at install or load time, silently preventing the plugin from registering on hosts below that version. This broke thread auto-sync (and all other plugin functionality) for affected users. The `openclaw.compat.pluginApi` metadata is retained for ClawHub validation only.
+- **Removed the new host-version load gate that `0.8.3` introduced.** The runtime code did not change in `0.8.3`; the regression came from package metadata. Adding `openclaw.install.minHostVersion` made OpenClaw treat the package as host-gated at install and load time. When the host version could not be resolved cleanly in some environments, the plugin was skipped before registration, which made thread auto-sync disappear even though the Mem server was healthy. `openclaw.compat.pluginApi` and `openclaw.build.openclawVersion` remain for ClawHub validation, but the runtime loader no longer sees this package as load-gated.
+- **Removed the unneeded `peerDependencies.openclaw` entry.** It was not the new regression introduced in `0.8.3`, but it also did not provide user value for this standalone plugin package.
 
 ## [0.8.3] - 2026-04-08
 

--- a/nowledge-mem-openclaw-plugin/CLAUDE.md
+++ b/nowledge-mem-openclaw-plugin/CLAUDE.md
@@ -94,7 +94,7 @@ A shared `ceState.active` flag (in `ce-state.js`) coordinates the two paths:
 |-----------|-----------|---------------------|
 | Behavioral guidance | `assemble()` → `systemPromptAddition` | `before_prompt_build` → `appendSystemContext` |
 | Memory recall | `assemble()` → `systemPromptAddition` | `before_prompt_build` → `appendSystemContext` |
-| Thread capture | `afterTurn()` (every turn) | `agent_end` / `after_compaction` / `before_reset` |
+| Thread capture | `afterTurn()` (every turn) + hook fallback | `agent_end` / `after_compaction` / `before_reset` |
 | Triage + distill | `afterTurn()` | `agent_end` only |
 | Compaction | `compact()` with memory-aware instructions | None (OpenClaw legacy) |
 | Subagent context | `prepareSubagentSpawn()` + `onSubagentEnded()` | None |

--- a/nowledge-mem-openclaw-plugin/README.md
+++ b/nowledge-mem-openclaw-plugin/README.md
@@ -522,7 +522,7 @@ Run `nowledge_mem_status` in a conversation and check:
 
 If the plugin is loaded on a normal interactive session, the `0.8.3` packaging metadata alone is not enough to explain missing thread sync. The meaningful runtime jump was `0.7.x -> 0.8.0`, especially the new cron / isolated-session exclusion.
 
-If your config enables `plugins.slots.contextEngine: "nowledge-mem"`, that session uses the Context Engine capture path instead of relying only on lifecycle hooks. In `0.8.6+`, capture hooks stay enabled as a safety net as well. On `0.8.5` and earlier, temporarily removing the `contextEngine` slot is a valid isolation step if thread sync stops while tools still work.
+If your config enables `plugins.slots.contextEngine: "nowledge-mem"`, that session uses the Context Engine capture path first. In `0.8.6+`, capture hooks stay enabled as a safety net as well. On `0.8.5` and earlier, temporarily removing the `contextEngine` slot is a valid isolation step if thread sync stops while tools still work.
 
 **Search timeouts with many concurrent agents**
 

--- a/nowledge-mem-openclaw-plugin/README.md
+++ b/nowledge-mem-openclaw-plugin/README.md
@@ -522,6 +522,8 @@ Run `nowledge_mem_status` in a conversation and check:
 
 If the plugin is loaded on a normal interactive session, the `0.8.3` packaging metadata alone is not enough to explain missing thread sync. The meaningful runtime jump was `0.7.x -> 0.8.0`, especially the new cron / isolated-session exclusion.
 
+If your config enables `plugins.slots.contextEngine: "nowledge-mem"`, that session uses the Context Engine capture path instead of relying only on lifecycle hooks. In `0.8.6+`, capture hooks stay enabled as a safety net as well. On `0.8.5` and earlier, temporarily removing the `contextEngine` slot is a valid isolation step if thread sync stops while tools still work.
+
 **Search timeouts with many concurrent agents**
 
 When running many agents in parallel, all searches share a single database connection. Upgrade to Nowledge Mem v0.6.12+ (backend) so scoring writes no longer block search responses.

--- a/nowledge-mem-openclaw-plugin/README.md
+++ b/nowledge-mem-openclaw-plugin/README.md
@@ -365,7 +365,7 @@ The behavioral guidance adjusts when `sessionContext` is enabled. Instead of "se
 
 **What happens to conversations I don't explicitly save?**
 
-With `sessionDigest` enabled (the default), every conversation is saved as a searchable thread. You can find it later with `nowledge_mem_thread_search`. On top of that, a lightweight LLM triage checks if the conversation contained decisions, insights, or preferences worth keeping as structured memories. If yes, they're extracted with proper types, labels, and temporal context. If the conversation was routine ("fix this typo"), nothing extra is saved.
+With `sessionDigest` enabled (the default), every conversation is saved as a searchable thread. One OpenClaw chat becomes one Mem thread: capture uses the stable OpenClaw `sessionKey`, not transient runtime ids, so Context Engine capture and hook-based capture append to the same conversation. Internal helper sessions like `temp:*` and subagent runs are excluded, so your recent threads stay focused on real chats. On top of thread capture, a lightweight LLM triage checks if the conversation contained decisions, insights, or preferences worth keeping as structured memories. If yes, they're extracted with proper types, labels, and temporal context. If the conversation was routine ("fix this typo"), nothing extra is saved.
 
 **Can memories be wrong or outdated?**
 
@@ -408,14 +408,14 @@ To change settings, use the OpenClaw plugin settings UI. Changes take effect on 
 
 ### Remote access
 
-Create `~/.nowledge-mem/config.json` with your credentials. This file is shared by all Nowledge Mem integrations (nmem CLI, Bub, Claude Code, etc.) so one file connects everything:
+Configure this machine once:
 
-```json
-{
-  "apiUrl": "https://<your-url>",
-  "apiKey": "nmem_..."
-}
+```bash
+nmem config client set url https://<your-url>
+nmem config client set api-key nmem_...
 ```
+
+That writes the shared local client config used by `nmem`, OpenClaw, Bub, Claude Code, and other integrations on this machine. You can still set **Server URL** and **API key** in the OpenClaw dashboard if you want plugin-specific overrides.
 
 See [Access Mem Anywhere](https://mem.nowledge.co/docs/remote-access).
 
@@ -449,7 +449,7 @@ Credentials (apiUrl, apiKey):
 openclaw.json (legacy) > OpenClaw dashboard > config.json (shared) > env vars > defaults
 ```
 
-`~/.nowledge-mem/openclaw.json` is still honored for backward compatibility but is no longer the recommended path. New users should configure plugin-specific settings via the OpenClaw dashboard and shared credentials via `~/.nowledge-mem/config.json`.
+`~/.nowledge-mem/openclaw.json` is still honored for backward compatibility but is no longer the recommended path. New users should configure plugin-specific settings via the OpenClaw dashboard and shared credentials via `nmem config client ...`.
 
 Use `nowledge_mem_status` (or `openclaw nowledge-mem status`) to see where each value comes from.
 
@@ -525,6 +525,18 @@ If your config enables `plugins.slots.contextEngine: "nowledge-mem"`:
 - on `0.8.6+`, Context Engine capture stays active and hooks remain enabled as a safety net
 - on `0.8.5` and earlier, temporarily removing the `contextEngine` slot is a valid isolation step if thread sync stops while tools still work
 
+What healthy OpenClaw thread sync looks like:
+
+- one visible chat becomes one Mem thread
+- helper sessions like `temp:slug-generator` do not appear
+- the synthetic `/new` / `/reset` startup prompt is not stored as the first user message
+
+To inspect the recent synced threads directly, run:
+
+```bash
+nmem t list --source openclaw -n 20
+```
+
 **Search timeouts with many concurrent agents**
 
 When running many agents in parallel, all searches share a single database connection. Upgrade to Nowledge Mem v0.6.12+ (backend) so scoring writes no longer block search responses.
@@ -535,7 +547,7 @@ The Nowledge Mem backend is not running. Start it from the desktop app, or run t
 
 **Remote mode not connecting**
 
-Check `~/.nowledge-mem/config.json` credentials. Run `nmem --json --api-url "$URL" status` to verify the server is reachable.
+Run `nmem config client show` and confirm the effective URL and API key state. Then run `nmem --json --api-url "$URL" status` to verify the server is reachable.
 
 ## What Makes This Different
 

--- a/nowledge-mem-openclaw-plugin/README.md
+++ b/nowledge-mem-openclaw-plugin/README.md
@@ -519,11 +519,14 @@ Run `nowledge_mem_status` in a conversation and check, in this order:
 - `sessionDigest` is still `true`
 - the backend is reachable
 - which capture path is active: hook events, or Context Engine `afterTurn` with hook fallback
+- whether you changed plugin settings recently without restarting OpenClaw yet
 
 If your config enables `plugins.slots.contextEngine: "nowledge-mem"`:
 
 - on `0.8.6+`, Context Engine capture stays active and hooks remain enabled as a safety net
 - on `0.8.5` and earlier, temporarily removing the `contextEngine` slot is a valid isolation step if thread sync stops while tools still work
+
+Remember: OpenClaw applies plugin setting changes after restart. If you turned `sessionDigest` off earlier but had not restarted yet, thread sync could appear to keep working until the next restart, then stop.
 
 What healthy OpenClaw thread sync looks like:
 

--- a/nowledge-mem-openclaw-plugin/README.md
+++ b/nowledge-mem-openclaw-plugin/README.md
@@ -513,16 +513,17 @@ This is usually a capture-path issue, not a search/save issue:
 - thread auto-sync uses the Mem HTTP API
 - cron / isolated automation sessions are intentionally excluded from capture in `0.8.x`
 
-Run `nowledge_mem_status` in a conversation and check:
+Run `nowledge_mem_status` in a conversation and check, in this order:
 
 - the plugin is loaded
 - `sessionDigest` is still `true`
 - the backend is reachable
-- which capture path is active: hook events or Context Engine `afterTurn`
+- which capture path is active: hook events, or Context Engine `afterTurn` with hook fallback
 
-If the plugin is loaded on a normal interactive session, the `0.8.3` packaging metadata alone is not enough to explain missing thread sync. The meaningful runtime jump was `0.7.x -> 0.8.0`, especially the new cron / isolated-session exclusion.
+If your config enables `plugins.slots.contextEngine: "nowledge-mem"`:
 
-If your config enables `plugins.slots.contextEngine: "nowledge-mem"`, that session uses the Context Engine capture path first. In `0.8.6+`, capture hooks stay enabled as a safety net as well. On `0.8.5` and earlier, temporarily removing the `contextEngine` slot is a valid isolation step if thread sync stops while tools still work.
+- on `0.8.6+`, Context Engine capture stays active and hooks remain enabled as a safety net
+- on `0.8.5` and earlier, temporarily removing the `contextEngine` slot is a valid isolation step if thread sync stops while tools still work
 
 **Search timeouts with many concurrent agents**
 

--- a/nowledge-mem-openclaw-plugin/README.md
+++ b/nowledge-mem-openclaw-plugin/README.md
@@ -505,6 +505,12 @@ If `openclaw status` shows a CRITICAL warning about `plugins.allow`, this is the
 
 Do not list `nowledge_mem_*` tool names in `tools.allow` — OpenClaw silently strips allowlists that contain only plugin entries, so the config looks active but does nothing.
 
+**Thread auto-sync stopped right after upgrading to `0.8.3`**
+
+This was a packaging regression, not a Mem server regression. `0.8.3` added a host-version gate in `package.json` that could cause OpenClaw to skip loading the plugin before registration in some environments. When that happened, thread capture and distillation stopped because the plugin never attached its lifecycle hooks.
+
+Upgrade to `0.8.5+`, then restart OpenClaw. If you want to confirm the plugin is really loaded, run `nowledge_mem_status` in a conversation and check that the plugin tools are present.
+
 **Search timeouts with many concurrent agents**
 
 When running many agents in parallel, all searches share a single database connection. Upgrade to Nowledge Mem v0.6.12+ (backend) so scoring writes no longer block search responses.

--- a/nowledge-mem-openclaw-plugin/README.md
+++ b/nowledge-mem-openclaw-plugin/README.md
@@ -505,11 +505,22 @@ If `openclaw status` shows a CRITICAL warning about `plugins.allow`, this is the
 
 Do not list `nowledge_mem_*` tool names in `tools.allow` — OpenClaw silently strips allowlists that contain only plugin entries, so the config looks active but does nothing.
 
-**Thread auto-sync stopped right after upgrading to `0.8.3`**
+**Memory tools still work, but thread auto-sync does not**
 
-This was a packaging regression, not a Mem server regression. `0.8.3` added a host-version gate in `package.json` that could cause OpenClaw to skip loading the plugin before registration in some environments. When that happened, thread capture and distillation stopped because the plugin never attached its lifecycle hooks.
+This is usually a capture-path issue, not a search/save issue:
 
-Upgrade to `0.8.5+`, then restart OpenClaw. If you want to confirm the plugin is really loaded, run `nowledge_mem_status` in a conversation and check that the plugin tools are present.
+- memory tools use the local `nmem` CLI
+- thread auto-sync uses the Mem HTTP API
+- cron / isolated automation sessions are intentionally excluded from capture in `0.8.x`
+
+Run `nowledge_mem_status` in a conversation and check:
+
+- the plugin is loaded
+- `sessionDigest` is still `true`
+- the backend is reachable
+- which capture path is active: hook events or Context Engine `afterTurn`
+
+If the plugin is loaded on a normal interactive session, the `0.8.3` packaging metadata alone is not enough to explain missing thread sync. The meaningful runtime jump was `0.7.x -> 0.8.0`, especially the new cron / isolated-session exclusion.
 
 **Search timeouts with many concurrent agents**
 

--- a/nowledge-mem-openclaw-plugin/RELEASING.md
+++ b/nowledge-mem-openclaw-plugin/RELEASING.md
@@ -99,7 +99,7 @@ npm publish --access public
 - bump `version` in `package.json` and `openclaw.plugin.json`
 - update `CHANGELOG.md`
 - keep `package.json` `openclaw.install.npmSpec`, `openclaw.compat`, and `openclaw.build` aligned with the tested OpenClaw baseline
-- do not add `openclaw.install.minHostVersion` unless the runtime truly hard-requires a host floor with no graceful fallback
+- keep `openclaw.install.minHostVersion` omitted for this plugin; `scripts/validate-plugin.mjs` enforces this and is the source of truth if the policy ever changes
 - run `node scripts/validate-plugin.mjs`
 - run `npm pack --dry-run`
 - run `clawhub package publish . --dry-run`

--- a/nowledge-mem-openclaw-plugin/RELEASING.md
+++ b/nowledge-mem-openclaw-plugin/RELEASING.md
@@ -98,7 +98,8 @@ npm publish --access public
 
 - bump `version` in `package.json` and `openclaw.plugin.json`
 - update `CHANGELOG.md`
-- keep `package.json` `openclaw.install`, `openclaw.compat`, and `openclaw.build` aligned with the tested OpenClaw baseline
+- keep `package.json` `openclaw.install.npmSpec`, `openclaw.compat`, and `openclaw.build` aligned with the tested OpenClaw baseline
+- do not add `openclaw.install.minHostVersion` unless the runtime truly hard-requires a host floor with no graceful fallback
 - run `node scripts/validate-plugin.mjs`
 - run `npm pack --dry-run`
 - run `clawhub package publish . --dry-run`

--- a/nowledge-mem-openclaw-plugin/openclaw.plugin.json
+++ b/nowledge-mem-openclaw-plugin/openclaw.plugin.json
@@ -2,7 +2,7 @@
 	"id": "openclaw-nowledge-mem",
 	"name": "Nowledge Mem",
 	"description": "Cross-tool knowledge graph memory for OpenClaw with Working Memory, graph search, and session distillation.",
-	"version": "0.8.7",
+	"version": "0.8.8",
 	"kind": "memory",
 	"skills": [
 		"skills/memory-guide"

--- a/nowledge-mem-openclaw-plugin/openclaw.plugin.json
+++ b/nowledge-mem-openclaw-plugin/openclaw.plugin.json
@@ -2,7 +2,7 @@
 	"id": "openclaw-nowledge-mem",
 	"name": "Nowledge Mem",
 	"description": "Cross-tool knowledge graph memory for OpenClaw with Working Memory, graph search, and session distillation.",
-	"version": "0.8.6",
+	"version": "0.8.7",
 	"kind": "memory",
 	"skills": [
 		"skills/memory-guide"

--- a/nowledge-mem-openclaw-plugin/openclaw.plugin.json
+++ b/nowledge-mem-openclaw-plugin/openclaw.plugin.json
@@ -2,7 +2,7 @@
 	"id": "openclaw-nowledge-mem",
 	"name": "Nowledge Mem",
 	"description": "Cross-tool knowledge graph memory for OpenClaw with Working Memory, graph search, and session distillation.",
-	"version": "0.8.4",
+	"version": "0.8.5",
 	"kind": "memory",
 	"skills": [
 		"skills/memory-guide"

--- a/nowledge-mem-openclaw-plugin/openclaw.plugin.json
+++ b/nowledge-mem-openclaw-plugin/openclaw.plugin.json
@@ -2,7 +2,7 @@
 	"id": "openclaw-nowledge-mem",
 	"name": "Nowledge Mem",
 	"description": "Cross-tool knowledge graph memory for OpenClaw with Working Memory, graph search, and session distillation.",
-	"version": "0.8.3",
+	"version": "0.8.4",
 	"kind": "memory",
 	"skills": [
 		"skills/memory-guide"

--- a/nowledge-mem-openclaw-plugin/openclaw.plugin.json
+++ b/nowledge-mem-openclaw-plugin/openclaw.plugin.json
@@ -2,7 +2,7 @@
 	"id": "openclaw-nowledge-mem",
 	"name": "Nowledge Mem",
 	"description": "Cross-tool knowledge graph memory for OpenClaw with Working Memory, graph search, and session distillation.",
-	"version": "0.8.5",
+	"version": "0.8.6",
 	"kind": "memory",
 	"skills": [
 		"skills/memory-guide"

--- a/nowledge-mem-openclaw-plugin/package-lock.json
+++ b/nowledge-mem-openclaw-plugin/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "@nowledge/openclaw-nowledge-mem",
-	"version": "0.8.6",
+	"version": "0.8.7",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "@nowledge/openclaw-nowledge-mem",
-			"version": "0.8.6",
+			"version": "0.8.7",
 			"license": "MIT",
 			"devDependencies": {
 				"@biomejs/biome": "^1.9.0"

--- a/nowledge-mem-openclaw-plugin/package-lock.json
+++ b/nowledge-mem-openclaw-plugin/package-lock.json
@@ -1,18 +1,15 @@
 {
 	"name": "@nowledge/openclaw-nowledge-mem",
-	"version": "0.8.3",
+	"version": "0.8.4",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "@nowledge/openclaw-nowledge-mem",
-			"version": "0.8.3",
+			"version": "0.8.4",
 			"license": "MIT",
 			"devDependencies": {
 				"@biomejs/biome": "^1.9.0"
-			},
-			"peerDependencies": {
-				"openclaw": ">=2026.4.5"
 			}
 		},
 		"node_modules/@agentclientprotocol/sdk": {

--- a/nowledge-mem-openclaw-plugin/package-lock.json
+++ b/nowledge-mem-openclaw-plugin/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "@nowledge/openclaw-nowledge-mem",
-	"version": "0.8.7",
+	"version": "0.8.8",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "@nowledge/openclaw-nowledge-mem",
-			"version": "0.8.7",
+			"version": "0.8.8",
 			"license": "MIT",
 			"devDependencies": {
 				"@biomejs/biome": "^1.9.0"

--- a/nowledge-mem-openclaw-plugin/package-lock.json
+++ b/nowledge-mem-openclaw-plugin/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "@nowledge/openclaw-nowledge-mem",
-	"version": "0.8.5",
+	"version": "0.8.6",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "@nowledge/openclaw-nowledge-mem",
-			"version": "0.8.5",
+			"version": "0.8.6",
 			"license": "MIT",
 			"devDependencies": {
 				"@biomejs/biome": "^1.9.0"

--- a/nowledge-mem-openclaw-plugin/package-lock.json
+++ b/nowledge-mem-openclaw-plugin/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "@nowledge/openclaw-nowledge-mem",
-	"version": "0.8.4",
+	"version": "0.8.5",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "@nowledge/openclaw-nowledge-mem",
-			"version": "0.8.4",
+			"version": "0.8.5",
 			"license": "MIT",
 			"devDependencies": {
 				"@biomejs/biome": "^1.9.0"

--- a/nowledge-mem-openclaw-plugin/package.json
+++ b/nowledge-mem-openclaw-plugin/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@nowledge/openclaw-nowledge-mem",
 	"displayName": "Nowledge Mem for OpenClaw",
-	"version": "0.8.5",
+	"version": "0.8.6",
 	"type": "module",
 	"description": "Nowledge Mem memory plugin for OpenClaw, local-first personal knowledge base",
 	"author": {

--- a/nowledge-mem-openclaw-plugin/package.json
+++ b/nowledge-mem-openclaw-plugin/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@nowledge/openclaw-nowledge-mem",
 	"displayName": "Nowledge Mem for OpenClaw",
-	"version": "0.8.7",
+	"version": "0.8.8",
 	"type": "module",
 	"description": "Nowledge Mem memory plugin for OpenClaw, local-first personal knowledge base",
 	"author": {

--- a/nowledge-mem-openclaw-plugin/package.json
+++ b/nowledge-mem-openclaw-plugin/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@nowledge/openclaw-nowledge-mem",
 	"displayName": "Nowledge Mem for OpenClaw",
-	"version": "0.8.4",
+	"version": "0.8.5",
 	"type": "module",
 	"description": "Nowledge Mem memory plugin for OpenClaw, local-first personal knowledge base",
 	"author": {
@@ -27,8 +27,7 @@
 	"openclaw": {
 		"extensions": ["./src/index.js"],
 		"install": {
-			"npmSpec": "@nowledge/openclaw-nowledge-mem",
-			"minHostVersion": ">=2026.4.5"
+			"npmSpec": "@nowledge/openclaw-nowledge-mem"
 		},
 		"compat": {
 			"pluginApi": ">=2026.4.5"

--- a/nowledge-mem-openclaw-plugin/package.json
+++ b/nowledge-mem-openclaw-plugin/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@nowledge/openclaw-nowledge-mem",
 	"displayName": "Nowledge Mem for OpenClaw",
-	"version": "0.8.3",
+	"version": "0.8.4",
 	"type": "module",
 	"description": "Nowledge Mem memory plugin for OpenClaw, local-first personal knowledge base",
 	"author": {
@@ -46,9 +46,6 @@
 		"validate": "node scripts/validate-plugin.mjs",
 		"lint": "biome check .",
 		"format": "biome format --write ."
-	},
-	"peerDependencies": {
-		"openclaw": ">=2026.4.5"
 	},
 	"devDependencies": {
 		"@biomejs/biome": "^1.9.0"

--- a/nowledge-mem-openclaw-plugin/package.json
+++ b/nowledge-mem-openclaw-plugin/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@nowledge/openclaw-nowledge-mem",
 	"displayName": "Nowledge Mem for OpenClaw",
-	"version": "0.8.6",
+	"version": "0.8.7",
 	"type": "module",
 	"description": "Nowledge Mem memory plugin for OpenClaw, local-first personal knowledge base",
 	"author": {

--- a/nowledge-mem-openclaw-plugin/scripts/validate-plugin.mjs
+++ b/nowledge-mem-openclaw-plugin/scripts/validate-plugin.mjs
@@ -107,9 +107,9 @@ async function main() {
     fail("package.json openclaw.install.npmSpec must match package.json name");
   }
 
-  if (pkg.peerDependencies?.openclaw !== openclaw.install.minHostVersion) {
-    fail("peerDependencies.openclaw must match openclaw.install.minHostVersion");
-  }
+  // peerDependencies removed: OpenClaw's plugin loader may enforce them at
+  // load time, silently blocking the plugin for users on older host versions.
+  // The openclaw.compat.pluginApi field is sufficient for ClawHub validation.
 
   if (manifest.id !== "openclaw-nowledge-mem") {
     fail("openclaw.plugin.json id must stay openclaw-nowledge-mem");

--- a/nowledge-mem-openclaw-plugin/scripts/validate-plugin.mjs
+++ b/nowledge-mem-openclaw-plugin/scripts/validate-plugin.mjs
@@ -97,7 +97,6 @@ async function main() {
   }
 
   assertString(openclaw.install?.npmSpec, "package.json openclaw.install.npmSpec");
-  assertVersionFloor(openclaw.install?.minHostVersion, "package.json openclaw.install.minHostVersion");
   assertVersionFloor(openclaw.compat?.pluginApi, "package.json openclaw.compat.pluginApi");
   assertString(openclaw.build?.openclawVersion, "package.json openclaw.build.openclawVersion");
   assertBoolean(openclaw.release?.publishToClawHub, "package.json openclaw.release.publishToClawHub");
@@ -107,9 +106,16 @@ async function main() {
     fail("package.json openclaw.install.npmSpec must match package.json name");
   }
 
-  // peerDependencies removed: OpenClaw's plugin loader may enforce them at
-  // load time, silently blocking the plugin for users on older host versions.
-  // The openclaw.compat.pluginApi field is sufficient for ClawHub validation.
+  if ("minHostVersion" in (openclaw.install ?? {})) {
+    fail(
+      "package.json openclaw.install.minHostVersion must be omitted for this plugin; rely on runtime feature detection and openclaw.compat.pluginApi instead",
+    );
+  }
+
+  // peerDependencies and openclaw.install.minHostVersion are intentionally
+  // omitted. The ClawHub contract only requires openclaw.compat.pluginApi and
+  // openclaw.build.openclawVersion, while OpenClaw's runtime loader treats
+  // minHostVersion as a hard install/load gate.
 
   if (manifest.id !== "openclaw-nowledge-mem") {
     fail("openclaw.plugin.json id must stay openclaw-nowledge-mem");

--- a/nowledge-mem-openclaw-plugin/src/ce-state.js
+++ b/nowledge-mem-openclaw-plugin/src/ce-state.js
@@ -1,8 +1,8 @@
 /**
  * Shared mutable state flag for context engine activation.
  *
- * When the CE is bootstrapped, `active` is set to true. Event hooks
- * check this flag to avoid duplicate work — the CE's lifecycle methods
- * (assemble, afterTurn, etc.) replace hook behavior when active.
+ * When the CE is bootstrapped, `active` is set to true. Prompt-building hooks
+ * use this to avoid duplicate context injection. Capture hooks stay enabled as
+ * a safety net because thread sync is already tail-synced and idempotent.
  */
 export const ceState = { active: false };

--- a/nowledge-mem-openclaw-plugin/src/context-engine.js
+++ b/nowledge-mem-openclaw-plugin/src/context-engine.js
@@ -27,6 +27,7 @@ import { BASE_GUIDANCE, SESSION_CONTEXT_GUIDANCE } from "./hooks/behavioral.js";
 import {
 	appendOrCreateThread,
 	hasSkipMarker,
+	isInternalCaptureSessionKey,
 	isCronCaptureSessionKey,
 	matchesExcludePattern,
 	triageAndDistill,
@@ -356,6 +357,10 @@ export function createNowledgeMemContextEngineFactory(client, cfg, logger) {
 
 				if (isCronCaptureSessionKey(normalizedKey)) {
 					logger.debug?.(`ce: skipped cron session ${normalizedKey}`);
+					return;
+				}
+				if (isInternalCaptureSessionKey(normalizedKey)) {
+					logger.debug?.(`ce: skipped internal session ${normalizedKey}`);
 					return;
 				}
 

--- a/nowledge-mem-openclaw-plugin/src/context-engine.js
+++ b/nowledge-mem-openclaw-plugin/src/context-engine.js
@@ -2,8 +2,8 @@
  * Nowledge Mem Context Engine for OpenClaw.
  *
  * Registers alongside the memory slot (kind: "memory"). When users activate
- * this CE via `plugins.slots.contextEngine: "nowledge-mem"`, it replaces the
- * hook-based approach with the richer CE lifecycle:
+ * this CE via `plugins.slots.contextEngine: "nowledge-mem"`, it takes over
+ * prompt assembly and adds richer lifecycle behavior:
  *
  *   assemble()              — behavioral guidance + recalled memories via systemPromptAddition
  *   afterTurn()             — continuous thread capture + triage/distillation (every turn)
@@ -12,7 +12,9 @@
  *   bootstrap()             — pre-warm Working Memory for first assemble
  *
  * When not activated, the existing hooks (behavioral, recall, capture) work
- * as before — full backward compatibility.
+ * as before. When activated, behavioral + recall hooks defer to the CE to
+ * avoid duplicate prompt context, while capture hooks remain as a safe
+ * fallback if a CE post-turn lifecycle is missed.
  *
  * Design:
  * - ownsCompaction: false — we enhance compaction instructions, not the algorithm

--- a/nowledge-mem-openclaw-plugin/src/hooks/capture.js
+++ b/nowledge-mem-openclaw-plugin/src/hooks/capture.js
@@ -205,7 +205,9 @@ export function normalizeRoleMessage(
 	const extractedText = extractText(msg.content);
 	if (!extractedText) return null;
 	const cleanedText = stripInternalSenderMetadata(extractedText);
-	if (cleanedText.startsWith(SESSION_RESET_PROMPT_PREFIX)) return null;
+	if (role === "user" && cleanedText.startsWith(SESSION_RESET_PROMPT_PREFIX)) {
+		return null;
+	}
 	const text = stripOpenClawDirectiveTags(cleanedText);
 	if (!text) return null;
 	if (role === "user" && text.startsWith("/")) return null;

--- a/nowledge-mem-openclaw-plugin/src/hooks/capture.js
+++ b/nowledge-mem-openclaw-plugin/src/hooks/capture.js
@@ -10,6 +10,8 @@ const SESSION_RESET_PROMPT_PREFIX =
 	"A new session was started via /new or /reset.";
 const OPENCLAW_DIRECTIVE_TAG_RE =
 	/\s*\[\[\s*(?:audio_as_voice|reply_to_current|reply_to\s*:\s*[^\]\n]+)\s*\]\]\s*/giu;
+const OPENCLAW_INTERNAL_SENDER_BLOCK_RE =
+	/^Sender \(untrusted metadata\):\s*```json\s*([\s\S]*?)\s*```\s*([\s\S]*)$/iu;
 
 // Per-thread triage cooldown: prevents burst triage/distillation from heartbeat.
 // Maps threadId -> timestamp (ms) of last successful triage.
@@ -139,6 +141,29 @@ function stripOpenClawDirectiveTags(text) {
 		.trim();
 }
 
+function stripInternalSenderMetadata(text) {
+	const raw = String(text || "").trim();
+	if (!raw.startsWith("Sender (untrusted metadata):")) return raw;
+	const match = raw.match(OPENCLAW_INTERNAL_SENDER_BLOCK_RE);
+	if (!match) return raw;
+	const [, jsonBlock, remainder] = match;
+	try {
+		const parsed = JSON.parse(jsonBlock);
+		const label = String(parsed?.label || "")
+			.trim()
+			.toLowerCase();
+		const id = String(parsed?.id || "")
+			.trim()
+			.toLowerCase();
+		if (label === "openclaw-control-ui" || id === "openclaw-control-ui") {
+			return String(remainder || "").trim();
+		}
+	} catch {
+		return raw;
+	}
+	return raw;
+}
+
 // ---------------------------------------------------------------------------
 // Message normalization utilities
 // ---------------------------------------------------------------------------
@@ -179,8 +204,9 @@ export function normalizeRoleMessage(
 	if (role !== "user" && role !== "assistant") return null;
 	const extractedText = extractText(msg.content);
 	if (!extractedText) return null;
-	if (extractedText.startsWith(SESSION_RESET_PROMPT_PREFIX)) return null;
-	const text = stripOpenClawDirectiveTags(extractedText);
+	const cleanedText = stripInternalSenderMetadata(extractedText);
+	if (cleanedText.startsWith(SESSION_RESET_PROMPT_PREFIX)) return null;
+	const text = stripOpenClawDirectiveTags(cleanedText);
 	if (!text) return null;
 	if (role === "user" && text.startsWith("/")) return null;
 

--- a/nowledge-mem-openclaw-plugin/src/hooks/capture.js
+++ b/nowledge-mem-openclaw-plugin/src/hooks/capture.js
@@ -1,7 +1,6 @@
 import { createHash } from "node:crypto";
 import { readFile } from "node:fs/promises";
 import { isCronSessionKey } from "openclaw/plugin-sdk/routing";
-import { ceState } from "../ce-state.js";
 
 export const DEFAULT_MAX_MESSAGE_CHARS = 800;
 export const MAX_DISTILL_MESSAGE_CHARS = 2000;
@@ -477,8 +476,9 @@ export async function triageAndDistill({
 /**
  * Capture thread + LLM-based distillation after a successful agent run.
  *
- * When the context engine is active, this hook is a no-op — afterTurn
- * handles capture and distillation through the CE lifecycle.
+ * Even when the context engine is active, this hook remains as a safety net.
+ * Thread append/create is already idempotent, so the hook path can safely
+ * backstop CE afterTurn without duplicating stored messages.
  *
  * Heartbeat sessions (ctx.trigger === "heartbeat") are skipped — they
  * produce repetitive status pings that aren't worth preserving.
@@ -487,7 +487,6 @@ export async function triageAndDistill({
  */
 export function buildAgentEndCaptureHandler(client, cfg, logger) {
 	return async (event, ctx) => {
-		if (ceState.active) return;
 		if (!event?.success) return;
 		if (ctx?.trigger === "heartbeat") return;
 
@@ -530,14 +529,13 @@ export function buildAgentEndCaptureHandler(client, cfg, logger) {
  * Capture thread messages before reset or after compaction.
  * Thread-only (no distillation) — these are lifecycle checkpoints.
  *
- * When the context engine is active, this hook is a no-op — afterTurn
- * handles capture through the CE lifecycle.
+ * This hook also stays enabled when the context engine is active.
+ * The shared tail-sync dedup keeps the fallback path cheap and safe.
  *
  * Heartbeat sessions are skipped (same rationale as agent_end).
  */
 export function buildBeforeResetCaptureHandler(client, cfg, logger) {
 	return async (event, ctx) => {
-		if (ceState.active) return;
 		if (ctx?.trigger === "heartbeat") return;
 
 		const sessionKey = String(ctx?.sessionKey || ctx?.sessionId || "");

--- a/nowledge-mem-openclaw-plugin/src/hooks/capture.js
+++ b/nowledge-mem-openclaw-plugin/src/hooks/capture.js
@@ -1,11 +1,15 @@
 import { createHash } from "node:crypto";
 import { readFile } from "node:fs/promises";
-import { isCronSessionKey } from "openclaw/plugin-sdk/routing";
+import { isCronSessionKey, isSubagentSessionKey } from "openclaw/plugin-sdk/routing";
 
 export const DEFAULT_MAX_MESSAGE_CHARS = 800;
 export const MAX_DISTILL_MESSAGE_CHARS = 2000;
 export const MAX_CONVERSATION_CHARS = 30_000;
 export const MIN_MESSAGES_FOR_DISTILL = 4;
+const SESSION_RESET_PROMPT_PREFIX =
+	"A new session was started via /new or /reset.";
+const OPENCLAW_DIRECTIVE_TAG_RE =
+	/\s*\[\[\s*(?:audio_as_voice|reply_to_current|reply_to\s*:\s*[^\]\n]+)\s*\]\]\s*/giu;
 
 // Per-thread triage cooldown: prevents burst triage/distillation from heartbeat.
 // Maps threadId -> timestamp (ms) of last successful triage.
@@ -112,6 +116,29 @@ export function hasSkipMarker(messages, marker) {
 	});
 }
 
+/**
+ * Internal helper / system sessions should not become user-facing Mem threads.
+ *
+ * - temp:* covers OpenClaw helper sessions such as slug generation
+ * - subagent sessions are execution internals, not first-class user chats
+ */
+export function isInternalCaptureSessionKey(sessionKey) {
+	const raw = String(sessionKey || "")
+		.trim()
+		.toLowerCase();
+	if (!raw) return false;
+	if (raw.startsWith("temp:")) return true;
+	return isSubagentSessionKey(raw);
+}
+
+function stripOpenClawDirectiveTags(text) {
+	return String(text || "")
+		.replace(OPENCLAW_DIRECTIVE_TAG_RE, " ")
+		.replace(/[ \t]+\n/g, "\n")
+		.replace(/\n{3,}/g, "\n\n")
+		.trim();
+}
+
 // ---------------------------------------------------------------------------
 // Message normalization utilities
 // ---------------------------------------------------------------------------
@@ -150,7 +177,10 @@ export function normalizeRoleMessage(
 		raw.message && typeof raw.message === "object" ? raw.message : raw;
 	const role = typeof msg.role === "string" ? msg.role : "";
 	if (role !== "user" && role !== "assistant") return null;
-	const text = extractText(msg.content);
+	const extractedText = extractText(msg.content);
+	if (!extractedText) return null;
+	if (extractedText.startsWith(SESSION_RESET_PROMPT_PREFIX)) return null;
+	const text = stripOpenClawDirectiveTags(extractedText);
 	if (!text) return null;
 	if (role === "user" && text.startsWith("/")) return null;
 
@@ -183,10 +213,9 @@ export function normalizeRoleMessage(
 	};
 }
 
-export function buildThreadTitle(ctx, reason) {
+export function buildThreadTitle(ctx) {
 	const session = ctx?.sessionKey || ctx?.sessionId || "session";
-	const reasonSuffix = reason ? ` (${reason})` : "";
-	return `OpenClaw ${session}${reasonSuffix}`;
+	return `OpenClaw ${session}`;
 }
 
 function sanitizeIdPart(input, max = 48) {
@@ -200,8 +229,8 @@ function sanitizeIdPart(input, max = 48) {
 
 export function buildStableThreadId(event, ctx) {
 	const base =
-		String(ctx?.sessionId || "").trim() ||
 		String(ctx?.sessionKey || "").trim() ||
+		String(ctx?.sessionId || "").trim() ||
 		String(event?.sessionFile || "").trim() ||
 		"session";
 	const slug = sanitizeIdPart(base);
@@ -281,7 +310,7 @@ export async function appendOrCreateThread({
 	const threadId = buildStableThreadId(event, ctx);
 	const sessionKey = String(ctx?.sessionKey || ctx?.sessionId || "session");
 	const sessionId = String(ctx?.sessionId || "").trim();
-	const title = buildThreadTitle(ctx, reason);
+	const title = buildThreadTitle(ctx);
 	const normalized = rawMessages
 		.map((message) => normalizeRoleMessage(message, maxMessageChars))
 		.filter(Boolean);
@@ -456,7 +485,7 @@ export async function triageAndDistill({
 
 		const distillResult = await client.distillThread({
 			threadId: captureResult.threadId,
-			title: buildThreadTitle(ctx, "distilled"),
+			title: buildThreadTitle(ctx),
 			content: conversationText,
 		});
 
@@ -493,6 +522,10 @@ export function buildAgentEndCaptureHandler(client, cfg, logger) {
 		const sessionKey = String(ctx?.sessionKey || ctx?.sessionId || "");
 		if (isCronCaptureSessionKey(sessionKey)) {
 			logger.debug?.(`capture: skipped cron session ${sessionKey}`);
+			return;
+		}
+		if (isInternalCaptureSessionKey(sessionKey)) {
+			logger.debug?.(`capture: skipped internal session ${sessionKey}`);
 			return;
 		}
 
@@ -541,6 +574,10 @@ export function buildBeforeResetCaptureHandler(client, cfg, logger) {
 		const sessionKey = String(ctx?.sessionKey || ctx?.sessionId || "");
 		if (isCronCaptureSessionKey(sessionKey)) {
 			logger.debug?.(`capture: skipped cron session ${sessionKey}`);
+			return;
+		}
+		if (isInternalCaptureSessionKey(sessionKey)) {
+			logger.debug?.(`capture: skipped internal session ${sessionKey}`);
 			return;
 		}
 

--- a/nowledge-mem-openclaw-plugin/src/index.js
+++ b/nowledge-mem-openclaw-plugin/src/index.js
@@ -61,13 +61,8 @@ export default {
 		const memorySlot = api.config?.plugins?.slots?.memory;
 		const contextEngineSlot = api.config?.plugins?.slots?.contextEngine;
 		const pluginsAllow = api.config?.plugins?.allow;
-		api.registerTool(
-			createStatusTool(client, logger, cfg, {
-				memorySlot,
-				contextEngineSlot,
-				pluginsAllow,
-			}),
-		);
+		let contextEngineRegistered = false;
+		let contextEngineRegistrationError = null;
 
 		// --- Context Engine registration ---
 		// When the user sets `plugins.slots.contextEngine: "nowledge-mem"`,
@@ -80,12 +75,24 @@ export default {
 				"nowledge-mem",
 				createNowledgeMemContextEngineFactory(client, cfg, logger),
 			);
+			contextEngineRegistered = true;
 		} catch (err) {
 			// OpenClaw < CE support — degrade gracefully to hooks-only mode
+			contextEngineRegistrationError = String(err);
 			logger.debug?.(
 				`nowledge-mem: context engine registration unavailable (${err}), using hooks`,
 			);
 		}
+
+		api.registerTool(
+			createStatusTool(client, logger, cfg, {
+				memorySlot,
+				contextEngineSlot,
+				pluginsAllow,
+				contextEngineRegistered,
+				contextEngineRegistrationError,
+			}),
+		);
 
 		// --- Corpus Supplement (when memory-core is the memory slot) ---
 		// Makes Nowledge Mem's knowledge graph searchable through memory-core's

--- a/nowledge-mem-openclaw-plugin/src/index.js
+++ b/nowledge-mem-openclaw-plugin/src/index.js
@@ -57,11 +57,16 @@ export default {
 
 		// Diagnostics — pass runtime config so the status tool can detect:
 		//   - plugins.allow missing or not including this plugin
-		//   - memory slot pointing elsewhere (e.g. memory-core)
+		//   - memory/context-engine slot routing for capture and recall
 		const memorySlot = api.config?.plugins?.slots?.memory;
+		const contextEngineSlot = api.config?.plugins?.slots?.contextEngine;
 		const pluginsAllow = api.config?.plugins?.allow;
 		api.registerTool(
-			createStatusTool(client, logger, cfg, { memorySlot, pluginsAllow }),
+			createStatusTool(client, logger, cfg, {
+				memorySlot,
+				contextEngineSlot,
+				pluginsAllow,
+			}),
 		);
 
 		// --- Context Engine registration ---

--- a/nowledge-mem-openclaw-plugin/src/index.js
+++ b/nowledge-mem-openclaw-plugin/src/index.js
@@ -107,9 +107,10 @@ export default {
 			}
 		}
 
-		// --- Hooks (fallback when CE is not active) ---
-		// Each hook checks ceState.active and returns early when the CE handles
-		// the same lifecycle through assemble/afterTurn.
+		// --- Hooks ---
+		// Behavioral + recall hooks defer to the active CE to avoid duplicate
+		// prompt injection. Capture hooks remain enabled as a backstop because
+		// thread append/create is tail-synced and idempotent.
 
 		// Always-on: behavioral guidance so the agent proactively saves and searches.
 		// Fires every turn via before_prompt_build — ~50 tokens, negligible cost.

--- a/nowledge-mem-openclaw-plugin/src/index.js
+++ b/nowledge-mem-openclaw-plugin/src/index.js
@@ -71,9 +71,10 @@ export default {
 
 		// --- Context Engine registration ---
 		// When the user sets `plugins.slots.contextEngine: "nowledge-mem"`,
-		// this CE takes over from the hooks below (assemble replaces behavioral
-		// + recall; afterTurn replaces agent_end + capture hooks). When the CE
-		// slot points elsewhere, hooks continue working as before.
+		// this CE takes over prompt assembly from the hooks below (assemble
+		// replaces behavioral + recall prompt injection). Capture hooks remain
+		// enabled as a reliability backstop because thread sync is idempotent.
+		// When the CE slot points elsewhere, hooks continue working as before.
 		try {
 			api.registerContextEngine(
 				"nowledge-mem",

--- a/nowledge-mem-openclaw-plugin/src/tools/status.js
+++ b/nowledge-mem-openclaw-plugin/src/tools/status.js
@@ -102,12 +102,12 @@ export function createStatusTool(client, _logger, cfg, runtimeInfo = {}) {
 					: "legacy";
 			const captureMode = !cfg.sessionDigest
 				? "disabled"
-				: ceSlot === "nowledge-mem" ? "context-engine" : "hooks";
+				: ceSlot === "nowledge-mem" ? "context-engine+hooks" : "hooks";
 			details.captureMode = captureMode;
 			if (ceSlot === "nowledge-mem") {
 				lines.push("Context Engine slot: nowledge-mem (active)");
 				lines.push(
-					"  Thread capture runs through Context Engine afterTurn, not hook events.",
+					"  Thread capture runs through Context Engine afterTurn with hook fallback (agent_end, after_compaction, before_reset).",
 				);
 			} else {
 				lines.push(

--- a/nowledge-mem-openclaw-plugin/src/tools/status.js
+++ b/nowledge-mem-openclaw-plugin/src/tools/status.js
@@ -61,7 +61,12 @@ export function createStatusTool(client, _logger, cfg, runtimeInfo = {}) {
 
 			// 0b. Memory slot check — show current mode and options
 			const memorySlot = runtimeInfo.memorySlot;
+			const contextEngineSlot = runtimeInfo.contextEngineSlot;
 			details.memorySlot = memorySlot ?? "(unknown)";
+			details.contextEngineSlot =
+				contextEngineSlot && String(contextEngineSlot).trim()
+					? String(contextEngineSlot)
+					: "legacy";
 			if (memorySlot && memorySlot !== "openclaw-nowledge-mem") {
 				const corpusOn = cfg.corpusSupplement === true;
 				if (corpusOn) {
@@ -90,6 +95,34 @@ export function createStatusTool(client, _logger, cfg, runtimeInfo = {}) {
 				lines.push("Memory slot: openclaw-nowledge-mem (active)");
 			}
 
+			// 0c. Capture routing — hooks vs context engine
+			const ceSlot =
+				contextEngineSlot && String(contextEngineSlot).trim()
+					? String(contextEngineSlot).trim()
+					: "legacy";
+			const captureMode = !cfg.sessionDigest
+				? "disabled"
+				: ceSlot === "nowledge-mem" ? "context-engine" : "hooks";
+			details.captureMode = captureMode;
+			if (ceSlot === "nowledge-mem") {
+				lines.push("Context Engine slot: nowledge-mem (active)");
+				lines.push(
+					"  Thread capture runs through Context Engine afterTurn, not hook events.",
+				);
+			} else {
+				lines.push(
+					`Context Engine slot: ${ceSlot === "legacy" ? "legacy (default)" : `"${ceSlot}"`}`,
+				);
+				if (cfg.sessionDigest) {
+					lines.push(
+						"  Thread capture runs through hooks: agent_end, after_compaction, before_reset.",
+					);
+				}
+			}
+			if (!cfg.sessionDigest) {
+				lines.push("Thread capture: disabled (sessionDigest=false)");
+			}
+
 			// 1. Mode + connection target
 			const remote = !isDefaultApiUrl(cfg.apiUrl);
 			const mode = remote ? "remote" : "local";
@@ -101,6 +134,8 @@ export function createStatusTool(client, _logger, cfg, runtimeInfo = {}) {
 				`Mode: ${remote ? `Remote (${cfg.apiUrl})` : "Local (127.0.0.1:14242)"}`,
 			);
 			lines.push(`API key: ${cfg.apiKey ? "set" : "not set"}`);
+			lines.push("Memory tools: nmem CLI");
+			lines.push("Thread sync: Mem HTTP API");
 
 			// 2. CLI resolution
 			try {
@@ -156,6 +191,9 @@ export function createStatusTool(client, _logger, cfg, runtimeInfo = {}) {
 				} else {
 					lines.push("  Ensure the Nowledge Mem desktop app is running.");
 				}
+				lines.push(
+					"  Memory tools may still work through the CLI, but thread auto-sync will fail while the HTTP API is unreachable.",
+				);
 			}
 
 			// 4. Effective config with sources
@@ -178,6 +216,9 @@ export function createStatusTool(client, _logger, cfg, runtimeInfo = {}) {
 			);
 			lines.push(
 				`  maxThreadMessageChars: ${cfg.maxThreadMessageChars} (${sources.maxThreadMessageChars || "?"})`,
+			);
+			lines.push(
+				`  corpusSupplement: ${cfg.corpusSupplement} (${sources.corpusSupplement || "?"})`,
 			);
 
 			details.config = {
@@ -204,6 +245,10 @@ export function createStatusTool(client, _logger, cfg, runtimeInfo = {}) {
 				maxThreadMessageChars: {
 					value: cfg.maxThreadMessageChars,
 					source: sources.maxThreadMessageChars,
+				},
+				corpusSupplement: {
+					value: cfg.corpusSupplement,
+					source: sources.corpusSupplement,
 				},
 				apiUrl: { value: cfg.apiUrl || "(local)", source: sources.apiUrl },
 				apiKey: {

--- a/nowledge-mem-openclaw-plugin/src/tools/status.js
+++ b/nowledge-mem-openclaw-plugin/src/tools/status.js
@@ -69,10 +69,11 @@ export function createStatusTool(client, _logger, cfg, runtimeInfo = {}) {
 					? runtimeInfo.contextEngineRegistrationError.trim()
 					: null;
 			details.memorySlot = memorySlot ?? "(unknown)";
-			details.contextEngineSlot =
+			const ceSlot =
 				contextEngineSlot && String(contextEngineSlot).trim()
-					? String(contextEngineSlot)
+					? String(contextEngineSlot).trim()
 					: "legacy";
+			details.contextEngineSlot = ceSlot;
 			details.contextEngineRegistered = contextEngineRegistered;
 			if (memorySlot && memorySlot !== "openclaw-nowledge-mem") {
 				const corpusOn = cfg.corpusSupplement === true;
@@ -103,10 +104,6 @@ export function createStatusTool(client, _logger, cfg, runtimeInfo = {}) {
 			}
 
 			// 0c. Capture routing — hooks vs context engine
-			const ceSlot =
-				contextEngineSlot && String(contextEngineSlot).trim()
-					? String(contextEngineSlot).trim()
-					: "legacy";
 			const ceActive = ceSlot === "nowledge-mem" && contextEngineRegistered;
 			const captureMode = !cfg.sessionDigest
 				? "disabled"

--- a/nowledge-mem-openclaw-plugin/src/tools/status.js
+++ b/nowledge-mem-openclaw-plugin/src/tools/status.js
@@ -62,11 +62,18 @@ export function createStatusTool(client, _logger, cfg, runtimeInfo = {}) {
 			// 0b. Memory slot check — show current mode and options
 			const memorySlot = runtimeInfo.memorySlot;
 			const contextEngineSlot = runtimeInfo.contextEngineSlot;
+			const contextEngineRegistered = runtimeInfo.contextEngineRegistered === true;
+			const contextEngineRegistrationError =
+				typeof runtimeInfo.contextEngineRegistrationError === "string" &&
+				runtimeInfo.contextEngineRegistrationError.trim()
+					? runtimeInfo.contextEngineRegistrationError.trim()
+					: null;
 			details.memorySlot = memorySlot ?? "(unknown)";
 			details.contextEngineSlot =
 				contextEngineSlot && String(contextEngineSlot).trim()
 					? String(contextEngineSlot)
 					: "legacy";
+			details.contextEngineRegistered = contextEngineRegistered;
 			if (memorySlot && memorySlot !== "openclaw-nowledge-mem") {
 				const corpusOn = cfg.corpusSupplement === true;
 				if (corpusOn) {
@@ -100,15 +107,24 @@ export function createStatusTool(client, _logger, cfg, runtimeInfo = {}) {
 				contextEngineSlot && String(contextEngineSlot).trim()
 					? String(contextEngineSlot).trim()
 					: "legacy";
+			const ceActive = ceSlot === "nowledge-mem" && contextEngineRegistered;
 			const captureMode = !cfg.sessionDigest
 				? "disabled"
-				: ceSlot === "nowledge-mem" ? "context-engine+hooks" : "hooks";
+				: ceActive ? "context-engine+hooks" : "hooks";
 			details.captureMode = captureMode;
-			if (ceSlot === "nowledge-mem") {
+			if (ceActive) {
 				lines.push("Context Engine slot: nowledge-mem (active)");
 				lines.push(
 					"  Thread capture runs through Context Engine afterTurn with hook fallback (agent_end, after_compaction, before_reset).",
 				);
+			} else if (ceSlot === "nowledge-mem") {
+				lines.push("Context Engine slot: nowledge-mem (configured, fallback to hooks)");
+				lines.push(
+					"  The slot points to Nowledge Mem, but Context Engine registration is not active in this runtime. Thread capture is using hooks only.",
+				);
+				if (contextEngineRegistrationError) {
+					lines.push(`  CE registration detail: ${contextEngineRegistrationError}`);
+				}
 			} else {
 				lines.push(
 					`Context Engine slot: ${ceSlot === "legacy" ? "legacy (default)" : `"${ceSlot}"`}`,


### PR DESCRIPTION
## Summary

This PR prepares the OpenClaw integration for release and tightens the thread-capture contract.

The final shape is broader and more defensible than the original incident report:

- capture no longer depends on a single runtime path when the Context Engine slot is active
- one logical OpenClaw chat persists as one Mem thread
- internal OpenClaw helper sessions no longer pollute Threads
- stored thread content is cleaned before persistence
- package metadata, validator rules, docs, and troubleshooting are aligned for npm and ClawHub release

## What Changed

### Capture reliability

- keep lifecycle hook capture enabled as a safety net when `plugins.slots.contextEngine = "nowledge-mem"`
- make `nowledge_mem_status` report the real active capture mode (`hooks` vs `context-engine+hooks`)
- make the CLI-backed memory tool path vs API-backed thread-sync path explicit in diagnostics

### Thread shape cleanup

- derive thread identity from stable OpenClaw `sessionKey`, not transient `sessionId`
- exclude internal helper sessions such as `temp:*` and subagent sessions
- strip synthetic `/new` / `/reset` startup prompts from persisted user content
- strip OpenClaw directive tags and internal `openclaw-control-ui` sender envelopes before persistence

### Release surfaces

- align package / manifest / registry versions
- keep ClawHub-required metadata while omitting unnecessary hard host gates
- strengthen the OpenClaw release validator and publish runbook
- clarify user docs for:
  - CE on / CE off behavior
  - remote config via `nmem config client ...`
  - restart semantics for `sessionDigest`
  - inspecting synced OpenClaw threads with `nmem t list --source openclaw`

## Validation

Passed locally:

- `node nowledge-mem-openclaw-plugin/scripts/validate-plugin.mjs`
- `cd nowledge-mem-openclaw-plugin && npm pack --dry-run`
- `cd ../3pp/clawhub && bun clawhub package publish /.../nowledge-mem-openclaw-plugin --dry-run`

Manual/local verification completed:

- OpenClaw plugin loads on the current host
- `nowledge_mem_status` reports the expected mode and routing
- live local plugin copy updated and loaded in OpenClaw

## Notes

- This PR improves reliability and cleanup around the reported thread-sync area, but it does **not** claim that every observed user report had the same root cause.
- Later follow-up suggested at least one report likely involved `sessionDigest` being off after a restart. The docs and postmortem were updated to reflect that nuance.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core thread-capture/persistence filtering and routing between Context Engine and hook paths; mistakes could cause missed captures or unexpected thread shapes despite idempotent tail-sync safeguards.
> 
> **Overview**
> Improves OpenClaw thread auto-sync reliability by keeping lifecycle capture hooks enabled even when the Context Engine slot is active, and by making thread identity prefer the stable `sessionKey` so CE `afterTurn` and hook capture append to the same Mem thread.
> 
> Tightens what gets persisted: excludes internal/helper sessions (`temp:*`, subagents), strips synthetic `/new`/`/reset` startup prompts, removes OpenClaw directive tags, and drops `openclaw-control-ui` sender metadata wrappers from stored thread messages.
> 
> Updates diagnostics and release surfaces: `nowledge_mem_status` now reports the effective capture mode (hooks vs `context-engine+hooks`), CE registration fallback details, and the split between CLI-backed memory tools and HTTP API thread sync; bumps the OpenClaw integration/plugin to `0.8.8`, removes hard host gates (`openclaw.install.minHostVersion`/`peerDependencies`), and updates the validator/runbook/docs to match.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 32005c33646a0b98cfc8c663b1ddc13337ead167. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved status reporting showing Context Engine registration state and capture routing (context-engine vs hooks).

* **Bug Fixes**
  * Better capture hygiene: excludes internal/helper sessions and transient control metadata; ensures stable thread appends when Context Engine is used.
  * Thread-sync behavior more reliable across session lifecycle.

* **Documentation**
  * Expanded troubleshooting, configuration guidance, and clarifications on session/thread capture behavior.

* **Chores**
  * Plugin and integration versions bumped to v0.8.8.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->