### PR TITLE
fix(codex): clarify marketplace update contract

### DIFF
--- a/integrations.json
+++ b/integrations.json
@@ -181,8 +181,8 @@
       },
       "install": {
         "command": "codex plugin marketplace add nowledge-co/community || codex marketplace add nowledge-co/community",
-        "updateCommand": "(codex plugin marketplace upgrade nowledge-community || codex plugin marketplace add nowledge-co/community || codex marketplace add nowledge-co/community) && HOOK_SETUP=\"$(find ~/.codex/plugins/cache -path '*/nowledge-mem/*/scripts/install_hooks.py' -print 2>/dev/null | sort | tail -1)\" && test -n \"$HOOK_SETUP\" && python3 \"$HOOK_SETUP\"",
-        "configRequired": "After marketplace add, install nowledge-mem@nowledge-community from Codex /plugins, then set [features] plugins = true, codex_hooks = true, and [plugins.\"nowledge-mem@nowledge-community\"] enabled = true in ~/.codex/config.toml. Run the installed scripts/install_hooks.py once to enable Stop-hook thread capture on current Codex stable. Add [mcp_servers.nowledge-mem] only to override the bundled local MCP endpoint.",
+        "updateCommand": "codex plugin marketplace upgrade nowledge-community || codex plugin marketplace add nowledge-co/community || codex marketplace add nowledge-co/community",
+        "configRequired": "After marketplace add or upgrade, install or update nowledge-mem@nowledge-community from Codex /plugins, then set [features] plugins = true, codex_hooks = true, and [plugins.\"nowledge-mem@nowledge-community\"] enabled = true in ~/.codex/config.toml. Run the installed scripts/install_hooks.py once after the package itself is installed to enable Stop-hook thread capture on current Codex stable. Add [mcp_servers.nowledge-mem] only to override the bundled local MCP endpoint.",
         "detectionHint": "Running as Codex CLI agent; ~/.codex/ exists",
         "docsUrl": "/docs/integrations/codex-cli"
       },

--- a/nowledge-mem-codex-plugin/README.md
+++ b/nowledge-mem-codex-plugin/README.md
@@ -80,7 +80,11 @@ Then enable thread capture for current stable Codex builds:
 
 ```bash
 HOOK_SETUP="$(find ~/.codex/plugins/cache -path '*/nowledge-mem/*/scripts/install_hooks.py' -print 2>/dev/null | sort | tail -1)"
-test -n "$HOOK_SETUP" && python3 "$HOOK_SETUP"
+if [ -z "$HOOK_SETUP" ]; then
+  echo "Hook setup was not found. Open Codex, run /plugins, install nowledge-mem@nowledge-community, then retry."
+else
+  python3 "$HOOK_SETUP"
+fi
 ```
 
 This installs a small Stop hook into `~/.codex/hooks.json`. The hook shells out to `nmem t save --from codex`, so local mode and remote Mem mode use the same `nmem` client configuration.
@@ -168,17 +172,23 @@ If Mem is not running yet, try `$nowledge-mem:status` to check connectivity.
 
 ## Update
 
-If you installed the Codex package before `0.1.10`, marketplace update alone refreshes plugin files but does not reliably refresh the host-level Stop hook. Run the hook setup below after updating; this replaces older async hook entries that current Codex stable skips.
+If you installed the Codex package before `0.1.10`, refresh the marketplace first. Current Codex builds may refresh the marketplace checkout without reinstalling the already-installed package cache, so the hook setup file may still be missing until the package itself is updated from `/plugins`.
 
 ```bash
 codex plugin marketplace upgrade nowledge-community
 ```
 
-Then refresh the host-level hook runtime:
+Open Codex, run `/plugins`, update or reinstall `nowledge-mem@nowledge-community`, then restart Codex.
+
+After the package itself is updated, refresh the host-level hook runtime:
 
 ```bash
 HOOK_SETUP="$(find ~/.codex/plugins/cache -path '*/nowledge-mem/*/scripts/install_hooks.py' -print 2>/dev/null | sort | tail -1)"
-test -n "$HOOK_SETUP" && python3 "$HOOK_SETUP"
+if [ -z "$HOOK_SETUP" ]; then
+  echo "Hook setup is still missing. Reinstall nowledge-mem@nowledge-community from Codex /plugins, then retry."
+else
+  python3 "$HOOK_SETUP"
+fi
 ```
 
 If the marketplace is not registered yet, run:


### PR DESCRIPTION
## Summary
- stop chaining Codex hook setup directly after marketplace refresh in integration metadata
- clarify that users must update or reinstall the Codex package from /plugins before running hook setup
- make the hook setup snippets fail with an actionable message when the installed package cache is still stale

## Verification
- node nowledge-mem-codex-plugin/scripts/validate-plugin.mjs
- uv run --with pytest pytest nowledge-mem-codex-plugin/tests tests/plugin_e2e -q
- jq empty integrations.json
- git diff --check
- isolated CODEX_HOME local marketplace add smoke
- isolated CODEX_HOME git marketplace add smoke against this branch

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified installation and configuration requirements for the Codex integration, including explicit setup steps and config file settings.
  * Improved upgrade instructions for users migrating from older versions.
  * Enhanced error messaging to guide users through the installation process.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/nowledge-co/community/pull/230)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->