### PR TITLE
Fix Copilot CLI packaged hook runtime

### DIFF
--- a/integrations.json
+++ b/integrations.json
@@ -54,7 +54,7 @@
       "name": "Copilot CLI",
       "category": "coding",
       "type": "plugin",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "directory": "nowledge-mem-copilot-cli-plugin",
       "transport": "cli",
       "capabilities": {
@@ -79,7 +79,7 @@
         "bestResultRequires": [
           "Install the native plugin",
           "Keep nmem available on this machine",
-          "Run install-hooks.sh after install to set up session capture"
+          "Restart Copilot CLI after install so hooks reload"
         ]
       },
       "install": {

--- a/nowledge-mem-copilot-cli-plugin/.claude-plugin/plugin.json
+++ b/nowledge-mem-copilot-cli-plugin/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "nowledge-mem",
   "description": "Personal knowledge graph for GitHub Copilot CLI — remembers decisions, searches past work, captures sessions",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "author": {
     "name": "Nowledge Labs",
     "email": "hello@nowledge-labs.ai",

--- a/nowledge-mem-copilot-cli-plugin/CHANGELOG.md
+++ b/nowledge-mem-copilot-cli-plugin/CHANGELOG.md
@@ -5,7 +5,15 @@ All notable changes to the Nowledge Mem Copilot CLI plugin will be documented in
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.1.0] - Unreleased
+## [0.1.1] - Unreleased
+
+### Fixed
+
+- **Marketplace install compatibility** — session capture now runs from packaged files in `hooks/`, so Copilot marketplace installs no longer depend on a missing `scripts/` directory
+- **Stop hook fallback chain** — capture prefers the packaged runtime under `COPILOT_PLUGIN_ROOT/hooks/`, then falls back to `~/.copilot/nowledge-mem-hooks/` for older installs
+- **Docs and release guidance** — no longer tell users to run a marketplace path that Copilot does not install
+
+## [0.1.0] - 2026-04-21
 
 ### Added
 
@@ -21,7 +29,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Incomplete turn detection (questions, background tasks, ask_user)
   - File locking for concurrent session safety
   - Auto-distill with guardrails (cooldown, content hash dedup, minimum thresholds)
-- **Idempotent installer** (`install-hooks.sh`) — copies capture scripts to `~/.copilot/nowledge-mem-hooks/`
+- **Idempotent installer** (`install-hooks.sh`) — compatibility fallback that copies capture scripts to `~/.copilot/nowledge-mem-hooks/`
 - **Cross-platform support** — Windows `nmem.cmd` fallback in hooks, Python runtime as primary
 - **Space support** via `NMEM_SPACE` environment variable
 - Registered in `integrations.json` as `copilot-cli` with `plugin-capture` thread save method

--- a/nowledge-mem-copilot-cli-plugin/README.md
+++ b/nowledge-mem-copilot-cli-plugin/README.md
@@ -10,9 +10,6 @@ copilot plugin marketplace add nowledge-co/community
 
 # Install the plugin
 copilot plugin install nowledge-mem@nowledge-community
-
-# Set up session capture hooks
-bash "$HOME/.copilot/installed-plugins/nowledge-community/nowledge-mem/scripts/install-hooks.sh"
 ```
 
 **Prerequisite:** `nmem` CLI must be in your PATH:
@@ -75,7 +72,7 @@ The plugin no longer ships separate command docs. Skills are still interpreted b
 
 The `SessionStart` hook tries `nmem --json wm read` first (works for both local and remote), then falls back to reading `~/ai-now/memory.md` only as the **Default-space** compatibility path.
 
-The `Stop` hook runs a Python capture script in the background after every response. It reads the Copilot CLI transcript, extracts messages, filters secrets, and creates threads via `nmem t import`. This is idempotent — repeated runs only append new content.
+The `Stop` hook runs a Python capture script from the plugin's own `hooks/` directory in the background after every response. For older installs, it still falls back to `~/.copilot/nowledge-mem-hooks/` if that compatibility copy exists. It reads the Copilot CLI transcript, extracts messages, filters secrets, and creates threads via `nmem t import`. This is idempotent — repeated runs only append new content.
 
 ### Session Capture Details
 
@@ -116,12 +113,9 @@ The session-start Working Memory read, per-turn guidance, skills, and background
 ```bash
 copilot plugin marketplace update nowledge-community
 copilot plugin update nowledge-mem
-
-# Re-run install-hooks.sh to update the capture script
-bash "$HOME/.copilot/installed-plugins/nowledge-community/nowledge-mem/scripts/install-hooks.sh"
-
-# Restart Copilot CLI to apply changes
 ```
+
+Restart Copilot CLI to apply changes.
 
 ## Customize without editing the plugin
 
@@ -139,7 +133,7 @@ Keep the plugin for lifecycle hooks and capture. Put your custom memory behavior
 
 **Server not running:** Start the Nowledge Mem desktop app, or run `nmem serve` on your server
 
-**Session capture not working:** Run `install-hooks.sh` again — it's idempotent. Check `~/.copilot/nowledge-mem-hooks/hook-log.jsonl` for diagnostics.
+**Session capture not working:** Restart Copilot CLI first. If capture still does not run, check `~/.copilot/nowledge-mem-hooks/hook-log.jsonl` for diagnostics. For older installs or local-development setups, you can still run `scripts/install-hooks.sh` from the source checkout as a compatibility fallback.
 
 **Check status:** Run `nmem status` to see connection details
 

--- a/nowledge-mem-copilot-cli-plugin/RELEASING.md
+++ b/nowledge-mem-copilot-cli-plugin/RELEASING.md
@@ -16,7 +16,7 @@ Before release:
 4. Install the plugin locally and verify:
    - Working Memory loads at session start
    - Per-turn nudge appears
-   - Stop hook captures sessions from the packaged plugin runtime (check `~/.copilot/nowledge-mem-hooks/hook-log.jsonl` if the compatibility fallback path is used)
+   - Stop hook captures sessions from the packaged plugin runtime, and `copilot-stop-save.py` writes diagnostics to `~/.copilot/nowledge-mem-hooks/hook-log.jsonl` for both the packaged and compatibility paths
    - Copilot shows only the skill-backed surface (no extra command-doc entries)
    - The remaining skills still match actual behavior (`read-working-memory`, `search-memory`, `distill-memory`, `save-thread`)
    - `nmem status` still works as the direct troubleshooting path

--- a/nowledge-mem-copilot-cli-plugin/RELEASING.md
+++ b/nowledge-mem-copilot-cli-plugin/RELEASING.md
@@ -16,7 +16,7 @@ Before release:
 4. Install the plugin locally and verify:
    - Working Memory loads at session start
    - Per-turn nudge appears
-   - Stop hook captures sessions (check `~/.copilot/nowledge-mem-hooks/hook-log.jsonl`)
+   - Stop hook captures sessions from the packaged plugin runtime (check `~/.copilot/nowledge-mem-hooks/hook-log.jsonl` if the compatibility fallback path is used)
    - Copilot shows only the skill-backed surface (no extra command-doc entries)
    - The remaining skills still match actual behavior (`read-working-memory`, `search-memory`, `distill-memory`, `save-thread`)
    - `nmem status` still works as the direct troubleshooting path

--- a/nowledge-mem-copilot-cli-plugin/hooks/copilot-stop-save.py
+++ b/nowledge-mem-copilot-cli-plugin/hooks/copilot-stop-save.py
@@ -1,0 +1,626 @@
+#!/usr/bin/env python3
+"""Copilot CLI session capture for Nowledge Mem.
+
+Reads Copilot CLI transcript events from stdin (via Stop hook), extracts
+user/assistant messages, filters secrets, and creates threads via
+``nmem t import``. Auto-distills valuable sessions.
+
+Thread ID: ``copilot-{session_id}`` (stable per-session, enables incremental
+append). State management with file locking for concurrent session safety.
+"""
+
+import hashlib
+import json
+import os
+import re
+import subprocess
+import sys
+import tempfile
+import time
+from datetime import datetime
+from pathlib import Path
+
+try:
+    import fcntl
+except ImportError:
+    fcntl = None  # Windows — locking handled via msvcrt fallback
+
+
+ROOT = Path.home() / ".copilot" / "nowledge-mem-hooks"
+STATE_DIR = ROOT / "state"
+LOG_FILE = ROOT / "hook-log.jsonl"
+
+MIN_SAVE_CHARS = 24
+MIN_DISTILL_CHARS = 320
+MIN_DISTILL_ASSISTANT_CHARS = 220
+DISTILL_COOLDOWN_SECS = 120
+
+INCOMPLETE_RE = re.compile(
+    r"(请确认|请选择|请告诉我|告诉我继续|完成后告诉我|需要你|你希望|你想让我|请提供|方便的话|要不要|"
+    r"please confirm|let me know|which option|can you provide|what would you like|want me to)",
+    re.IGNORECASE,
+)
+SIGNAL_RE = re.compile(
+    r"(决定|采用|结论|原因|因为|流程|步骤|根因|修复|策略|标准|规则|约定|配置|经验|注意|陷阱|风险|"
+    r"decision|because|rationale|procedure|workflow|root cause|playbook|guideline|trade-?off)",
+    re.IGNORECASE,
+)
+TAG_BLOCK_RE = re.compile(
+    r"<(current_datetime|reminder|tools_changed_notice)[^>]*>.*?</\1>", re.DOTALL
+)
+TAG_LINE_RE = re.compile(r"^\s*</?[^>\n]+>\s*$", re.MULTILINE)
+SECRET_PATTERNS = [
+    re.compile(r"(ghp_[A-Za-z0-9]{20,})"),
+    re.compile(r"(github_pat_[A-Za-z0-9_]{20,})"),
+    re.compile(r"(sk-[A-Za-z0-9_-]{16,})"),
+    re.compile(r"(Bearer\s+)[A-Za-z0-9._-]{16,}", re.IGNORECASE),
+    re.compile(
+        r"((?:API|ACCESS|AUTH|SECRET|PASSWORD|TOKEN)[A-Z0-9_]*\s*[:=]\s*[\"']?)[^\"'\s]+",
+        re.IGNORECASE,
+    ),
+]
+SENSITIVE_SKIP_PATTERNS = [
+    re.compile(r"-----BEGIN [A-Z0-9 ]*PRIVATE KEY-----"),
+    re.compile(r"\bssh-(?:rsa|ed25519)\s+[A-Za-z0-9+/=]{80,}"),
+    re.compile(r"\b(?:AKIA|ASIA)[0-9A-Z]{16}\b"),
+    re.compile(r"\bghp_[A-Za-z0-9]{20,}\b"),
+    re.compile(r"\bgithub_pat_[A-Za-z0-9_]{20,}\b"),
+    re.compile(r"\bsk-[A-Za-z0-9_-]{16,}\b"),
+    re.compile(
+        r"\beyJ[A-Za-z0-9_-]{8,}\.[A-Za-z0-9._-]{8,}\.[A-Za-z0-9._-]{8,}\b"
+    ),
+    re.compile(
+        r"\b(?:postgres|postgresql|mysql|mongodb(?:\\+srv)?|redis|amqp|kafka)://\S+",
+        re.IGNORECASE,
+    ),
+    re.compile(r"\b(?:cookie|set-cookie)\s*[:=]", re.IGNORECASE),
+    re.compile(r"\bxox[baprs]-[A-Za-z0-9-]{10,}\b"),
+]
+SENSITIVE_ASSIGN_RE = re.compile(
+    r"\b(?:api_key|access_key|access_token|auth_token|secret_key|secret|password|token|client_secret|"
+    r"connection_string|database_url|session_cookie)\s*[:=]\s*[\"']?([A-Za-z0-9._~+/=-]{12,})",
+    re.IGNORECASE,
+)
+PLACEHOLDER_HINTS = (
+    "placeholder",
+    "example",
+    "sample",
+    "dummy",
+    "fake",
+    "redacted",
+    "test",
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def log(payload: dict) -> None:
+    ROOT.mkdir(parents=True, exist_ok=True)
+    with LOG_FILE.open("a", encoding="utf-8") as fh:
+        fh.write(json.dumps(payload, ensure_ascii=False) + "\n")
+
+
+def extract_input(payload: dict) -> dict:
+    if isinstance(payload, dict):
+        if isinstance(payload.get("input"), dict):
+            return payload["input"]
+        if isinstance(payload.get("data"), dict):
+            data = payload["data"]
+            if isinstance(data.get("input"), dict):
+                return data["input"]
+            return data
+    return payload if isinstance(payload, dict) else {}
+
+
+def strip_wrappers(text: str) -> str:
+    text = text or ""
+    text = TAG_BLOCK_RE.sub("", text)
+    text = TAG_LINE_RE.sub("", text)
+    return text.strip()
+
+
+def redact(text: str) -> str:
+    redacted = text or ""
+    for pattern in SECRET_PATTERNS:
+        if pattern.groups == 0:
+            redacted = pattern.sub("[REDACTED]", redacted)
+        elif pattern.groups == 1:
+            redacted = pattern.sub("[REDACTED]", redacted)
+        else:
+            redacted = pattern.sub(r"\1[REDACTED]", redacted)
+    return redacted
+
+
+def clean_user_text(event: dict) -> str:
+    data = event.get("data", {})
+    text = (data.get("content") or "").strip()
+    if not text:
+        return ""
+    return redact(strip_wrappers(text)).strip()
+
+
+def clean_assistant_text(event: dict) -> str:
+    data = event.get("data", {})
+    return redact((data.get("content") or "").strip())
+
+
+def raw_visible_text(events: list) -> str:
+    parts: list[str] = []
+    for event in events:
+        data = event.get("data", {})
+        if event.get("type") == "user.message":
+            text = (data.get("content") or "").strip()
+            if text:
+                parts.append(text)
+        elif event.get("type") == "assistant.message":
+            text = (data.get("content") or "").strip()
+            if text:
+                parts.append(text)
+    return "\n\n".join(parts)
+
+
+def has_sensitive_content(text: str) -> bool:
+    if any(pattern.search(text) for pattern in SENSITIVE_SKIP_PATTERNS):
+        return True
+    for match in SENSITIVE_ASSIGN_RE.finditer(text):
+        value = match.group(1)
+        lower_value = value.lower()
+        if any(hint in lower_value for hint in PLACEHOLDER_HINTS):
+            continue
+        if len(value) >= 24:
+            return True
+        if len(value) >= 20 and (
+            any(ch.isdigit() for ch in value)
+            or any(ch in "._~+/=-" for ch in value)
+        ):
+            return True
+    return False
+
+
+def build_nmem_command(nmem_bin: str, *args: str) -> list[str]:
+    if nmem_bin.lower().endswith(".cmd"):
+        return [
+            "cmd.exe",
+            "/s",
+            "/c",
+            subprocess.list2cmdline([nmem_bin, *args]),
+        ]
+    return [nmem_bin, *args]
+
+
+def load_events(transcript_path: str) -> list[dict]:
+    with open(transcript_path, encoding="utf-8") as fh:
+        return [json.loads(line) for line in fh]
+
+
+def find_index(events: list[dict], event_id: str | None) -> int | None:
+    if not event_id:
+        return None
+    for idx, event in enumerate(events):
+        if event.get("id") == event_id:
+            return idx
+    return None
+
+
+def collect_messages(events: list[dict]) -> list[dict]:
+    messages: list[dict] = []
+    for event in events:
+        etype = event.get("type")
+        if etype == "user.message":
+            text = clean_user_text(event)
+            role = "user"
+        elif etype == "assistant.message":
+            text = clean_assistant_text(event)
+            role = "assistant"
+        else:
+            continue
+
+        if not text:
+            continue
+        if messages and messages[-1]["role"] == role:
+            messages[-1]["content"] += "\n\n" + text
+        else:
+            messages.append({"role": role, "content": text})
+    return messages
+
+
+def run_json(args: list[str]) -> dict:
+    proc = subprocess.run(args, capture_output=True, text=True)
+    if proc.returncode != 0:
+        raise RuntimeError(
+            proc.stderr.strip() or proc.stdout.strip() or "command failed"
+        )
+    output = proc.stdout.strip()
+    return json.loads(output) if output else {}
+
+
+def load_state(session_id: str) -> tuple[Path, dict]:
+    STATE_DIR.mkdir(parents=True, exist_ok=True)
+    path = STATE_DIR / f"{state_token(session_id)}.json"
+    if not path.exists():
+        return path, {
+            "active_start_event_id": None,
+            "last_saved_turn_end_id": None,
+            "last_distill_ts": 0,
+            "last_content_hash": None,
+        }
+    with path.open(encoding="utf-8") as fh:
+        state = json.load(fh)
+        state.setdefault("last_distill_ts", 0)
+        state.setdefault("last_content_hash", None)
+        return path, state
+
+
+def save_state(path: Path, state: dict) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("w", encoding="utf-8") as fh:
+        json.dump(state, fh, ensure_ascii=False, indent=2)
+
+
+def title_from_messages(messages: list[dict]) -> str:
+    user_parts = [
+        msg["content"].replace("\n", " ").strip()
+        for msg in messages
+        if msg["role"] == "user"
+    ]
+    title = user_parts[0] if user_parts else "GitHub Copilot CLI request"
+    return title[:96]
+
+
+def event_timestamp_ms(event: dict) -> int | None:
+    raw = event.get("timestamp")
+    if not raw:
+        return None
+    return int(
+        datetime.fromisoformat(raw.replace("Z", "+00:00")).timestamp() * 1000
+    )
+
+
+def content_hash(messages: list[dict]) -> str:
+    blob = json.dumps(messages, ensure_ascii=False, sort_keys=True)
+    return hashlib.sha256(blob.encode()).hexdigest()[:16]
+
+
+def state_token(session_id: str) -> str:
+    """Map a session id to a filesystem-safe, deterministic token."""
+    return hashlib.sha256(session_id.encode("utf-8")).hexdigest()[:32]
+
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+
+def main() -> int:
+    import shutil
+
+    raw = sys.stdin.read().strip()
+    payload = json.loads(raw) if raw else {}
+    hook_input = extract_input(payload)
+
+    session_id = hook_input.get("sessionId")
+    transcript_path = hook_input.get("transcriptPath")
+    stop_reason = hook_input.get("stopReason")
+    hook_timestamp = hook_input.get("timestamp")
+
+    if not session_id or not transcript_path or stop_reason != "end_turn":
+        return 0
+    if not Path(transcript_path).exists():
+        return 0
+
+    nmem_bin = shutil.which("nmem") or shutil.which("nmem.cmd")
+    if not nmem_bin:
+        log({"session_id": session_id, "action": "skip", "reason": "nmem_missing"})
+        return 0
+
+    lock_path = STATE_DIR / f"{state_token(session_id)}.lock"
+    lock_path.parent.mkdir(parents=True, exist_ok=True)
+    with lock_path.open("w+", encoding="utf-8") as lock_fh:
+        if fcntl:
+            fcntl.flock(lock_fh, fcntl.LOCK_EX)
+        else:
+            import msvcrt
+            lock_fh.write("\0")
+            lock_fh.flush()
+            lock_fh.seek(0)
+            msvcrt.locking(lock_fh.fileno(), msvcrt.LK_LOCK, 1)
+
+        state_path, state = load_state(session_id)
+        events = load_events(transcript_path)
+
+        # --- Locate current turn end ---
+        turn_end_events = [
+            e for e in events if e.get("type") == "assistant.turn_end"
+        ]
+        if not turn_end_events:
+            return 0
+        current_turn_end = next(
+            (
+                event
+                for event in reversed(turn_end_events)
+                if hook_timestamp is None
+                or (
+                    event_timestamp_ms(event) is not None
+                    and event_timestamp_ms(event) <= hook_timestamp
+                )
+            ),
+            turn_end_events[-1],
+        )
+        current_turn_end_id = current_turn_end.get("id")
+        if current_turn_end_id and current_turn_end_id == state.get(
+            "last_saved_turn_end_id"
+        ):
+            return 0
+
+        # --- Determine event window ---
+        last_saved_idx = find_index(
+            events, state.get("last_saved_turn_end_id")
+        )
+        real_user_indices = [
+            idx
+            for idx, event in enumerate(events)
+            if event.get("type") == "user.message" and clean_user_text(event)
+        ]
+        if not real_user_indices:
+            return 0
+
+        if state.get("active_start_event_id"):
+            start_idx = find_index(events, state["active_start_event_id"])
+        else:
+            start_idx = None
+        if start_idx is None:
+            start_idx = next(
+                (
+                    idx
+                    for idx in real_user_indices
+                    if last_saved_idx is None or idx > last_saved_idx
+                ),
+                None,
+            )
+        if start_idx is None:
+            return 0
+
+        end_idx = find_index(events, current_turn_end_id)
+        if end_idx is None or end_idx <= start_idx:
+            return 0
+
+        slice_events = events[start_idx : end_idx + 1]
+
+        # --- Incomplete turn detection ---
+        turn_start_indices = [
+            idx
+            for idx, event in enumerate(slice_events)
+            if event.get("type") == "assistant.turn_start"
+        ]
+        if not turn_start_indices:
+            return 0
+        cycle_start_idx = max(turn_start_indices)
+        cycle_events = slice_events[cycle_start_idx:]
+
+        cycle_tools: list[str] = []
+        has_background = False
+        used_task_complete = False
+        tool_starts: dict[str, dict] = {}
+        for event in cycle_events:
+            if event.get("type") == "tool.execution_start":
+                data = event.get("data", {})
+                name = data.get("toolName")
+                args = data.get("arguments", {})
+                tool_starts[data.get("toolCallId")] = data
+                cycle_tools.append(name)
+                if name == "task_complete":
+                    used_task_complete = True
+                if name == "ask_user":
+                    state["active_start_event_id"] = state.get(
+                        "active_start_event_id"
+                    ) or slice_events[0].get("id")
+                    save_state(state_path, state)
+                    log(
+                        {
+                            "session_id": session_id,
+                            "action": "skip",
+                            "reason": "awaiting_user",
+                        }
+                    )
+                    return 0
+                if name == "task" and args.get("mode") == "background":
+                    has_background = True
+                if name == "bash" and (
+                    args.get("mode") == "async" or args.get("detach")
+                ):
+                    has_background = True
+            elif event.get("type") == "tool.execution_complete":
+                data = event.get("data", {})
+                start = tool_starts.get(data.get("toolCallId"))
+                if not start or start.get("toolName") != "bash":
+                    continue
+                result_blob = json.dumps(
+                    data.get("result", {}), ensure_ascii=False
+                )
+                if "shellId" in result_blob:
+                    has_background = True
+
+        cycle_assistant_messages = [
+            clean_assistant_text(event)
+            for event in cycle_events
+            if event.get("type") == "assistant.message"
+            and clean_assistant_text(event)
+        ]
+        final_assistant_text = (
+            cycle_assistant_messages[-1] if cycle_assistant_messages else ""
+        )
+
+        looks_incomplete = not used_task_complete and (
+            not final_assistant_text
+            or final_assistant_text.endswith(("?", "？"))
+            or bool(INCOMPLETE_RE.search(final_assistant_text))
+            or has_background
+        )
+        if looks_incomplete:
+            state["active_start_event_id"] = state.get(
+                "active_start_event_id"
+            ) or slice_events[0].get("id")
+            save_state(state_path, state)
+            log(
+                {
+                    "session_id": session_id,
+                    "action": "skip",
+                    "reason": "unfinished_turn",
+                }
+            )
+            return 0
+
+        # --- Build and validate messages ---
+        messages = collect_messages(slice_events)
+        total_chars = sum(len(msg["content"]) for msg in messages)
+        if len(messages) < 2 or total_chars < MIN_SAVE_CHARS:
+            state["active_start_event_id"] = None
+            state["last_saved_turn_end_id"] = current_turn_end_id
+            save_state(state_path, state)
+            log(
+                {
+                    "session_id": session_id,
+                    "action": "skip",
+                    "reason": "too_small",
+                }
+            )
+            return 0
+
+        if has_sensitive_content(raw_visible_text(slice_events)):
+            state["active_start_event_id"] = None
+            state["last_saved_turn_end_id"] = current_turn_end_id
+            save_state(state_path, state)
+            log(
+                {
+                    "session_id": session_id,
+                    "action": "skip",
+                    "reason": "sensitive_content",
+                }
+            )
+            return 0
+
+        # --- Stable per-session thread ID ---
+        thread_id = f"copilot-{session_id}"
+        title = title_from_messages(messages)
+
+        import_file = None
+        try:
+            import_file = tempfile.NamedTemporaryFile(
+                "w", encoding="utf-8", suffix=".json", delete=False
+            )
+            json.dump(messages, import_file, ensure_ascii=False)
+            import_file.flush()
+            import_file.close()
+
+            thread_exists = False
+            try:
+                run_json(
+                    build_nmem_command(
+                        nmem_bin,
+                        "--json",
+                        "t",
+                        "import",
+                        "-f",
+                        import_file.name,
+                        "-t",
+                        title,
+                        "--id",
+                        thread_id,
+                        "-s",
+                        "copilot-cli",
+                    )
+                )
+            except Exception as exc:
+                if "already exists" in str(exc).lower():
+                    thread_exists = True
+                else:
+                    raise
+
+            if thread_exists:
+                run_json(
+                    build_nmem_command(
+                        nmem_bin,
+                        "--json",
+                        "t",
+                        "append",
+                        thread_id,
+                        "-f",
+                        import_file.name,
+                    )
+                )
+        finally:
+            if import_file and Path(import_file.name).exists():
+                Path(import_file.name).unlink()
+
+        # --- Auto-distill with guardrails ---
+        current_hash = content_hash(messages)
+        now_ts = int(time.time())
+        assistant_text = "\n\n".join(
+            msg["content"] for msg in messages if msg["role"] == "assistant"
+        )
+        combined_text = "\n\n".join(
+            f"{msg['role']}: {msg['content']}" for msg in messages
+        )
+        should_try_distill = (
+            total_chars >= MIN_DISTILL_CHARS
+            and current_hash != state.get("last_content_hash")
+            and (now_ts - state.get("last_distill_ts", 0)) >= DISTILL_COOLDOWN_SECS
+            and (
+                len(assistant_text) >= MIN_DISTILL_ASSISTANT_CHARS
+                or len([msg for msg in messages if msg["role"] == "user"]) > 1
+                or len(cycle_tools) >= 3
+                or bool(SIGNAL_RE.search(combined_text))
+            )
+        )
+
+        triage = None
+        distill_attempted = False
+        if should_try_distill:
+            triage = run_json(
+                build_nmem_command(
+                    nmem_bin, "--json", "t", "triage", thread_id
+                )
+            )
+            if triage.get("should_distill"):
+                distill_attempted = True
+                run_json(
+                    build_nmem_command(
+                        nmem_bin,
+                        "--json",
+                        "t",
+                        "distill",
+                        thread_id,
+                        "--triage",
+                    )
+                )
+                state["last_distill_ts"] = now_ts
+
+        state["active_start_event_id"] = None
+        state["last_saved_turn_end_id"] = current_turn_end_id
+        state["last_content_hash"] = current_hash
+        save_state(state_path, state)
+
+        log(
+            {
+                "session_id": session_id,
+                "action": "saved",
+                "thread_id": thread_id,
+                "message_count": len(messages),
+                "total_chars": total_chars,
+                "distill_attempted": distill_attempted,
+                "triage": triage,
+            }
+        )
+
+    return 0
+
+
+if __name__ == "__main__":
+    try:
+        raise SystemExit(main())
+    except Exception as exc:
+        log({"action": "error", "error": str(exc)})
+        raise

--- a/nowledge-mem-copilot-cli-plugin/hooks/copilot-stop-save.py
+++ b/nowledge-mem-copilot-cli-plugin/hooks/copilot-stop-save.py
@@ -71,7 +71,7 @@ SENSITIVE_SKIP_PATTERNS = [
         r"\beyJ[A-Za-z0-9_-]{8,}\.[A-Za-z0-9._-]{8,}\.[A-Za-z0-9._-]{8,}\b"
     ),
     re.compile(
-        r"\b(?:postgres|postgresql|mysql|mongodb(?:\\+srv)?|redis|amqp|kafka)://\S+",
+        r"\b(?:postgres|postgresql|mysql|mongodb(?:\+srv)?|redis|amqp|kafka)://\S+",
         re.IGNORECASE,
     ),
     re.compile(r"\b(?:cookie|set-cookie)\s*[:=]", re.IGNORECASE),
@@ -237,8 +237,15 @@ def run_json(args: list[str]) -> dict:
             timeout=NMEM_TIMEOUT_SECS,
         )
     except subprocess.TimeoutExpired as exc:
-        stdout = (exc.stdout or "").strip() if isinstance(exc.stdout, str) else ""
-        stderr = (exc.stderr or "").strip() if isinstance(exc.stderr, str) else ""
+        def _decode_timeout_output(value: object) -> str:
+            if value is None:
+                return ""
+            if isinstance(value, bytes):
+                return value.decode("utf-8", errors="replace").strip()
+            return str(value).strip()
+
+        stdout = _decode_timeout_output(exc.stdout)
+        stderr = _decode_timeout_output(exc.stderr)
         raise RuntimeError(
             stderr
             or stdout

--- a/nowledge-mem-copilot-cli-plugin/hooks/copilot-stop-save.py
+++ b/nowledge-mem-copilot-cli-plugin/hooks/copilot-stop-save.py
@@ -34,6 +34,7 @@ MIN_SAVE_CHARS = 24
 MIN_DISTILL_CHARS = 320
 MIN_DISTILL_ASSISTANT_CHARS = 220
 DISTILL_COOLDOWN_SECS = 120
+NMEM_TIMEOUT_SECS = 30
 
 INCOMPLETE_RE = re.compile(
     r"(请确认|请选择|请告诉我|告诉我继续|完成后告诉我|需要你|你希望|你想让我|请提供|方便的话|要不要|"
@@ -228,7 +229,21 @@ def collect_messages(events: list[dict]) -> list[dict]:
 
 
 def run_json(args: list[str]) -> dict:
-    proc = subprocess.run(args, capture_output=True, text=True)
+    try:
+        proc = subprocess.run(
+            args,
+            capture_output=True,
+            text=True,
+            timeout=NMEM_TIMEOUT_SECS,
+        )
+    except subprocess.TimeoutExpired as exc:
+        stdout = (exc.stdout or "").strip() if isinstance(exc.stdout, str) else ""
+        stderr = (exc.stderr or "").strip() if isinstance(exc.stderr, str) else ""
+        raise RuntimeError(
+            stderr
+            or stdout
+            or f"command timed out after {NMEM_TIMEOUT_SECS}s"
+        ) from exc
     if proc.returncode != 0:
         raise RuntimeError(
             proc.stderr.strip() or proc.stdout.strip() or "command failed"
@@ -272,11 +287,31 @@ def title_from_messages(messages: list[dict]) -> str:
 
 def event_timestamp_ms(event: dict) -> int | None:
     raw = event.get("timestamp")
-    if not raw:
+    return normalize_timestamp_ms(raw)
+
+
+def normalize_timestamp_ms(raw: object) -> int | None:
+    if raw is None:
         return None
-    return int(
-        datetime.fromisoformat(raw.replace("Z", "+00:00")).timestamp() * 1000
-    )
+    if isinstance(raw, (int, float)):
+        value = float(raw)
+        return int(value if value >= 1_000_000_000_000 else value * 1000)
+    if isinstance(raw, str):
+        text = raw.strip()
+        if not text:
+            return None
+        try:
+            value = float(text)
+        except ValueError:
+            try:
+                return int(
+                    datetime.fromisoformat(text.replace("Z", "+00:00")).timestamp()
+                    * 1000
+                )
+            except ValueError:
+                return None
+        return int(value if value >= 1_000_000_000_000 else value * 1000)
+    return None
 
 
 def content_hash(messages: list[dict]) -> str:
@@ -304,7 +339,7 @@ def main() -> int:
     session_id = hook_input.get("sessionId")
     transcript_path = hook_input.get("transcriptPath")
     stop_reason = hook_input.get("stopReason")
-    hook_timestamp = hook_input.get("timestamp")
+    hook_timestamp_ms = normalize_timestamp_ms(hook_input.get("timestamp"))
 
     if not session_id or not transcript_path or stop_reason != "end_turn":
         return 0
@@ -341,10 +376,10 @@ def main() -> int:
             (
                 event
                 for event in reversed(turn_end_events)
-                if hook_timestamp is None
+                if hook_timestamp_ms is None
                 or (
                     event_timestamp_ms(event) is not None
-                    and event_timestamp_ms(event) <= hook_timestamp
+                    and event_timestamp_ms(event) <= hook_timestamp_ms
                 )
             ),
             turn_end_events[-1],
@@ -579,24 +614,34 @@ def main() -> int:
         triage = None
         distill_attempted = False
         if should_try_distill:
-            triage = run_json(
-                build_nmem_command(
-                    nmem_bin, "--json", "t", "triage", thread_id
-                )
-            )
-            if triage.get("should_distill"):
-                distill_attempted = True
-                run_json(
+            try:
+                triage = run_json(
                     build_nmem_command(
-                        nmem_bin,
-                        "--json",
-                        "t",
-                        "distill",
-                        thread_id,
-                        "--triage",
+                        nmem_bin, "--json", "t", "triage", thread_id
                     )
                 )
-                state["last_distill_ts"] = now_ts
+                if triage.get("should_distill"):
+                    distill_attempted = True
+                    run_json(
+                        build_nmem_command(
+                            nmem_bin,
+                            "--json",
+                            "t",
+                            "distill",
+                            thread_id,
+                            "--triage",
+                        )
+                    )
+                    state["last_distill_ts"] = now_ts
+            except Exception as exc:
+                log(
+                    {
+                        "session_id": session_id,
+                        "action": "distill_error",
+                        "thread_id": thread_id,
+                        "error": str(exc),
+                    }
+                )
 
         state["active_start_event_id"] = None
         state["last_saved_turn_end_id"] = current_turn_end_id

--- a/nowledge-mem-copilot-cli-plugin/hooks/copilot-stop-save.sh
+++ b/nowledge-mem-copilot-cli-plugin/hooks/copilot-stop-save.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+# Shell launcher for copilot-stop-save.py
+# Called by hooks.json Stop event — receives JSON via stdin.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+exec python3 "${SCRIPT_DIR}/copilot-stop-save.py"

--- a/nowledge-mem-copilot-cli-plugin/hooks/hooks.json
+++ b/nowledge-mem-copilot-cli-plugin/hooks/hooks.json
@@ -36,7 +36,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "PLUGIN_HOOK_DIR=\"${COPILOT_PLUGIN_ROOT:-${PLUGIN_ROOT:-${CLAUDE_PLUGIN_ROOT:-}}}/hooks\"; FALLBACK_HOOK_DIR=\"${HOME}/.copilot/nowledge-mem-hooks\"; if [ -f \"${PLUGIN_HOOK_DIR}/copilot-stop-save.py\" ]; then python3 \"${PLUGIN_HOOK_DIR}/copilot-stop-save.py\"; elif [ -f \"${FALLBACK_HOOK_DIR}/copilot-stop-save.py\" ]; then python3 \"${FALLBACK_HOOK_DIR}/copilot-stop-save.py\"; else true; fi",
+            "command": "PLUGIN_HOOK_DIR=\"${COPILOT_PLUGIN_ROOT:-${PLUGIN_ROOT:-${CLAUDE_PLUGIN_ROOT:-}}}/hooks\"; FALLBACK_HOOK_DIR=\"${HOME}/.copilot/nowledge-mem-hooks\"; if [ -f \"${PLUGIN_HOOK_DIR}/copilot-stop-save.py\" ]; then python3 \"${PLUGIN_HOOK_DIR}/copilot-stop-save.py\" || true; elif [ -f \"${FALLBACK_HOOK_DIR}/copilot-stop-save.py\" ]; then python3 \"${FALLBACK_HOOK_DIR}/copilot-stop-save.py\" || true; else true; fi",
             "async": true
           }
         ]

--- a/nowledge-mem-copilot-cli-plugin/hooks/hooks.json
+++ b/nowledge-mem-copilot-cli-plugin/hooks/hooks.json
@@ -36,7 +36,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "HOOK_DIR=\"${HOME}/.copilot/nowledge-mem-hooks\"; [ -f \"${HOOK_DIR}/copilot-stop-save.py\" ] && python3 \"${HOOK_DIR}/copilot-stop-save.py\" || true",
+            "command": "PLUGIN_HOOK_DIR=\"${COPILOT_PLUGIN_ROOT:-${PLUGIN_ROOT:-${CLAUDE_PLUGIN_ROOT:-}}}/hooks\"; FALLBACK_HOOK_DIR=\"${HOME}/.copilot/nowledge-mem-hooks\"; if [ -f \"${PLUGIN_HOOK_DIR}/copilot-stop-save.py\" ]; then python3 \"${PLUGIN_HOOK_DIR}/copilot-stop-save.py\"; elif [ -f \"${FALLBACK_HOOK_DIR}/copilot-stop-save.py\" ]; then python3 \"${FALLBACK_HOOK_DIR}/copilot-stop-save.py\"; else true; fi",
             "async": true
           }
         ]

--- a/nowledge-mem-copilot-cli-plugin/scripts/copilot-stop-save.py
+++ b/nowledge-mem-copilot-cli-plugin/scripts/copilot-stop-save.py
@@ -71,7 +71,7 @@ SENSITIVE_SKIP_PATTERNS = [
         r"\beyJ[A-Za-z0-9_-]{8,}\.[A-Za-z0-9._-]{8,}\.[A-Za-z0-9._-]{8,}\b"
     ),
     re.compile(
-        r"\b(?:postgres|postgresql|mysql|mongodb(?:\\+srv)?|redis|amqp|kafka)://\S+",
+        r"\b(?:postgres|postgresql|mysql|mongodb(?:\+srv)?|redis|amqp|kafka)://\S+",
         re.IGNORECASE,
     ),
     re.compile(r"\b(?:cookie|set-cookie)\s*[:=]", re.IGNORECASE),
@@ -237,8 +237,15 @@ def run_json(args: list[str]) -> dict:
             timeout=NMEM_TIMEOUT_SECS,
         )
     except subprocess.TimeoutExpired as exc:
-        stdout = (exc.stdout or "").strip() if isinstance(exc.stdout, str) else ""
-        stderr = (exc.stderr or "").strip() if isinstance(exc.stderr, str) else ""
+        def _decode_timeout_output(value: object) -> str:
+            if value is None:
+                return ""
+            if isinstance(value, bytes):
+                return value.decode("utf-8", errors="replace").strip()
+            return str(value).strip()
+
+        stdout = _decode_timeout_output(exc.stdout)
+        stderr = _decode_timeout_output(exc.stderr)
         raise RuntimeError(
             stderr
             or stdout

--- a/nowledge-mem-copilot-cli-plugin/scripts/copilot-stop-save.py
+++ b/nowledge-mem-copilot-cli-plugin/scripts/copilot-stop-save.py
@@ -34,6 +34,7 @@ MIN_SAVE_CHARS = 24
 MIN_DISTILL_CHARS = 320
 MIN_DISTILL_ASSISTANT_CHARS = 220
 DISTILL_COOLDOWN_SECS = 120
+NMEM_TIMEOUT_SECS = 30
 
 INCOMPLETE_RE = re.compile(
     r"(请确认|请选择|请告诉我|告诉我继续|完成后告诉我|需要你|你希望|你想让我|请提供|方便的话|要不要|"
@@ -228,7 +229,21 @@ def collect_messages(events: list[dict]) -> list[dict]:
 
 
 def run_json(args: list[str]) -> dict:
-    proc = subprocess.run(args, capture_output=True, text=True)
+    try:
+        proc = subprocess.run(
+            args,
+            capture_output=True,
+            text=True,
+            timeout=NMEM_TIMEOUT_SECS,
+        )
+    except subprocess.TimeoutExpired as exc:
+        stdout = (exc.stdout or "").strip() if isinstance(exc.stdout, str) else ""
+        stderr = (exc.stderr or "").strip() if isinstance(exc.stderr, str) else ""
+        raise RuntimeError(
+            stderr
+            or stdout
+            or f"command timed out after {NMEM_TIMEOUT_SECS}s"
+        ) from exc
     if proc.returncode != 0:
         raise RuntimeError(
             proc.stderr.strip() or proc.stdout.strip() or "command failed"
@@ -272,11 +287,31 @@ def title_from_messages(messages: list[dict]) -> str:
 
 def event_timestamp_ms(event: dict) -> int | None:
     raw = event.get("timestamp")
-    if not raw:
+    return normalize_timestamp_ms(raw)
+
+
+def normalize_timestamp_ms(raw: object) -> int | None:
+    if raw is None:
         return None
-    return int(
-        datetime.fromisoformat(raw.replace("Z", "+00:00")).timestamp() * 1000
-    )
+    if isinstance(raw, (int, float)):
+        value = float(raw)
+        return int(value if value >= 1_000_000_000_000 else value * 1000)
+    if isinstance(raw, str):
+        text = raw.strip()
+        if not text:
+            return None
+        try:
+            value = float(text)
+        except ValueError:
+            try:
+                return int(
+                    datetime.fromisoformat(text.replace("Z", "+00:00")).timestamp()
+                    * 1000
+                )
+            except ValueError:
+                return None
+        return int(value if value >= 1_000_000_000_000 else value * 1000)
+    return None
 
 
 def content_hash(messages: list[dict]) -> str:
@@ -304,7 +339,7 @@ def main() -> int:
     session_id = hook_input.get("sessionId")
     transcript_path = hook_input.get("transcriptPath")
     stop_reason = hook_input.get("stopReason")
-    hook_timestamp = hook_input.get("timestamp")
+    hook_timestamp_ms = normalize_timestamp_ms(hook_input.get("timestamp"))
 
     if not session_id or not transcript_path or stop_reason != "end_turn":
         return 0
@@ -341,10 +376,10 @@ def main() -> int:
             (
                 event
                 for event in reversed(turn_end_events)
-                if hook_timestamp is None
+                if hook_timestamp_ms is None
                 or (
                     event_timestamp_ms(event) is not None
-                    and event_timestamp_ms(event) <= hook_timestamp
+                    and event_timestamp_ms(event) <= hook_timestamp_ms
                 )
             ),
             turn_end_events[-1],
@@ -579,24 +614,34 @@ def main() -> int:
         triage = None
         distill_attempted = False
         if should_try_distill:
-            triage = run_json(
-                build_nmem_command(
-                    nmem_bin, "--json", "t", "triage", thread_id
-                )
-            )
-            if triage.get("should_distill"):
-                distill_attempted = True
-                run_json(
+            try:
+                triage = run_json(
                     build_nmem_command(
-                        nmem_bin,
-                        "--json",
-                        "t",
-                        "distill",
-                        thread_id,
-                        "--triage",
+                        nmem_bin, "--json", "t", "triage", thread_id
                     )
                 )
-                state["last_distill_ts"] = now_ts
+                if triage.get("should_distill"):
+                    distill_attempted = True
+                    run_json(
+                        build_nmem_command(
+                            nmem_bin,
+                            "--json",
+                            "t",
+                            "distill",
+                            thread_id,
+                            "--triage",
+                        )
+                    )
+                    state["last_distill_ts"] = now_ts
+            except Exception as exc:
+                log(
+                    {
+                        "session_id": session_id,
+                        "action": "distill_error",
+                        "thread_id": thread_id,
+                        "error": str(exc),
+                    }
+                )
 
         state["active_start_event_id"] = None
         state["last_saved_turn_end_id"] = current_turn_end_id

--- a/nowledge-mem-copilot-cli-plugin/scripts/install-hooks.sh
+++ b/nowledge-mem-copilot-cli-plugin/scripts/install-hooks.sh
@@ -8,8 +8,31 @@
 set -euo pipefail
 
 HOOK_DIR="${HOME}/.copilot/nowledge-mem-hooks"
-PLUGIN_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+SCRIPT_SOURCE="${BASH_SOURCE[0]:-$0}"
+if command -v realpath >/dev/null 2>&1; then
+  SCRIPT_PATH="$(realpath "${SCRIPT_SOURCE}")"
+elif command -v readlink >/dev/null 2>&1; then
+  RESOLVED="$(readlink "${SCRIPT_SOURCE}" 2>/dev/null || true)"
+  if [[ -n "${RESOLVED}" ]]; then
+    if [[ "${RESOLVED}" = /* ]]; then
+      SCRIPT_PATH="${RESOLVED}"
+    else
+      SCRIPT_PATH="$(cd "$(dirname "${SCRIPT_SOURCE}")" && cd "$(dirname "${RESOLVED}")" && pwd)/$(basename "${RESOLVED}")"
+    fi
+  else
+    SCRIPT_PATH="$(cd "$(dirname "${SCRIPT_SOURCE}")" && pwd)/$(basename "${SCRIPT_SOURCE}")"
+  fi
+else
+  SCRIPT_PATH="$(cd "$(dirname "${SCRIPT_SOURCE}")" && pwd)/$(basename "${SCRIPT_SOURCE}")"
+fi
+
+PLUGIN_ROOT="$(cd "$(dirname "${SCRIPT_PATH}")/.." && pwd)"
 SOURCE_DIR="${PLUGIN_ROOT}/hooks"
+
+if [[ ! -f "${SOURCE_DIR}/copilot-stop-save.py" || ! -f "${SOURCE_DIR}/copilot-stop-save.sh" ]]; then
+  echo "ERROR: Expected hook sources under ${SOURCE_DIR}. Run this script from the plugin's scripts/ directory." >&2
+  exit 1
+fi
 
 echo "Installing compatibility copy of Nowledge Mem Copilot CLI hooks..."
 

--- a/nowledge-mem-copilot-cli-plugin/scripts/install-hooks.sh
+++ b/nowledge-mem-copilot-cli-plugin/scripts/install-hooks.sh
@@ -1,22 +1,24 @@
 #!/usr/bin/env bash
-# install-hooks.sh — Idempotent installer for Copilot CLI session capture hooks.
+# install-hooks.sh — optional compatibility installer for Copilot CLI session capture hooks.
 #
-# Copies the Python capture script and shell launcher to
-# ~/.copilot/nowledge-mem-hooks/ so the hooks.json Stop event can find them.
-# Safe to run multiple times (idempotent).
+# Current Copilot marketplace installs should execute the capture runtime directly from
+# the plugin's hooks/ directory via COPILOT_PLUGIN_ROOT. This script remains as an
+# idempotent fallback for older installs or local development flows that still want a
+# compatibility copy in ~/.copilot/nowledge-mem-hooks/.
 set -euo pipefail
 
 HOOK_DIR="${HOME}/.copilot/nowledge-mem-hooks"
-SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+PLUGIN_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+SOURCE_DIR="${PLUGIN_ROOT}/hooks"
 
-echo "Installing Nowledge Mem Copilot CLI hooks..."
+echo "Installing compatibility copy of Nowledge Mem Copilot CLI hooks..."
 
 # Create directories
 mkdir -p "${HOOK_DIR}/state"
 
 # Copy scripts
-cp -f "${SCRIPT_DIR}/copilot-stop-save.py" "${HOOK_DIR}/copilot-stop-save.py"
-cp -f "${SCRIPT_DIR}/copilot-stop-save.sh" "${HOOK_DIR}/copilot-stop-save.sh"
+cp -f "${SOURCE_DIR}/copilot-stop-save.py" "${HOOK_DIR}/copilot-stop-save.py"
+cp -f "${SOURCE_DIR}/copilot-stop-save.sh" "${HOOK_DIR}/copilot-stop-save.sh"
 
 # Ensure executable
 chmod +x "${HOOK_DIR}/copilot-stop-save.sh"
@@ -36,9 +38,12 @@ else
   echo "WARNING: nmem not found in PATH. Install with: pip install nmem-cli"
 fi
 
-echo "✓ Hooks installed to ${HOOK_DIR}"
+echo "✓ Compatibility hooks installed to ${HOOK_DIR}"
 echo ""
-echo "The Stop hook is configured in hooks/hooks.json to run:"
-echo "  python3 ${HOOK_DIR}/copilot-stop-save.py"
+echo "Modern marketplace installs should run directly from:"
+echo "  ${SOURCE_DIR}/copilot-stop-save.py"
+echo ""
+echo "This fallback copy remains available at:"
+echo "  ${HOOK_DIR}/copilot-stop-save.py"
 echo ""
 echo "Session capture is now active. Restart Copilot CLI to apply."

--- a/nowledge-mem-copilot-cli-plugin/tests/test_copilot_plugin.py
+++ b/nowledge-mem-copilot-cli-plugin/tests/test_copilot_plugin.py
@@ -38,12 +38,12 @@ _spec.loader.exec_module(copilot_stop_save)
 def test_packaged_hook_runtime_matches_compatibility_copy():
     repo_root = Path(__file__).parent.parent
     assert (
-        (repo_root / "hooks" / "copilot-stop-save.py").read_text(encoding="utf-8")
-        == (repo_root / "scripts" / "copilot-stop-save.py").read_text(encoding="utf-8")
+        (repo_root / "hooks" / "copilot-stop-save.py").read_bytes()
+        == (repo_root / "scripts" / "copilot-stop-save.py").read_bytes()
     )
     assert (
-        (repo_root / "hooks" / "copilot-stop-save.sh").read_text(encoding="utf-8")
-        == (repo_root / "scripts" / "copilot-stop-save.sh").read_text(encoding="utf-8")
+        (repo_root / "hooks" / "copilot-stop-save.sh").read_bytes()
+        == (repo_root / "scripts" / "copilot-stop-save.sh").read_bytes()
     )
 
 

--- a/nowledge-mem-copilot-cli-plugin/tests/test_copilot_plugin.py
+++ b/nowledge-mem-copilot-cli-plugin/tests/test_copilot_plugin.py
@@ -35,6 +35,18 @@ copilot_stop_save = importlib.util.module_from_spec(_spec)
 _spec.loader.exec_module(copilot_stop_save)
 
 
+def test_packaged_hook_runtime_matches_compatibility_copy():
+    repo_root = Path(__file__).parent.parent
+    assert (
+        (repo_root / "hooks" / "copilot-stop-save.py").read_text(encoding="utf-8")
+        == (repo_root / "scripts" / "copilot-stop-save.py").read_text(encoding="utf-8")
+    )
+    assert (
+        (repo_root / "hooks" / "copilot-stop-save.sh").read_text(encoding="utf-8")
+        == (repo_root / "scripts" / "copilot-stop-save.sh").read_text(encoding="utf-8")
+    )
+
+
 # ---------------------------------------------------------------------------
 # Fixtures
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes affect the `Stop` hook execution path and background capture/distill behavior, which could impact whether sessions are saved or skipped across environments.
> 
> **Overview**
> Copilot CLI plugin session capture is moved to run from the packaged `hooks/` runtime via `COPILOT_PLUGIN_ROOT`, with a fallback to `~/.copilot/nowledge-mem-hooks/` for older installs, removing reliance on marketplace-installed `scripts/` paths.
> 
> The capture script is duplicated into `hooks/` (plus a shell launcher), and the compatibility installer is reframed to copy from `hooks/` into the legacy location. The capture logic is hardened with `nmem` timeouts, more robust timestamp parsing, and non-fatal distill errors; docs/testing are updated accordingly and versions are bumped to `0.1.1`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9cce1c1f5c8be8869792c6ad8038e670408ad1dd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Session capture now runs from the bundled plugin runtime and can auto-import/distill eligible turns.

* **Bug Fixes**
  * Restarting Copilot CLI is sufficient after update; improved fallback for older installs.
  * More robust save/distill flow with timeouts and non-blocking error handling to avoid interruptions.

* **Documentation**
  * Updated installation, troubleshooting, and release guidance to match new runtime behavior.

* **Tests**
  * Added packaging parity test to ensure bundled hooks match compatibility copies.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->