### PR TITLE
fix(claude-code): centralize working memory hook

### DIFF
--- a/integrations.json
+++ b/integrations.json
@@ -8,7 +8,7 @@
       "name": "Claude Code",
       "category": "coding",
       "type": "plugin",
-      "version": "0.7.8",
+      "version": "0.7.9",
       "directory": "nowledge-mem-claude-code-plugin",
       "transport": "cli",
       "capabilities": {

--- a/nowledge-mem-claude-code-plugin/.claude-plugin/plugin.json
+++ b/nowledge-mem-claude-code-plugin/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "nowledge-mem",
   "description": "Personal knowledge graph for Claude Code \u2014 remembers decisions, searches past work, captures sessions",
-  "version": "0.7.8",
+  "version": "0.7.9",
   "author": {
     "name": "Nowledge Labs",
     "email": "hello@nowledge-labs.ai",

--- a/nowledge-mem-claude-code-plugin/CHANGELOG.md
+++ b/nowledge-mem-claude-code-plugin/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to the Nowledge Mem Claude Code plugin will be documented in
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.7.9] - 2026-05-12
+
+### Changed
+
+- SessionStart and compact Working Memory reload now share one hook script instead of duplicating the same shell pipeline in `hooks.json`. Behavior is unchanged: project-space Working Memory is tried first when a space resolves, then default-space `nmem wm read`, then `~/ai-now/memory.md`.
+- Added regression coverage for the read hook's git-space resolution, `NMEM_SPACE` override, default-space fallback, and local file fallback.
+
 ## [0.7.8] - 2026-05-07
 
 ### Changed

--- a/nowledge-mem-claude-code-plugin/CHANGELOG.md
+++ b/nowledge-mem-claude-code-plugin/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - SessionStart and compact Working Memory reload now share one hook script instead of duplicating the same shell pipeline in `hooks.json`. Behavior is unchanged: project-space Working Memory is tried first when a space resolves, then default-space `nmem wm read`, then `~/ai-now/memory.md`.
 - Added regression coverage for the read hook's git-space resolution, `NMEM_SPACE` override, default-space fallback, and local file fallback.
+- The `~/ai-now/memory.md` fallback remains available even if Claude Code launches a hook without `CLAUDE_PLUGIN_ROOT`.
 
 ## [0.7.8] - 2026-05-07
 

--- a/nowledge-mem-claude-code-plugin/hooks/hooks.json
+++ b/nowledge-mem-claude-code-plugin/hooks/hooks.json
@@ -7,7 +7,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "command -v nmem >/dev/null 2>&1 || { command -v nmem.cmd >/dev/null 2>&1 && nmem(){ local q=''; for a in \"$@\"; do q=\"$q \\\"$a\\\"\"; done; cmd.exe /s /c \"\\\"nmem.cmd\\\"$q\"; }; }; PY=\"$(command -v python3 || command -v python || true)\"; SPACE=\"${NMEM_SPACE:-$(basename \"$(cd \"$(dirname \"$(git rev-parse --git-common-dir 2>/dev/null)\")\" 2>/dev/null && pwd)\" 2>/dev/null | tr '[:upper:]' '[:lower:]')}\"; { [ -n \"$PY\" ] && [ -n \"$SPACE\" ] && nmem --json wm read --space \"$SPACE\" 2>/dev/null | \"$PY\" -c \"import sys,json;d=json.load(sys.stdin);c=d.get('content','');print(c) if d.get('exists') and c else sys.exit(1)\" 2>/dev/null; } || { [ -n \"$PY\" ] && nmem --json wm read 2>/dev/null | \"$PY\" -c \"import sys,json;d=json.load(sys.stdin);c=d.get('content','');print(c) if c else sys.exit(1)\" 2>/dev/null; } || cat ~/ai-now/memory.md 2>/dev/null || true"
+            "command": "SCRIPT=\"${CLAUDE_PLUGIN_ROOT:-}/scripts/nmem-hook-read.sh\"; [ -f \"$SCRIPT\" ] && sh \"$SCRIPT\" || true"
           }
         ]
       },
@@ -16,7 +16,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "command -v nmem >/dev/null 2>&1 || { command -v nmem.cmd >/dev/null 2>&1 && nmem(){ local q=''; for a in \"$@\"; do q=\"$q \\\"$a\\\"\"; done; cmd.exe /s /c \"\\\"nmem.cmd\\\"$q\"; }; }; PY=\"$(command -v python3 || command -v python || true)\"; SPACE=\"${NMEM_SPACE:-$(basename \"$(cd \"$(dirname \"$(git rev-parse --git-common-dir 2>/dev/null)\")\" 2>/dev/null && pwd)\" 2>/dev/null | tr '[:upper:]' '[:lower:]')}\"; { { [ -n \"$PY\" ] && [ -n \"$SPACE\" ] && nmem --json wm read --space \"$SPACE\" 2>/dev/null | \"$PY\" -c \"import sys,json;d=json.load(sys.stdin);c=d.get('content','');print(c) if d.get('exists') and c else sys.exit(1)\" 2>/dev/null; } || { [ -n \"$PY\" ] && nmem --json wm read 2>/dev/null | \"$PY\" -c \"import sys,json;d=json.load(sys.stdin);c=d.get('content','');print(c) if c else sys.exit(1)\" 2>/dev/null; } || cat ~/ai-now/memory.md 2>/dev/null || true; } && printf '\\n---\\nContext was compacted. If you discovered important insights, save them before continuing:\\n  nmem m add \"<insight>\" --title \"<short title>\" --importance 0.8\\n'"
+            "command": "SCRIPT=\"${CLAUDE_PLUGIN_ROOT:-}/scripts/nmem-hook-read.sh\"; { [ -f \"$SCRIPT\" ] && sh \"$SCRIPT\" || true; } && printf '\\n---\\nContext was compacted. If you discovered important insights, save them before continuing:\\n  nmem m add \"<insight>\" --title \"<short title>\" --importance 0.8\\n'"
           }
         ]
       }

--- a/nowledge-mem-claude-code-plugin/hooks/hooks.json
+++ b/nowledge-mem-claude-code-plugin/hooks/hooks.json
@@ -7,7 +7,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "SCRIPT=\"${CLAUDE_PLUGIN_ROOT:-}/scripts/nmem-hook-read.sh\"; [ -f \"$SCRIPT\" ] && sh \"$SCRIPT\" || true"
+            "command": "SCRIPT=\"${CLAUDE_PLUGIN_ROOT:-}/scripts/nmem-hook-read.sh\"; { [ -f \"$SCRIPT\" ] && sh \"$SCRIPT\"; } || cat \"$HOME/ai-now/memory.md\" 2>/dev/null || true"
           }
         ]
       },
@@ -16,7 +16,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "SCRIPT=\"${CLAUDE_PLUGIN_ROOT:-}/scripts/nmem-hook-read.sh\"; { [ -f \"$SCRIPT\" ] && sh \"$SCRIPT\" || true; } && printf '\\n---\\nContext was compacted. If you discovered important insights, save them before continuing:\\n  nmem m add \"<insight>\" --title \"<short title>\" --importance 0.8\\n'"
+            "command": "SCRIPT=\"${CLAUDE_PLUGIN_ROOT:-}/scripts/nmem-hook-read.sh\"; { { [ -f \"$SCRIPT\" ] && sh \"$SCRIPT\"; } || cat \"$HOME/ai-now/memory.md\" 2>/dev/null || true; } && printf '\\n---\\nContext was compacted. If you discovered important insights, save them before continuing:\\n  nmem m add \"<insight>\" --title \"<short title>\" --importance 0.8\\n'"
           }
         ]
       }

--- a/nowledge-mem-claude-code-plugin/scripts/nmem-hook-read.sh
+++ b/nowledge-mem-claude-code-plugin/scripts/nmem-hook-read.sh
@@ -3,10 +3,14 @@
 
 if ! command -v nmem >/dev/null 2>&1; then
   if command -v nmem.cmd >/dev/null 2>&1; then
+    escape_cmd_arg() {
+      printf '%s' "$1" | sed 's/\\/\\\\/g; s/"/\\"/g'
+    }
+
     nmem() {
       q=""
       for a in "$@"; do
-        q="$q \"$a\""
+        q="$q \"$(escape_cmd_arg "$a")\""
       done
       cmd.exe /s /c "\"nmem.cmd\"$q"
     }

--- a/nowledge-mem-claude-code-plugin/scripts/nmem-hook-read.sh
+++ b/nowledge-mem-claude-code-plugin/scripts/nmem-hook-read.sh
@@ -2,14 +2,13 @@
 # Best-effort Working Memory injection for Claude Code lifecycle hooks.
 
 if ! command -v nmem >/dev/null 2>&1; then
-  NMEM_CMD="$(command -v nmem.cmd 2>/dev/null || true)"
-  if [ -n "$NMEM_CMD" ]; then
+  if command -v nmem.cmd >/dev/null 2>&1; then
     nmem() {
       q=""
       for a in "$@"; do
         q="$q \"$a\""
       done
-      cmd.exe /s /c "\"$NMEM_CMD\"$q"
+      cmd.exe /s /c "\"nmem.cmd\"$q"
     }
   fi
 fi

--- a/nowledge-mem-claude-code-plugin/scripts/nmem-hook-read.sh
+++ b/nowledge-mem-claude-code-plugin/scripts/nmem-hook-read.sh
@@ -1,0 +1,55 @@
+#!/bin/sh
+# Best-effort Working Memory injection for Claude Code lifecycle hooks.
+
+if ! command -v nmem >/dev/null 2>&1; then
+  NMEM_CMD="$(command -v nmem.cmd 2>/dev/null || true)"
+  if [ -n "$NMEM_CMD" ]; then
+    nmem() {
+      q=""
+      for a in "$@"; do
+        q="$q \"$a\""
+      done
+      cmd.exe /s /c "\"$NMEM_CMD\"$q"
+    }
+  fi
+fi
+
+PY="$(command -v python3 2>/dev/null || command -v python 2>/dev/null || true)"
+
+resolve_space() {
+  if [ -n "${NMEM_SPACE:-}" ]; then
+    printf '%s\n' "$NMEM_SPACE"
+    return 0
+  fi
+
+  common_dir="$(git rev-parse --git-common-dir 2>/dev/null)" || return 0
+  [ -n "$common_dir" ] || return 0
+
+  case "$common_dir" in
+    /*) common_path="$common_dir" ;;
+    *) common_path="$(pwd -P)/$common_dir" ;;
+  esac
+
+  common_parent="$(cd "$(dirname "$common_path")" 2>/dev/null && pwd -P)" || return 0
+  basename "$common_parent" 2>/dev/null | tr '[:upper:]' '[:lower:]'
+}
+
+SPACE="$(resolve_space)"
+
+parse_existing_space_wm='import sys,json; d=json.load(sys.stdin); c=d.get("content",""); print(c) if d.get("exists") and c else sys.exit(1)'
+parse_default_wm='import sys,json; d=json.load(sys.stdin); c=d.get("content",""); print(c) if c else sys.exit(1)'
+
+if command -v nmem >/dev/null 2>&1 && [ -n "$PY" ]; then
+  if [ -n "$SPACE" ] \
+    && nmem --json wm read --space "$SPACE" 2>/dev/null \
+      | "$PY" -c "$parse_existing_space_wm" 2>/dev/null; then
+    exit 0
+  fi
+
+  if nmem --json wm read 2>/dev/null \
+    | "$PY" -c "$parse_default_wm" 2>/dev/null; then
+    exit 0
+  fi
+fi
+
+cat "$HOME/ai-now/memory.md" 2>/dev/null || true

--- a/nowledge-mem-claude-code-plugin/tests/test_nmem_hook_read.py
+++ b/nowledge-mem-claude-code-plugin/tests/test_nmem_hook_read.py
@@ -123,3 +123,36 @@ def test_read_hook_falls_back_to_local_memory_file_without_nmem(tmp_path):
 
     assert result.returncode == 0
     assert result.stdout.strip() == "file briefing"
+
+
+def test_read_hook_invokes_windows_nmem_cmd_by_command_name(tmp_path):
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    calls = tmp_path / "cmd.log"
+
+    nmem_cmd = bin_dir / "nmem.cmd"
+    nmem_cmd.write_text("", encoding="utf-8")
+    nmem_cmd.chmod(0o755)
+
+    cmd_exe = bin_dir / "cmd.exe"
+    cmd_exe.write_text(
+        f"""#!/bin/sh
+printf '%s\\n' "$*" > "{calls}"
+case "$*" in
+  *"nmem.cmd"*) printf '%s\\n' '{{"exists": true, "content": "cmd briefing"}}' ;;
+  *) exit 1 ;;
+esac
+""",
+        encoding="utf-8",
+    )
+    cmd_exe.chmod(0o755)
+
+    result = _run_hook(
+        tmp_path,
+        cwd=tmp_path,
+        env={"PATH": f"{bin_dir}:/bin:/usr/bin", "NMEM_SPACE": ""},
+    )
+
+    assert result.returncode == 0
+    assert result.stdout.strip() == "cmd briefing"
+    assert '"nmem.cmd" "--json" "wm" "read"' in calls.read_text(encoding="utf-8")

--- a/nowledge-mem-claude-code-plugin/tests/test_nmem_hook_read.py
+++ b/nowledge-mem-claude-code-plugin/tests/test_nmem_hook_read.py
@@ -1,0 +1,125 @@
+import os
+import subprocess
+from pathlib import Path
+
+
+SCRIPT_PATH = Path(__file__).parent.parent / "scripts" / "nmem-hook-read.sh"
+
+
+def _write_fake_nmem(bin_dir: Path, body: str) -> Path:
+    fake_nmem = bin_dir / "nmem"
+    fake_nmem.write_text("#!/bin/sh\n" + body, encoding="utf-8")
+    fake_nmem.chmod(0o755)
+    return fake_nmem
+
+
+def _run_hook(tmp_path: Path, *, cwd: Path, env: dict[str, str]) -> subprocess.CompletedProcess[str]:
+    hook_env = os.environ.copy()
+    hook_env.update(env)
+    hook_env["HOME"] = str(tmp_path / "home")
+    (Path(hook_env["HOME"]) / "ai-now").mkdir(parents=True, exist_ok=True)
+    return subprocess.run(
+        ["sh", str(SCRIPT_PATH)],
+        cwd=str(cwd),
+        env=hook_env,
+        text=True,
+        capture_output=True,
+        timeout=15,
+    )
+
+
+def test_read_hook_prefers_git_common_dir_space(tmp_path):
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    calls = tmp_path / "calls.log"
+    _write_fake_nmem(
+        bin_dir,
+        f"""
+printf '%s\\n' "$*" >> "{calls}"
+case "$*" in
+  *"--space examplerepo"*) printf '%s\\n' '{{"exists": true, "content": "space briefing"}}' ;;
+  *) printf '%s\\n' '{{"exists": true, "content": "default briefing"}}' ;;
+esac
+""",
+    )
+    project = tmp_path / "ExampleRepo"
+    subdir = project / "subdir"
+    subdir.mkdir(parents=True)
+    subprocess.run(["git", "init", "-q"], cwd=str(project), check=True)
+
+    result = _run_hook(
+        tmp_path,
+        cwd=subdir,
+        env={"PATH": f"{bin_dir}:{os.environ['PATH']}", "NMEM_SPACE": ""},
+    )
+
+    assert result.returncode == 0
+    assert result.stdout.strip() == "space briefing"
+    assert "--space examplerepo" in calls.read_text(encoding="utf-8")
+
+
+def test_read_hook_honors_nmem_space_override(tmp_path):
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    calls = tmp_path / "calls.log"
+    _write_fake_nmem(
+        bin_dir,
+        f"""
+printf '%s\\n' "$*" >> "{calls}"
+case "$*" in
+  *"--space Research Lane"*) printf '%s\\n' '{{"exists": true, "content": "env briefing"}}' ;;
+  *) printf '%s\\n' '{{"exists": true, "content": "default briefing"}}' ;;
+esac
+""",
+    )
+
+    result = _run_hook(
+        tmp_path,
+        cwd=tmp_path,
+        env={"PATH": f"{bin_dir}:{os.environ['PATH']}", "NMEM_SPACE": "Research Lane"},
+    )
+
+    assert result.returncode == 0
+    assert result.stdout.strip() == "env briefing"
+    assert "--space Research Lane" in calls.read_text(encoding="utf-8")
+
+
+def test_read_hook_falls_back_to_default_space_when_project_space_empty(tmp_path):
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    _write_fake_nmem(
+        bin_dir,
+        """
+case "$*" in
+  *"--space "*) printf '%s\\n' '{"exists": false, "content": ""}' ;;
+  *) printf '%s\\n' '{"exists": true, "content": "default briefing"}' ;;
+esac
+""",
+    )
+    project = tmp_path / "repo"
+    project.mkdir()
+    subprocess.run(["git", "init", "-q"], cwd=str(project), check=True)
+
+    result = _run_hook(
+        tmp_path,
+        cwd=project,
+        env={"PATH": f"{bin_dir}:{os.environ['PATH']}", "NMEM_SPACE": ""},
+    )
+
+    assert result.returncode == 0
+    assert result.stdout.strip() == "default briefing"
+
+
+def test_read_hook_falls_back_to_local_memory_file_without_nmem(tmp_path):
+    memory_file = tmp_path / "home" / "ai-now" / "memory.md"
+    memory_file.parent.mkdir(parents=True)
+    memory_file.write_text("file briefing\n", encoding="utf-8")
+
+    result = _run_hook(
+        tmp_path,
+        cwd=tmp_path,
+        env={"PATH": "/bin:/usr/bin", "NMEM_SPACE": ""},
+    )
+
+    assert result.returncode == 0
+    assert result.stdout.strip() == "file briefing"

--- a/nowledge-mem-claude-code-plugin/tests/test_nmem_hook_read.py
+++ b/nowledge-mem-claude-code-plugin/tests/test_nmem_hook_read.py
@@ -19,7 +19,7 @@ def _run_hook(tmp_path: Path, *, cwd: Path, env: dict[str, str]) -> subprocess.C
     hook_env["HOME"] = str(tmp_path / "home")
     (Path(hook_env["HOME"]) / "ai-now").mkdir(parents=True, exist_ok=True)
     return subprocess.run(
-        ["sh", str(SCRIPT_PATH)],
+        ["/bin/sh", str(SCRIPT_PATH)],
         cwd=str(cwd),
         env=hook_env,
         text=True,
@@ -114,11 +114,14 @@ def test_read_hook_falls_back_to_local_memory_file_without_nmem(tmp_path):
     memory_file = tmp_path / "home" / "ai-now" / "memory.md"
     memory_file.parent.mkdir(parents=True)
     memory_file.write_text("file briefing\n", encoding="utf-8")
+    bin_dir = tmp_path / "no-nmem-bin"
+    bin_dir.mkdir()
+    (bin_dir / "cat").symlink_to("/bin/cat")
 
     result = _run_hook(
         tmp_path,
         cwd=tmp_path,
-        env={"PATH": "/bin:/usr/bin", "NMEM_SPACE": ""},
+        env={"PATH": str(bin_dir), "NMEM_SPACE": ""},
     )
 
     assert result.returncode == 0

--- a/nowledge-mem-claude-code-plugin/tests/test_nmem_hook_read.py
+++ b/nowledge-mem-claude-code-plugin/tests/test_nmem_hook_read.py
@@ -153,9 +153,11 @@ esac
     result = _run_hook(
         tmp_path,
         cwd=tmp_path,
-        env={"PATH": f"{bin_dir}:/bin:/usr/bin", "NMEM_SPACE": ""},
+        env={"PATH": f"{bin_dir}:/bin:/usr/bin", "NMEM_SPACE": 'project"2024'},
     )
 
     assert result.returncode == 0
     assert result.stdout.strip() == "cmd briefing"
-    assert '"nmem.cmd" "--json" "wm" "read"' in calls.read_text(encoding="utf-8")
+    command = calls.read_text(encoding="utf-8")
+    assert '"nmem.cmd" "--json" "wm" "read"' in command
+    assert '"project\\"2024"' in command

--- a/tests/plugin_e2e/test_key_plugins_e2e.py
+++ b/tests/plugin_e2e/test_key_plugins_e2e.py
@@ -195,7 +195,10 @@ def test_key_plugin_static_contracts_are_declared():
     claude_hooks = _read_json(CLAUDE_PLUGIN / "hooks" / "hooks.json")["hooks"]
     assert claude_manifest["name"] == "nowledge-mem"
     assert {"SessionStart", "UserPromptSubmit", "PreCompact", "Stop"} <= set(claude_hooks)
+    assert "nmem-hook-read.sh" in json.dumps(claude_hooks)
     assert "nmem-hook-save.py" in json.dumps(claude_hooks)
+    assert "wm read" not in json.dumps(claude_hooks)
+    assert (CLAUDE_PLUGIN / "scripts" / "nmem-hook-read.sh").exists()
     assert (CLAUDE_PLUGIN / "skills" / "save-thread" / "SKILL.md").exists()
 
     codex_manifest = _read_json(CODEX_PLUGIN / ".codex-plugin" / "plugin.json")

--- a/tests/plugin_e2e/test_key_plugins_e2e.py
+++ b/tests/plugin_e2e/test_key_plugins_e2e.py
@@ -246,6 +246,42 @@ def test_key_plugin_static_contracts_are_declared():
     assert "nowledge_mem_save_thread" in opencode_source
 
 
+def test_claude_read_hooks_keep_file_fallback_without_plugin_root(tmp_path):
+    hooks = _read_json(CLAUDE_PLUGIN / "hooks" / "hooks.json")["hooks"]
+    home = tmp_path / "home"
+    memory_file = home / "ai-now" / "memory.md"
+    memory_file.parent.mkdir(parents=True)
+    memory_file.write_text("fallback briefing\n", encoding="utf-8")
+
+    env = {
+        "HOME": str(home),
+        "PATH": "/bin:/usr/bin",
+        "CLAUDE_PLUGIN_ROOT": "",
+    }
+    startup_command = hooks["SessionStart"][0]["hooks"][0]["command"]
+    startup = subprocess.run(
+        ["/bin/sh", "-c", startup_command],
+        env=env,
+        text=True,
+        capture_output=True,
+        timeout=15,
+    )
+    assert startup.returncode == 0
+    assert startup.stdout.strip() == "fallback briefing"
+
+    compact_command = hooks["SessionStart"][1]["hooks"][0]["command"]
+    compact = subprocess.run(
+        ["/bin/sh", "-c", compact_command],
+        env=env,
+        text=True,
+        capture_output=True,
+        timeout=15,
+    )
+    assert compact.returncode == 0
+    assert "fallback briefing" in compact.stdout
+    assert "Context was compacted" in compact.stdout
+
+
 def test_key_plugin_credentials_stay_out_of_static_runtime_urls():
     hermes_client = (HERMES_PLUGIN / "client.py").read_text(encoding="utf-8").lower()
     openclaw_client = (OPENCLAW_PLUGIN / "src" / "client.js").read_text(encoding="utf-8").lower()


### PR DESCRIPTION
## Summary
- Extract Claude Code SessionStart/compact Working Memory loading into `scripts/nmem-hook-read.sh` so both hook matchers share the same behavior.
- Preserve the existing fallback order: project-space `nmem wm read`, default-space `nmem wm read`, then `~/ai-now/memory.md`.
- Bump the Claude Code plugin metadata to 0.7.9 and add regression coverage for space resolution and fallback paths.

## Verification
- `uv run --with pytest pytest nowledge-mem-claude-code-plugin/tests/test_nmem_hook_read.py nowledge-mem-claude-code-plugin/tests/test_nmem_hook_save.py tests/plugin_e2e/test_key_plugins_e2e.py -q`
- `uv run --with pytest pytest tests/plugin_e2e -q`
- `uv run --with pytest pytest nowledge-mem-hermes/tests -q`
- `node nowledge-mem-codex-plugin/scripts/validate-plugin.mjs`
- `sh -n nowledge-mem-claude-code-plugin/scripts/nmem-hook-read.sh`
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk refactor of Claude Code hook wiring plus added tests; main risk is regressions in shell hook execution and fallback behavior across environments (git/non-git, missing `CLAUDE_PLUGIN_ROOT`, Windows `nmem.cmd`).
> 
> **Overview**
> Claude Code’s `SessionStart` and `compact` Working Memory injection is refactored to call a new shared script (`scripts/nmem-hook-read.sh`) instead of duplicating a long inline shell pipeline in `hooks.json`, while preserving the same fallback order (space-aware `wm read` → default `wm read` → `$HOME/ai-now/memory.md`).
> 
> Adds focused regression tests for space resolution (`git --git-common-dir` and `NMEM_SPACE` override), fallback behavior when space/default WM is empty or `nmem` is missing, and Windows `nmem.cmd` invocation/escaping; updates plugin registry/manifest versions to `0.7.9` and asserts in E2E static checks that hooks no longer embed `wm read` directly and that file fallback works without `CLAUDE_PLUGIN_ROOT`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3d3baa8e5e8d2e2e98f5a66faca9d82fd51ef385. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Bumped version to 0.7.9

* **Tests**
  * Added test coverage for working memory read hook behavior, including git-space resolution, environment variable overrides, and fallback scenarios

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/nowledge-co/community/pull/231)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->