### PR TITLE
fix(openclaw&herm): dreaming and hermes setup script

### DIFF
--- a/integrations.json
+++ b/integrations.json
@@ -427,7 +427,7 @@
       "name": "Hermes Agent",
       "category": "coding",
       "type": "plugin",
-      "version": "0.5.7",
+      "version": "0.5.8",
       "directory": "nowledge-mem-hermes",
       "transport": "cli",
       "capabilities": {

--- a/integrations.json
+++ b/integrations.json
@@ -240,7 +240,7 @@
       "name": "OpenClaw",
       "category": "coding",
       "type": "plugin",
-      "version": "0.8.13",
+      "version": "0.8.14",
       "directory": "nowledge-mem-openclaw-plugin",
       "transport": "cli",
       "capabilities": {

--- a/nowledge-mem-hermes/CHANGELOG.md
+++ b/nowledge-mem-hermes/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ## Unreleased
 
+## [0.5.8] - 2026-04-14
+
+### Fixed
+
+- `setup.sh` now repairs an existing `memory:` block when `provider` is missing or set to an empty string. Earlier builds installed the plugin files correctly but still exited with code `1`, which left users with a half-successful setup until they edited `config.yaml` by hand.
+- The installer still refuses to overwrite a different non-empty `memory.provider` silently. It now explains that conflict directly instead of treating every non-ready `memory:` block as the same generic failure.
+
 ### Fixed
 
 - Invalid `timeout` values in `~/.hermes/nowledge-mem.json` no longer crash the provider. Hermes now falls back to the default timeout and keeps the provider available.

--- a/nowledge-mem-hermes/README.md
+++ b/nowledge-mem-hermes/README.md
@@ -16,6 +16,8 @@ The plugin integrates at the memory-provider level: Working Memory loads automat
 bash <(curl -sL https://raw.githubusercontent.com/nowledge-co/community/main/nowledge-mem-hermes/setup.sh)
 ```
 
+The installer is idempotent. If `~/.hermes/config.yaml` already has a `memory:` block, it now fills a missing or empty `provider` automatically. It still stops and explains the change when `memory.provider` already points at a different non-empty provider.
+
 Or with the interactive setup:
 
 ```bash

--- a/nowledge-mem-hermes/plugin.yaml
+++ b/nowledge-mem-hermes/plugin.yaml
@@ -1,5 +1,5 @@
 name: nowledge-mem
-version: 0.5.7
+version: 0.5.8
 description: "Cross-tool personal knowledge graph with semantic search, Working Memory, and proactive recall."
 hooks:
   - prefetch

--- a/nowledge-mem-hermes/setup.sh
+++ b/nowledge-mem-hermes/setup.sh
@@ -42,6 +42,80 @@ get_file() {
   fi
 }
 
+ensure_memory_provider() {
+  local config_path="$1"
+  python3 - "$config_path" <<'PY'
+from pathlib import Path
+import re
+import sys
+
+config_path = Path(sys.argv[1])
+if not config_path.exists():
+    print("missing-file")
+    raise SystemExit(0)
+
+text = config_path.read_text(encoding="utf-8")
+lines = text.splitlines()
+
+memory_idx = None
+for idx, line in enumerate(lines):
+    if re.match(r"^memory:\s*(#.*)?$", line):
+        memory_idx = idx
+        break
+
+if memory_idx is None:
+    print("missing-memory")
+    raise SystemExit(0)
+
+block_end = len(lines)
+for idx in range(memory_idx + 1, len(lines)):
+    line = lines[idx]
+    stripped = line.strip()
+    if not stripped:
+        continue
+    if line.lstrip().startswith("#"):
+        continue
+    if not line.startswith((" ", "\t")):
+        block_end = idx
+        break
+
+child_indent = "  "
+for idx in range(memory_idx + 1, block_end):
+    line = lines[idx]
+    stripped = line.strip()
+    if not stripped or line.lstrip().startswith("#"):
+        continue
+    match = re.match(r"^(\s+)", line)
+    if match:
+        child_indent = match.group(1)
+        break
+
+for idx in range(memory_idx + 1, block_end):
+    line = lines[idx]
+    match = re.match(r"^(\s*)provider:\s*(.*?)\s*(#.*)?$", line)
+    if not match:
+        continue
+    indent = match.group(1) or child_indent
+    raw_value = (match.group(2) or "").strip()
+    if raw_value in ('"nowledge-mem"', "'nowledge-mem'", "nowledge-mem"):
+        print("already")
+        raise SystemExit(0)
+    if raw_value in ("", '""', "''"):
+        lines[idx] = f'{indent}provider: "nowledge-mem"'
+        trailing_newline = "\n" if text.endswith("\n") else ""
+        config_path.write_text("\n".join(lines) + trailing_newline, encoding="utf-8")
+        print("updated-empty")
+        raise SystemExit(0)
+    print(f"conflict:{raw_value}")
+    raise SystemExit(0)
+
+lines.insert(memory_idx + 1, f'{child_indent}provider: "nowledge-mem"')
+trailing_newline = "\n" if text.endswith("\n") else ""
+config_path.write_text("\n".join(lines) + trailing_newline, encoding="utf-8")
+print("inserted")
+PY
+}
+
 # =========================================================================
 # Plugin install
 # =========================================================================
@@ -86,31 +160,45 @@ if [ "$MODE" = "plugin" ]; then
     echo "  [ok] Removed old install path $OLD_PLUGIN_DIR"
   fi
 
-  # Set memory.provider in config.yaml
-  # Use a single grep to avoid false positives when "provider:" and "nowledge-mem"
-  # appear in unrelated sections (e.g. mcp_servers).
-  if [ -f "$CONFIG" ] && grep -qE 'provider:.*nowledge-mem' "$CONFIG"; then
-    echo "[ok] memory.provider already set in $CONFIG"
-  elif [ ! -f "$CONFIG" ]; then
+  # Set memory.provider in config.yaml.
+  if [ ! -f "$CONFIG" ]; then
     cat > "$CONFIG" << 'YAML'
 memory:
   provider: "nowledge-mem"
 YAML
     echo "[ok] Created $CONFIG with memory.provider: nowledge-mem"
-  elif grep -qF "memory:" "$CONFIG"; then
-    # memory section exists but provider not set — inform user
-    echo ""
-    echo "[action needed] $CONFIG has a memory: section but provider is not set."
-    echo "Add the following under your memory: block:"
-    echo ""
-    echo '  provider: "nowledge-mem"'
-    echo ""
-    echo "Plugin installed to $PLUGIN_DIR but config is incomplete."
-    exit 1
   else
-    # No memory section — append it
-    printf '\nmemory:\n  provider: "nowledge-mem"\n' >> "$CONFIG"
-    echo "[ok] Added memory.provider to $CONFIG"
+    MEMORY_PROVIDER_STATUS="$(ensure_memory_provider "$CONFIG")"
+    case "$MEMORY_PROVIDER_STATUS" in
+      already)
+        echo "[ok] memory.provider already set in $CONFIG"
+        ;;
+      updated-empty)
+        echo "[ok] Filled empty memory.provider in $CONFIG"
+        ;;
+      inserted)
+        echo "[ok] Added memory.provider under existing memory: block in $CONFIG"
+        ;;
+      missing-memory)
+        printf '\nmemory:\n  provider: "nowledge-mem"\n' >> "$CONFIG"
+        echo "[ok] Added memory.provider to $CONFIG"
+        ;;
+      conflict:*)
+        EXISTING_PROVIDER="${MEMORY_PROVIDER_STATUS#conflict:}"
+        echo ""
+        echo "[action needed] $CONFIG already sets memory.provider to $EXISTING_PROVIDER."
+        echo "If you want Hermes to use this plugin, change it to:"
+        echo ""
+        echo '  provider: "nowledge-mem"'
+        echo ""
+        echo "Plugin installed to $PLUGIN_DIR but config still points at another provider."
+        exit 1
+        ;;
+      *)
+        echo "[error] Could not update memory.provider in $CONFIG"
+        exit 1
+        ;;
+    esac
   fi
 
   # Remove MCP server config if present (plugin replaces it)

--- a/nowledge-mem-hermes/tests/test_setup.sh
+++ b/nowledge-mem-hermes/tests/test_setup.sh
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+SETUP_SH="$ROOT_DIR/setup.sh"
+TMP_DIR="$(mktemp -d)"
+trap 'rm -rf "$TMP_DIR"' EXIT
+
+fail() {
+  echo "[fail] $1" >&2
+  exit 1
+}
+
+run_with_config() {
+  local fixture_name="$1"
+  local fixture_content="$2"
+  local expected_line="$3"
+  local expected_output="$4"
+
+  local home_dir="$TMP_DIR/$fixture_name-home"
+  local hermes_home="$home_dir/.hermes"
+  mkdir -p "$hermes_home"
+  printf '%s\n' "$fixture_content" > "$hermes_home/config.yaml"
+
+  local output
+  if ! output="$(HOME="$home_dir" HERMES_HOME="$hermes_home" bash "$SETUP_SH" 2>&1)"; then
+    echo "$output" >&2
+    fail "$fixture_name exited non-zero"
+  fi
+
+  grep -Fq "$expected_line" "$hermes_home/config.yaml" || fail "$fixture_name did not update config.yaml"
+  grep -Fq "$expected_output" <<<"$output" || fail "$fixture_name did not report expected installer output"
+  [ -f "$hermes_home/plugins/nowledge-mem/plugin.yaml" ] || fail "$fixture_name did not install plugin files"
+}
+
+run_with_config \
+  "empty-provider" \
+  $'memory:\n  provider: ""' \
+  'provider: "nowledge-mem"' \
+  '[ok] Filled empty memory.provider'
+
+run_with_config \
+  "missing-provider" \
+  $'memory:\n  timeout: 30' \
+  'provider: "nowledge-mem"' \
+  '[ok] Added memory.provider under existing memory: block'
+
+conflict_home="$TMP_DIR/conflict-home"
+conflict_hermes="$conflict_home/.hermes"
+mkdir -p "$conflict_hermes"
+cat > "$conflict_hermes/config.yaml" <<'YAML'
+memory:
+  provider: "other-provider"
+YAML
+
+set +e
+conflict_output="$(HOME="$conflict_home" HERMES_HOME="$conflict_hermes" bash "$SETUP_SH" 2>&1)"
+conflict_status=$?
+set -e
+
+[ "$conflict_status" -ne 0 ] || fail "conflict-provider unexpectedly succeeded"
+grep -Fq '[action needed]' <<<"$conflict_output" || fail "conflict-provider did not explain the conflict"
+grep -Fq 'provider: "other-provider"' "$conflict_hermes/config.yaml" || fail "conflict-provider should not rewrite existing provider"
+
+echo "[ok] Hermes setup installer regression checks passed"

--- a/nowledge-mem-openclaw-plugin/CHANGELOG.md
+++ b/nowledge-mem-openclaw-plugin/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to the Nowledge Mem OpenClaw plugin will be documented in th
 
 ## Unreleased
 
+## [0.8.14] - 2026-04-14
+
+### Fixed
+
+- OpenClaw-native `dreaming` config no longer crashes plugin registration when Nowledge Mem owns the memory slot. The plugin now accepts that host-managed config object instead of rejecting it as an unknown key, so memory-core can keep running the dreaming engine alongside Nowledge Mem.
+
+### Changed
+
+- The OpenClaw manifest, validator, and docs now explicitly treat `dreaming` as a host-owned pass-through config key for memory-slot compatibility.
+
 ## [0.8.13] - 2026-04-11
 
 ### Fixed

--- a/nowledge-mem-openclaw-plugin/README.md
+++ b/nowledge-mem-openclaw-plugin/README.md
@@ -240,6 +240,8 @@ When OpenClaw's memory-core is the primary memory slot and Nowledge Mem runs alo
 
 Requires OpenClaw >= 2026.4.5.
 
+If OpenClaw stores a top-level `dreaming` object on this plugin while it owns the memory slot, that is expected. Dreaming remains OpenClaw-native host config; this plugin accepts it so memory-core can run the dreaming engine alongside Nowledge Mem without registration errors.
+
 ### Three Modes at a Glance
 
 ```mermaid
@@ -428,6 +430,7 @@ To change settings, use the OpenClaw plugin settings UI. Changes take effect on 
 | `corpusSupplement` | boolean | `false` | Register as a searchable corpus inside memory-core's recall and dreaming pipeline |
 | `corpusMaxResults` | integer | `5` | Max results per corpus supplement search (1-20) |
 | `corpusMinScore` | integer | `0` | Min relevance score (0-100%) for supplement results. 0 = include all |
+| `dreaming` | object | — | Optional OpenClaw-native dreaming config accepted when this plugin owns the memory slot. The host consumes it; this plugin only tolerates and preserves it |
 | `apiUrl` | string | `""` | Remote server URL. Empty = local (`http://127.0.0.1:14242`) |
 | `apiKey` | string | `""` | API key for remote access. Injected as `NMEM_API_KEY` env var, never logged |
 

--- a/nowledge-mem-openclaw-plugin/openclaw.plugin.json
+++ b/nowledge-mem-openclaw-plugin/openclaw.plugin.json
@@ -2,7 +2,7 @@
 	"id": "openclaw-nowledge-mem",
 	"name": "Nowledge Mem",
 	"description": "Cross-tool knowledge graph memory for OpenClaw with Working Memory, graph search, and session distillation.",
-	"version": "0.8.13",
+	"version": "0.8.14",
 	"kind": "memory",
 	"skills": [
 		"skills/memory-guide"
@@ -51,6 +51,10 @@
 		"corpusMinScore": {
 			"label": "Corpus supplement min score (%)",
 			"help": "Minimum relevance score (0-100%) for corpus supplement results. Set to 0 to include all. Only used when corpusSupplement is enabled."
+		},
+		"dreaming": {
+			"label": "Dreaming",
+			"help": "Optional OpenClaw dreaming config consumed by the host when this plugin owns the memory slot. This plugin accepts and preserves the setting; memory-core still provides the dreaming engine."
 		},
 		"apiUrl": {
 			"label": "Server URL (remote mode)",
@@ -142,6 +146,10 @@
 				"minimum": 0,
 				"maximum": 100,
 				"description": "Minimum relevance score (0-100%) for corpus supplement results (only used when corpusSupplement is enabled)"
+			},
+			"dreaming": {
+				"type": "object",
+				"description": "Optional OpenClaw native dreaming config. Accepted and preserved when this plugin owns the memory slot."
 			},
 			"apiUrl": {
 				"type": "string",

--- a/nowledge-mem-openclaw-plugin/package-lock.json
+++ b/nowledge-mem-openclaw-plugin/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "@nowledge/openclaw-nowledge-mem",
-	"version": "0.8.13",
+	"version": "0.8.14",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "@nowledge/openclaw-nowledge-mem",
-			"version": "0.8.13",
+			"version": "0.8.14",
 			"license": "MIT",
 			"devDependencies": {
 				"@biomejs/biome": "^1.9.0"

--- a/nowledge-mem-openclaw-plugin/package.json
+++ b/nowledge-mem-openclaw-plugin/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@nowledge/openclaw-nowledge-mem",
 	"displayName": "Nowledge Mem for OpenClaw",
-	"version": "0.8.13",
+	"version": "0.8.14",
 	"type": "module",
 	"description": "Nowledge Mem memory plugin for OpenClaw, local-first personal knowledge base",
 	"author": {

--- a/nowledge-mem-openclaw-plugin/scripts/validate-plugin.mjs
+++ b/nowledge-mem-openclaw-plugin/scripts/validate-plugin.mjs
@@ -157,6 +157,7 @@ async function main() {
     corpusSupplement: { type: "boolean", default: false },
     corpusMaxResults: { type: "integer", default: 5, minimum: 1, maximum: 20 },
     corpusMinScore: { type: "integer", default: 0, minimum: 0, maximum: 100 },
+    dreaming: { type: "object" },
     apiUrl: { type: "string", default: "" },
     apiKey: { type: "string", default: "" },
     space: { type: "string", default: "" },
@@ -177,7 +178,11 @@ async function main() {
     if (property.type !== spec.type) {
       fail(`configSchema.properties.${key}.type must be ${spec.type}`);
     }
-    assertSameJsonValue(property.default, spec.default, `configSchema.properties.${key}.default`);
+    if (Object.prototype.hasOwnProperty.call(spec, "default")) {
+      assertSameJsonValue(property.default, spec.default, `configSchema.properties.${key}.default`);
+    } else if (Object.prototype.hasOwnProperty.call(property, "default")) {
+      fail(`configSchema.properties.${key}.default should be omitted`);
+    }
     if (spec.type === "integer") {
       if (property.minimum !== spec.minimum) {
         fail(`configSchema.properties.${key}.minimum must be ${spec.minimum}`);

--- a/nowledge-mem-openclaw-plugin/src/config.js
+++ b/nowledge-mem-openclaw-plugin/src/config.js
@@ -26,6 +26,7 @@ const ALLOWED_KEYS = new Set([
 	"corpusSupplement",
 	"corpusMaxResults",
 	"corpusMinScore",
+	"dreaming",
 	"apiUrl",
 	"apiKey",
 	"space",
@@ -213,7 +214,7 @@ function firstDefined(...options) {
  *
  * Canonical keys: sessionContext, sessionDigest, digestMinInterval,
  *                 maxContextResults, recallMinScore, maxThreadMessageChars,
- *                 apiUrl, apiKey, space, spaceTemplate
+ *                 apiUrl, apiKey, space, spaceTemplate, dreaming
  *
  * Legacy aliases (accepted from all sources; never shown in docs):
  *   autoRecall → sessionContext
@@ -234,6 +235,12 @@ function firstDefined(...options) {
  *   NMEM_API_URL               — remote server URL
  *   NMEM_API_KEY               — API key (never logged)
  *   NMEM_SPACE                 — ambient space name (legacy: NMEM_SPACE_ID)
+ *
+ * Host-owned pass-through key:
+ *   dreaming                   — OpenClaw's native dreaming config object.
+ *                                This plugin does not interpret it, but must
+ *                                tolerate it when OpenClaw stores dreaming
+ *                                settings on the selected memory-slot owner.
  */
 export function parseConfig(raw, logger) {
 	const pluginCfg = raw && typeof raw === "object" ? raw : {};

--- a/nowledge-mem-openclaw-plugin/tests/space-config.test.mjs
+++ b/nowledge-mem-openclaw-plugin/tests/space-config.test.mjs
@@ -75,6 +75,20 @@ test("parseConfig preserves explicit empty space over ambient env", () => {
 	}
 });
 
+test("parseConfig accepts OpenClaw host-owned dreaming config", () => {
+	const cfg = parseConfig(
+		{
+			dreaming: {
+				enabled: true,
+				frequency: "0 3 * * *",
+			},
+		},
+		logger,
+	);
+	assert.equal(cfg.sessionDigest, true);
+	assert.equal(cfg.corpusSupplement, false);
+});
+
 test("parseConfig rejects unknown keys in legacy file config", () => {
 	const tempHome = mkdtempSync(join(tmpdir(), "nmem-openclaw-home-"));
 	mkdirSync(join(tempHome, ".nowledge-mem"), { recursive: true });


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Moderate risk because `nowledge-mem-hermes/setup.sh` now programmatically edits users’ `config.yaml` via a custom Python/YAML-ish parser, which could mis-handle unusual formatting; OpenClaw changes are mostly additive schema/validation tweaks.
> 
> **Overview**
> **OpenClaw plugin:** bumps to `0.8.14` and updates config handling to *accept a top-level host-owned `dreaming` object* (treated as pass-through) so plugin registration doesn’t fail when OpenClaw stores dreaming settings on the memory-slot owner. This is reflected across the manifest/schema (`openclaw.plugin.json`), validator (`validate-plugin.mjs` default-check logic for keys without defaults), config parser allowlist (`src/config.js`), and a new test covering the `dreaming` key.
> 
> **Hermes provider:** bumps to `0.5.8` and fixes `setup.sh` so it’s truly idempotent: when `~/.hermes/config.yaml` already contains `memory:` it now inserts/fills `memory.provider` if missing/empty, but fails with a clear message if a different non-empty provider is configured. Adds a small shell regression test (`tests/test_setup.sh`) and updates README/changelog accordingly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 472d840e40bddc5ab01f8502006a27612b7aebe3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * OpenClaw plugin now supports optional dreaming configuration.

* **Bug Fixes**
  * Hermes Agent installer now properly handles missing or empty memory provider settings instead of failing.
  * Hermes Agent installer provides clearer error messages when memory provider conflicts with existing configuration.
  * OpenClaw plugin accepts and preserves host-native dreaming configuration during registration.

* **Updates**
  * OpenClaw plugin bumped to v0.8.14.
  * Hermes Agent plugin bumped to v0.5.8.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->