### PR TITLE
Fix managed plugin update verification

### DIFF
--- a/integrations.json
+++ b/integrations.json
@@ -38,7 +38,7 @@
       },
       "install": {
         "command": "claude plugin marketplace add nowledge-co/community && claude plugin install nowledge-mem@nowledge-community",
-        "updateCommand": "claude plugin marketplace update && claude plugin update nowledge-mem@nowledge-community",
+        "updateCommand": "claude plugin marketplace add nowledge-co/community && claude plugin marketplace update nowledge-community && claude plugin update nowledge-mem@nowledge-community",
         "detectionHint": "Running as Claude Code agent; ~/.claude/ exists",
         "docsUrl": "/docs/integrations/claude-code"
       },
@@ -84,7 +84,7 @@
       },
       "install": {
         "command": "copilot plugin marketplace add nowledge-co/community && copilot plugin install nowledge-mem@nowledge-community",
-        "updateCommand": "copilot plugin marketplace update nowledge-community && copilot plugin update nowledge-mem",
+        "updateCommand": "copilot plugin marketplace add nowledge-co/community && copilot plugin marketplace update nowledge-community && copilot plugin update nowledge-mem",
         "detectionHint": "Running as GitHub Copilot CLI agent; ~/.copilot/ exists",
         "docsUrl": "/docs/integrations/copilot-cli"
       },
@@ -411,8 +411,8 @@
         ]
       },
       "install": {
-        "command": "python3 -m pip install nowledge-mem-bub",
-        "updateCommand": "python3 -m pip install --upgrade nowledge-mem-bub",
+        "command": "python3 -m pip install nowledge-mem-bub || python -m pip install nowledge-mem-bub || py -3 -m pip install nowledge-mem-bub",
+        "updateCommand": "python3 -m pip install --upgrade nowledge-mem-bub || python -m pip install --upgrade nowledge-mem-bub || py -3 -m pip install --upgrade nowledge-mem-bub",
         "detectionHint": "Running inside Bub",
         "docsUrl": "/docs/integrations/bub"
       },

--- a/nowledge-mem-claude-code-plugin/README.md
+++ b/nowledge-mem-claude-code-plugin/README.md
@@ -110,7 +110,8 @@ Shared spaces, default retrieval, and agent guidance still live in Mem's own spa
 ## Update
 
 ```bash
-claude plugin marketplace update
+claude plugin marketplace add nowledge-co/community
+claude plugin marketplace update nowledge-community
 claude plugin update nowledge-mem@nowledge-community
 # Restart Claude Code to apply changes
 ```

--- a/nowledge-mem-copilot-cli-plugin/README.md
+++ b/nowledge-mem-copilot-cli-plugin/README.md
@@ -113,6 +113,7 @@ The session-start Working Memory read, per-turn guidance, skills, and background
 ## Update
 
 ```bash
+copilot plugin marketplace add nowledge-co/community
 copilot plugin marketplace update nowledge-community
 copilot plugin update nowledge-mem
 ```


### PR DESCRIPTION
## Summary
- Canonicalize Claude Code and Copilot CLI marketplace sources before plugin updates so stale local marketplace checkouts cannot report a false latest version.
- Add Python launcher fallbacks for Bub install/update commands across macOS/Linux/Windows-style environments.
- Align Claude Code and Copilot CLI README update instructions with the app-managed command path.

## Verification
- `uv run --with pytest pytest nowledge-mem-claude-code-plugin/tests nowledge-mem-codex-plugin/tests nowledge-mem-copilot-cli-plugin/tests nowledge-mem-hermes/tests -q` -> 106 passed
- `node --test nowledge-mem-openclaw-plugin/tests/*.test.mjs` -> 24 passed
- `node --test nowledge-mem-alma-plugin/tests/*.test.mjs` -> 8 passed
- `bash nowledge-mem-hermes/tests/test_setup.sh` -> passed
- `uv run --with pytest pytest tests/plugin_e2e -q` -> 3 passed, 5 skipped
- `node nowledge-mem-codex-plugin/scripts/validate-plugin.mjs` -> passed

## Note
Root-level `pytest -q` is not a valid gate for this repo today: pytest attempts to import `nowledge-mem-hermes/__init__.py` as a test package because the plugin directory contains tests under a hyphenated directory. Scoped plugin suites pass.