### PR TITLE
feat: expose Hermes nmem search importance filter

### DIFF
--- a/integrations.json
+++ b/integrations.json
@@ -475,7 +475,7 @@
       "name": "Hermes Agent",
       "category": "coding",
       "type": "plugin",
-      "version": "0.5.13",
+      "version": "0.5.14",
       "directory": "nowledge-mem-hermes",
       "transport": "cli",
       "capabilities": {

--- a/nowledge-mem-hermes/CHANGELOG.md
+++ b/nowledge-mem-hermes/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## Unreleased
 
+## [0.5.14] - 2026-05-10
+
+### Added
+
+- `nmem_search` now exposes `min_importance`, forwarding it to `nmem m search --importance` so Hermes can filter out lower-priority memories during recall.
+
 ## [0.5.13] - 2026-05-02
 
 ### Fixed

--- a/nowledge-mem-hermes/client.py
+++ b/nowledge-mem-hermes/client.py
@@ -79,6 +79,7 @@ class NowledgeMemClient:
         limit: int = 10,
         filter_labels: Optional[List[str]] = None,
         mode: Optional[str] = None,
+        min_importance: Optional[float] = None,
     ) -> Any:
         """Search memories. CLI requires a query string."""
         if not query:
@@ -91,6 +92,8 @@ class NowledgeMemClient:
                 cmd.extend(["-l", label])
         if mode == "deep":
             cmd.extend(["--mode", "deep"])
+        if min_importance is not None:
+            cmd.extend(["--importance", str(min_importance)])
         return self._cli(cmd)
 
     def save(

--- a/nowledge-mem-hermes/plugin.yaml
+++ b/nowledge-mem-hermes/plugin.yaml
@@ -1,5 +1,5 @@
 name: nowledge-mem
-version: 0.5.13
+version: 0.5.14
 description: "Cross-tool personal knowledge graph with semantic search, Working Memory, and proactive recall."
 hooks:
   - prefetch

--- a/nowledge-mem-hermes/provider.py
+++ b/nowledge-mem-hermes/provider.py
@@ -59,7 +59,7 @@ topic, use nmem_update rather than create a duplicate."""
 
 _SEARCH = {
     "name": "nmem_search",
-    "description": "Search stored memories. Supports label filtering and deep search mode.",
+    "description": "Search stored memories. Supports label filtering, minimum-importance filtering, and deep search mode.",
     "parameters": {
         "type": "object",
         "properties": {
@@ -72,6 +72,10 @@ _SEARCH = {
             "mode": {
                 "type": "string",
                 "description": "'normal' (fast, default) or 'deep' (graph-enhanced).",
+            },
+            "min_importance": {
+                "type": "number",
+                "description": "Minimum importance threshold, 0.0-1.0. Filters out lower-priority memories.",
             },
         },
         "required": ["query"],
@@ -472,6 +476,7 @@ class NowledgeMemProvider(MemoryProvider):
                 limit=args.get("limit", 10),
                 filter_labels=self._parse_csv(args.get("filter_labels")),
                 mode=args.get("mode"),
+                min_importance=args.get("min_importance"),
             )
         if tool_name == "nmem_save":
             return client.save(

--- a/nowledge-mem-hermes/tests/test_search_importance.py
+++ b/nowledge-mem-hermes/tests/test_search_importance.py
@@ -1,0 +1,130 @@
+from __future__ import annotations
+
+import importlib.util
+import sys
+import types
+import unittest
+from pathlib import Path
+
+
+def _load_provider_module():
+    plugin_dir = Path(__file__).resolve().parents[1]
+
+    agent_module = types.ModuleType("agent")
+    memory_provider_module = types.ModuleType("agent.memory_provider")
+
+    class MemoryProvider:  # pragma: no cover - compatibility stub
+        pass
+
+    memory_provider_module.MemoryProvider = MemoryProvider
+    agent_module.memory_provider = memory_provider_module
+    sys.modules.setdefault("agent", agent_module)
+    sys.modules.setdefault("agent.memory_provider", memory_provider_module)
+
+    package_name = "nowledge_mem_hermes"
+    if package_name not in sys.modules:
+        package = types.ModuleType(package_name)
+        package.__path__ = [str(plugin_dir)]
+        sys.modules[package_name] = package
+
+    spec = importlib.util.spec_from_file_location(
+        f"{package_name}.provider",
+        plugin_dir / "provider.py",
+    )
+    module = importlib.util.module_from_spec(spec)
+    assert spec and spec.loader
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+provider = _load_provider_module()
+client_module = sys.modules["nowledge_mem_hermes.client"]
+
+
+class SearchImportanceTests(unittest.TestCase):
+    def test_schema_exposes_min_importance_filter(self):
+        properties = provider._SEARCH["parameters"]["properties"]
+        self.assertIn("min_importance", properties)
+        self.assertEqual(properties["min_importance"]["type"], "number")
+
+    def test_dispatch_passes_min_importance_to_client(self):
+        captured: dict[str, object] = {}
+
+        class _FakeClient:
+            def search(self, query, **kwargs):
+                captured["query"] = query
+                captured.update(kwargs)
+                return {"memories": []}
+
+        instance = provider.NowledgeMemProvider()
+        instance._client = _FakeClient()
+        instance._dispatch(
+            "nmem_search",
+            {
+                "query": "project context",
+                "limit": 5,
+                "filter_labels": "work,decision",
+                "mode": "deep",
+                "min_importance": 0.7,
+            },
+        )
+
+        self.assertEqual(captured["query"], "project context")
+        self.assertEqual(captured["limit"], 5)
+        self.assertEqual(captured["filter_labels"], ["work", "decision"])
+        self.assertEqual(captured["mode"], "deep")
+        self.assertEqual(captured["min_importance"], 0.7)
+
+    def test_client_search_adds_importance_flag(self):
+        captured: dict[str, object] = {}
+        original_run = client_module.subprocess.run
+
+        def _fake_run(cmd, **kwargs):
+            captured["cmd"] = cmd
+
+            class _Result:
+                returncode = 0
+                stdout = "{}"
+                stderr = ""
+
+            return _Result()
+
+        try:
+            client_module.subprocess.run = _fake_run
+            client = client_module.NowledgeMemClient()
+            client.search("project context", min_importance=0.7)
+        finally:
+            client_module.subprocess.run = original_run
+
+        self.assertEqual(
+            captured["cmd"],
+            ["nmem", "--json", "m", "search", "project context", "--importance", "0.7"],
+        )
+
+    def test_client_search_omits_importance_when_not_set(self):
+        captured: dict[str, object] = {}
+        original_run = client_module.subprocess.run
+
+        def _fake_run(cmd, **kwargs):
+            captured["cmd"] = cmd
+
+            class _Result:
+                returncode = 0
+                stdout = "{}"
+                stderr = ""
+
+            return _Result()
+
+        try:
+            client_module.subprocess.run = _fake_run
+            client = client_module.NowledgeMemClient()
+            client.search("project context")
+        finally:
+            client_module.subprocess.run = original_run
+
+        self.assertNotIn("--importance", captured["cmd"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Adds a `min_importance` parameter to the Hermes native `nmem_search` tool and forwards it to the existing nmem CLI `--importance` filter.

This lets Hermes agents request retrieval like:

```json
{"query": "project context", "min_importance": 0.7}
```

which becomes:

```bash
nmem --json m search "project context" --importance 0.7
```

## Changes

- expose `min_importance` in the `nmem_search` tool schema
- pass `min_importance` through provider dispatch
- append `--importance <value>` in the nmem CLI client
- bump Hermes plugin version to `0.5.14`
- add changelog entry and regression tests

## Test Plan

```bash
cd nowledge-mem-hermes
for t in tests/test_*.py; do python3 "$t" -v || exit 1; done
```

Result: all executed tests passed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added `min_importance` filter parameter to search functionality, allowing users to exclude lower-priority memories during recall.

* **Documentation**
  * Updated changelog documenting version 0.5.14 release.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/nowledge-co/community/pull/227)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->