### PR TITLE
feat: docker headless image

### DIFF
--- a/docker/Caddyfile
+++ b/docker/Caddyfile
@@ -1,0 +1,43 @@
+# Caddy configuration for fronting the headless Nowledge Mem server with TLS.
+#
+# This file is mounted read-only into the caddy sidecar. It uses runtime env
+# vars (NOWLEDGE_DOMAIN, NOWLEDGE_LE_EMAIL) sourced from compose.tls.yaml.
+#
+# What it does:
+#   - Obtains and renews a Let's Encrypt certificate for NOWLEDGE_DOMAIN.
+#   - Terminates TLS 1.2+ with HTTP/3 (QUIC) support.
+#   - Reverse-proxies all traffic to the mem container on port 14242.
+#   - Enables HSTS once you're confident the cert is stable. Uncomment when ready.
+#
+# The headless server's own /remote-api gateway and license/auth contract stay
+# intact behind this — Caddy only adds transport security and a hostname.
+
+{
+	# Use a real email for renewal notifications and account recovery.
+	email {$NOWLEDGE_LE_EMAIL}
+
+	# Encode JSON access logs (skip if you don't need them; logs go to stdout
+	# of the caddy container by default).
+	log {
+		output stdout
+		format json
+	}
+}
+
+{$NOWLEDGE_DOMAIN} {
+	encode zstd gzip
+
+	# Forward everything (SPA at /app, API, MCP, WebSockets, SSE) to mem:14242.
+	reverse_proxy mem:14242 {
+		# Streaming endpoints (SSE for graph intelligence, /agent/ai-now/*)
+		# need a long timeout and unbuffered pass-through.
+		flush_interval -1
+		transport http {
+			read_timeout  10m
+			write_timeout 10m
+		}
+	}
+
+	# Uncomment after first successful issuance and at least one renewal:
+	# header Strict-Transport-Security "max-age=31536000; includeSubDomains; preload"
+}

--- a/docker/Caddyfile
+++ b/docker/Caddyfile
@@ -16,8 +16,9 @@
 	# Use a real email for renewal notifications and account recovery.
 	email {$NOWLEDGE_LE_EMAIL}
 
-	# Encode JSON access logs (skip if you don't need them; logs go to stdout
-	# of the caddy container by default).
+	# Global runtime logger (Caddy's own diagnostics, not per-request).
+	# Per-request access logs are configured in the site block below; Caddy
+	# v2 does not emit HTTP access logs unless a site-scoped `log` is set.
 	log {
 		output stdout
 		format json
@@ -26,6 +27,13 @@
 
 {$NOWLEDGE_DOMAIN} {
 	encode zstd gzip
+
+	# Per-request HTTP access logs in JSON to the caddy container's stdout.
+	# Pair with `docker compose logs -f caddy` (or your log aggregator).
+	log {
+		output stdout
+		format json
+	}
 
 	# Forward everything (SPA at /app, API, MCP, WebSockets, SSE) to mem:14242.
 	reverse_proxy mem:14242 {

--- a/docker/README.md
+++ b/docker/README.md
@@ -31,7 +31,7 @@ docker compose pull
 docker compose up -d        # restart with new image, all three volumes intact
 ```
 
-### The two contracts that make this work — and that we will not break
+### The three contracts that make this work — and that we will not break
 
 1. **UID 10001 is forever.** The container runs as `uid=10001 gid=10001`.
    Files in your volumes are owned by 10001:10001 on the host. Every future
@@ -43,6 +43,18 @@ docker compose up -d        # restart with new image, all three volumes intact
    move. The `XDG_*` env vars inside the image will not move either. You can
    bind your compose volumes to wherever you want on the host without worrying
    about path drift across releases.
+3. **Your device identity lives in the `config` volume.** A UUID seed at
+   `/etc/nowledge-mem/co.nowledge.mem.desktop/machine_id` (auto-generated on
+   first start) is what the license backend sees as your device. So:
+   - `docker compose down && up -d` → same device, license stays activated.
+   - `docker compose pull && up -d` → same device, license stays activated.
+   - `docker compose down -v` → device gone, equivalent to a fresh install.
+   - Moving the volume to another host → license follows the volume.
+   - Fleet operators: override with `NOWLEDGE_DEVICE_FINGERPRINT=<value>` env
+     for centralized identity (e.g. derived from a secret manager).
+   This is the contract that makes the per-license device cap meaningful when
+   running in containers — without it, every container restart would look
+   like a brand-new device to the license server.
 
 ### Air-gapped / pre-baked models
 

--- a/docker/README.md
+++ b/docker/README.md
@@ -413,3 +413,27 @@ buffer pool exhausted. `docker compose restart mem` recovers; if it keeps
 recurring, bump `mem_limit` per the table above or pin
 `NOWLEDGE_KUZU_BUFFER_POOL_SIZE` explicitly. See "Memory and recovery"
 above and `docs/design/HEADLESS_MEMORY_CONTRACT.md` for the full picture.
+
+**AI Now / feed agent hangs, /livez stops responding, container goes
+"unhealthy".** Different cause from the buffer-pool wedge above: the
+agent is retrying an LLM provider call that's failing (timeout, missing
+API key, or no provider configured at all). The retry loop holds CPU
+and embedding memory; the asyncio event loop gets starved and `/livez`
+falls off. Confirm with `docker stats nowledge-mem` (CPU near 200 %,
+memory near `mem_limit`) and `docker logs nowledge-mem | grep -i
+"timeout\|httpx.*timeout\|ReadTimeout" | tail -5`.
+
+Recover:
+
+```bash
+docker compose restart mem        # clears the loop
+# Then BEFORE re-triggering the agent:
+#   - Settings → Providers → confirm an LLM is configured with a working key
+#   - Or bump mem_limit to 8g per the table above for agent workloads
+```
+
+The structural fix (bounded retries + structured error to UI) is tracked
+in `docs/design/HEADLESS_MEMORY_CONTRACT.md` Appendix A. Until that
+lands, the rule of thumb is: do not invoke agent flows on a deploy that
+hasn't been re-configured with a remote-LLM provider after a
+`down -v`.

--- a/docker/README.md
+++ b/docker/README.md
@@ -65,7 +65,7 @@ once on a connected machine:
 # On a connected machine, with the same image:
 docker compose up -d
 # Trigger a search so embedding weights download:
-docker compose exec mem curl -s -H "Authorization: Bearer $(docker compose exec mem nmem key | tr -d '\r\n')" \
+docker compose exec -T mem curl -s -H "Authorization: Bearer $(docker compose exec -T mem nmem key | tr -d '\r\n')" \
   "http://127.0.0.1:14242/memories/search?q=warmup&limit=1" >/dev/null
 docker compose down
 

--- a/docker/README.md
+++ b/docker/README.md
@@ -70,12 +70,12 @@ docker compose exec mem curl -s -H "Authorization: Bearer $(docker compose exec 
 docker compose down
 
 # Snapshot the cache volume:
-docker run --rm -v nowledge-mem_cache:/cache -v "$PWD":/dst alpine \
+docker run --rm -v nowledge-mem-cache:/cache -v "$PWD":/dst alpine \
   tar -C /cache -czf /dst/nmem-cache.tgz .
 
 # On the air-gapped machine:
-docker volume create nowledge-mem_cache
-docker run --rm -v nowledge-mem_cache:/cache -v "$PWD":/src alpine \
+docker volume create nowledge-mem-cache
+docker run --rm -v nowledge-mem-cache:/cache -v "$PWD":/src alpine \
   tar -C /cache -xzf /src/nmem-cache.tgz
 docker compose up -d
 ```
@@ -112,7 +112,10 @@ docker compose logs -f mem                                 # wait for "Applicati
 docker compose exec mem nmem key                           # show the API key
 docker compose exec mem nmem license status                # license tier
 docker compose exec mem nmem license activate <CODE>       # optional
-open http://localhost:14242/app
+
+# macOS:   open http://localhost:14242/app
+# Linux:   xdg-open http://localhost:14242/app
+# Windows: start http://localhost:14242/app
 ```
 
 ---
@@ -164,7 +167,7 @@ skip auth by default.
 
 ### Where the key lives
 
-```
+```text
 /etc/nowledge-mem/co.nowledge.mem.desktop/remote-access.json
                   ^                       ^
                   app namespace           mode 0600, owner nowledge:nowledge
@@ -190,7 +193,7 @@ cat > ./seed/co.nowledge.mem.desktop/remote-access.json <<EOF
 EOF
 chmod 0600 ./seed/co.nowledge.mem.desktop/remote-access.json
 # Then bind ./seed onto /etc/nowledge-mem in compose.yaml (or copy into the
-# volume with `docker run --rm -v config:/dst -v $PWD/seed:/src alpine cp -a /src/. /dst/`).
+# volume with `docker run --rm -v nowledge-mem-config:/dst -v "$PWD"/seed:/src alpine cp -a /src/. /dst/`).
 ```
 
 ### Rate-limit recovery
@@ -257,8 +260,8 @@ you pulled was not produced by our pipeline.
 
 ```bash
 docker run --rm \
-  -v nowledge-mem_data:/data:ro \
-  -v nowledge-mem_config:/config:ro \
+  -v nowledge-mem-data:/data:ro \
+  -v nowledge-mem-config:/config:ro \
   -v "$PWD":/backup \
   alpine \
   tar -C / -czf /backup/nowledge-mem-$(date +%F).tgz data config
@@ -281,7 +284,7 @@ once a newer image has opened the database, an older image will refuse to.
 
 ```bash
 docker compose down
-docker volume rm nowledge-mem_data nowledge-mem_config nowledge-mem_cache
+docker volume rm nowledge-mem-data nowledge-mem-config nowledge-mem-cache
 docker compose up -d
 ```
 
@@ -425,7 +428,7 @@ install is on the roadmap.
 buffer pool exhausted. `docker compose restart mem` recovers; if it keeps
 recurring, bump `mem_limit` per the table above or pin
 `NOWLEDGE_KUZU_BUFFER_POOL_SIZE` explicitly. See "Memory and recovery"
-above and `docs/design/HEADLESS_MEMORY_CONTRACT.md` for the full picture.
+above.
 
 **Feed agent / knowledge agent hangs the container, /livez goes
 "unhealthy".** Different cause from the buffer-pool wedge above: those
@@ -461,5 +464,5 @@ This is **not** a misconfigured LLM provider — verified by inspecting
 on-disk state, all three agents (AI Now, feed, knowledge) read the
 same `remote_llm.json`. The structural fix lives in the agent layer
 (off-event-loop ONNX inference, batched embedding calls, bounded
-retries) and is tracked in
-`docs/design/HEADLESS_MEMORY_CONTRACT.md` Appendix A (TODO 5.5a–5.5d).
+retries) and is tracked upstream; for now, sizing the container
+generously per the table above is the working mitigation.

--- a/docker/README.md
+++ b/docker/README.md
@@ -108,10 +108,10 @@ certificate for you.
 
 ```bash
 docker compose up -d
-docker compose logs -f mem                                 # wait for "Application startup complete"
-docker compose exec mem nmem key                           # show the API key
-docker compose exec mem nmem license status                # license tier
-docker compose exec mem nmem license activate <CODE>       # optional
+docker compose logs -f mem                                    # wait for "Application startup complete"
+docker compose exec -T mem nmem key                           # show the API key
+docker compose exec -T mem nmem license status                # license tier
+docker compose exec -T mem nmem license activate <CODE>       # optional
 
 # macOS:   open http://localhost:14242/app
 # Linux:   xdg-open http://localhost:14242/app
@@ -180,10 +180,10 @@ up the key.
 
 ```bash
 # Show the current key
-./bootstrap.sh                            # or: docker compose exec mem nmem key
+./bootstrap.sh                            # or: docker compose exec -T mem nmem key
 
 # Rotate (invalidates the old value immediately; re-paste in clients)
-./bootstrap.sh rotate-key                 # or: docker compose exec mem nmem key --rotate
+./bootstrap.sh rotate-key                 # or: docker compose exec -T mem nmem key --rotate
 
 # Pre-seed a known key (useful for fleets managed by a secret manager).
 # Write the file before first `docker compose up`:
@@ -198,8 +198,9 @@ chmod 0600 ./seed/co.nowledge.mem.desktop/remote-access.json
 
 ### Rate-limit recovery
 
-After 5 invalid-auth attempts from the same client IP, the server blocks
-that IP for **15 minutes**. If you locked yourself out during testing:
+After **8 invalid-auth attempts within a 5-minute window** from the same
+client IP, the server blocks that IP for **10 minutes**. If you locked
+yourself out during testing:
 
 ```bash
 docker compose restart mem        # clears the in-memory rate-limit window
@@ -242,7 +243,7 @@ identity that produced the build.
 
 ```bash
 cosign verify docker.io/nowledgelabs/mem:0.8.4 \
-  --certificate-identity-regexp='https://github.com/nowledge-co/nowledge-mem/.github/workflows/release-docker.yml@.*' \
+  --certificate-identity-regexp='https://github.com/nowledge-co/mem/.github/workflows/release-docker.yml@.*' \
   --certificate-oidc-issuer='https://token.actions.githubusercontent.com'
 ```
 

--- a/docker/README.md
+++ b/docker/README.md
@@ -348,10 +348,23 @@ your dataset — bump it per the table above and recreate the stack.
 - `NOWLEDGE_KUZU_BUFFER_POOL_SIZE` — pin the pool to a fixed size
   (e.g. `1GB`, `512MB`). Disables both the heuristic and auto-escalation.
   Use when you want deterministic capacity planning at scale.
-- *(roadmap)* `NOWLEDGE_KUZU_BUFFER_POOL_FLOOR_MB` and cgroup-aware
-  auto-cap detection are tracked in
-  `docs/design/HEADLESS_MEMORY_CONTRACT.md`; until those land, set the
-  explicit size above on tight-memory hosts.
+- `NOWLEDGE_KUZU_BUFFER_POOL_FLOOR_MB` — override the auto-mode floor.
+  Headless containers default to **256 MB** so a fresh deploy can absorb
+  a first-day ingest workload. Set to `0` to opt out on tight-memory
+  hosts (e.g. 1 GiB VPS); set higher on bulk-ingest hosts.
+- `NOWLEDGE_AGENT_MAX_CONCURRENT` — per-agent-type concurrency cap.
+  Default **1** on headless, 2 on desktop. Raise to 2 on an 8 GiB
+  container, 3+ on a 16 GiB container. Above this cap the server
+  returns `AgentBusy` immediately rather than queueing — the browser
+  shows "agent is busy, try again in a few seconds" instead of
+  silently double-booking memory and OOM-killing the container.
+
+**Container memory cap is now cgroup-aware.** Earlier builds would
+size Kuzu's auto-cap from the *host's* RAM, ignoring your
+`mem_limit`. Starting 0.8.4 the auto-cap clamps to the cgroup
+`memory.max` (or v1 equivalent), so Mem cannot grow its graph memory
+past what Docker has actually given the container. No action needed
+— this just means `mem_limit: 4g` is honoured the way you'd expect.
 
 ---
 

--- a/docker/README.md
+++ b/docker/README.md
@@ -300,6 +300,59 @@ docker compose logs -f mem
 - `GET /health` — process is up **and** the database is open. Use this for
   readiness gating (k8s readinessProbe, load balancer health check).
 
+### Memory and recovery
+
+The server uses KuzuDB for the graph, and KuzuDB has a per-process buffer
+pool. The pool is sized at startup from a heuristic over the current DB
+size and grown automatically as the data scales. Two things to know:
+
+**Sizing your container.** The compose default (`mem_limit: 4g`) is sized
+for a small-to-medium personal graph. As your data grows, lift the
+container:
+
+| DB size (steady state) | Recommended `mem_limit` |
+|---|---|
+| < 200 MB | 2 GB |
+| < 1 GB | **4 GB** (the compose default) |
+| 1 – 4 GB | 8 GB |
+| 4 – 16 GB | 16 GB |
+| > 16 GB | host-specific; pin `NOWLEDGE_KUZU_BUFFER_POOL_SIZE` explicitly |
+
+A rough rule: the Kuzu pool wants ~25% of the container budget; the
+embedding model wants ~1.4 GB; Python + uvicorn want ~500 MB; and you
+want ~25% headroom for OS page cache and ingestion temp buffers.
+
+**If a large upload fails with a 500 and the next few reads also 500**,
+you've hit a buffer-pool exhaustion (`docker compose logs mem | grep
+"Buffer manager exception"` confirms). Today's recovery:
+
+```bash
+docker compose restart mem
+# Then verify the new floor:
+curl -s http://127.0.0.1:14242/health \
+  | jq '{
+      pool:  .buffer_pool_current_mb,
+      floor: .buffer_pool_auto_floor_mb,
+      cap:   .buffer_pool_auto_cap_mb,
+      need_restart: .buffer_pool_restart_required
+    }'
+```
+
+The image self-escalates the floor on exhaustion and the next restart
+picks up the new value, so a single restart is normally enough. If
+exhaustion keeps recurring, your container's `mem_limit` is too low for
+your dataset — bump it per the table above and recreate the stack.
+
+**Power-user knobs:**
+
+- `NOWLEDGE_KUZU_BUFFER_POOL_SIZE` — pin the pool to a fixed size
+  (e.g. `1GB`, `512MB`). Disables both the heuristic and auto-escalation.
+  Use when you want deterministic capacity planning at scale.
+- *(roadmap)* `NOWLEDGE_KUZU_BUFFER_POOL_FLOOR_MB` and cgroup-aware
+  auto-cap detection are tracked in
+  `docs/design/HEADLESS_MEMORY_CONTRACT.md`; until those land, set the
+  explicit size above on tight-memory hosts.
+
 ---
 
 ## Secrets
@@ -354,3 +407,9 @@ to `npx`/`uvx`. The default image trusts outbound HTTPS but does not include
 those CLIs. For now, install plugins on the desktop app and they'll be picked
 up by the server via the shared config volume; first-class headless plugin
 install is on the roadmap.
+
+**A file upload returned 500 and now every page in the UI fails.** The Kuzu
+buffer pool exhausted. `docker compose restart mem` recovers; if it keeps
+recurring, bump `mem_limit` per the table above or pin
+`NOWLEDGE_KUZU_BUFFER_POOL_SIZE` explicitly. See "Memory and recovery"
+above and `docs/design/HEADLESS_MEMORY_CONTRACT.md` for the full picture.

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,6 +1,6 @@
 # Run Nowledge Mem in Docker
 
-The official headless image at `docker.io/nowledge/mem` runs the full Nowledge
+The official headless image at `docker.io/nowledgelabs/mem` runs the full Nowledge
 Mem server: REST API, MCP, and the web UI at `/app`. The container ships the
 **same** PyArmor-protected Python bundle as the desktop release, runs as a
 non-root user, and lives entirely off three named volumes.
@@ -238,7 +238,7 @@ public keys to download or rotate — verification uses the GitHub Actions OIDC
 identity that produced the build.
 
 ```bash
-cosign verify docker.io/nowledge/mem:0.8.4 \
+cosign verify docker.io/nowledgelabs/mem:0.8.4 \
   --certificate-identity-regexp='https://github.com/nowledge-co/nowledge-mem/.github/workflows/release-docker.yml@.*' \
   --certificate-oidc-issuer='https://token.actions.githubusercontent.com'
 ```

--- a/docker/README.md
+++ b/docker/README.md
@@ -414,26 +414,39 @@ recurring, bump `mem_limit` per the table above or pin
 `NOWLEDGE_KUZU_BUFFER_POOL_SIZE` explicitly. See "Memory and recovery"
 above and `docs/design/HEADLESS_MEMORY_CONTRACT.md` for the full picture.
 
-**AI Now / feed agent hangs, /livez stops responding, container goes
-"unhealthy".** Different cause from the buffer-pool wedge above: the
-agent is retrying an LLM provider call that's failing (timeout, missing
-API key, or no provider configured at all). The retry loop holds CPU
-and embedding memory; the asyncio event loop gets starved and `/livez`
-falls off. Confirm with `docker stats nowledge-mem` (CPU near 200 %,
-memory near `mem_limit`) and `docker logs nowledge-mem | grep -i
-"timeout\|httpx.*timeout\|ReadTimeout" | tail -5`.
+**Feed agent / knowledge agent hangs the container, /livez goes
+"unhealthy".** Different cause from the buffer-pool wedge above: those
+agents do many synchronous BGE-m3 ONNX embedding passes during context
+gathering. Sync inference on CPU starves the asyncio event loop;
+in-flight `httpx` LLM responses can't be serviced and report
+`ReadTimeout` **even though the network and the LLM provider are
+fine**. The agent retries, doing more inference, and memory climbs
+toward `mem_limit`. Eventually Docker OOM-kills.
 
-Recover:
+Confirm:
 
 ```bash
-docker compose restart mem        # clears the loop
-# Then BEFORE re-triggering the agent:
-#   - Settings → Providers → confirm an LLM is configured with a working key
-#   - Or bump mem_limit to 8g per the table above for agent workloads
+docker stats --no-stream nowledge-mem
+# CPU near 200 %, memory near mem_limit → it's this failure mode.
+docker logs nowledge-mem | grep -E "httpx.*Timeout|ReadTimeout" | tail -3
+# Many of these → confirms the event-loop starvation pattern.
 ```
 
-The structural fix (bounded retries + structured error to UI) is tracked
-in `docs/design/HEADLESS_MEMORY_CONTRACT.md` Appendix A. Until that
-lands, the rule of thumb is: do not invoke agent flows on a deploy that
-hasn't been re-configured with a remote-LLM provider after a
-`down -v`.
+Recover and avoid recurrence:
+
+```bash
+docker compose restart mem        # kills the wedged agent loop
+# Then BEFORE re-triggering feed/knowledge:
+#   - Bump mem_limit to 8g per the table above. The default 4g is
+#     sized for passive (graph + web UI + idle embedding); agent
+#     flows need headroom for retries + the resident embedding model.
+#   - AI Now is lighter and works inside 4g; feed/knowledge are the
+#     heavyweights right now.
+```
+
+This is **not** a misconfigured LLM provider — verified by inspecting
+on-disk state, all three agents (AI Now, feed, knowledge) read the
+same `remote_llm.json`. The structural fix lives in the agent layer
+(off-event-loop ONNX inference, batched embedding calls, bounded
+retries) and is tracked in
+`docs/design/HEADLESS_MEMORY_CONTRACT.md` Appendix A (TODO 5.5a–5.5d).

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,0 +1,344 @@
+# Run Nowledge Mem in Docker
+
+The official headless image at `docker.io/nowledge/mem` runs the full Nowledge
+Mem server: REST API, MCP, and the web UI at `/app`. The container ships the
+**same** PyArmor-protected Python bundle as the desktop release, runs as a
+non-root user, and lives entirely off three named volumes.
+
+It is **headless** by design. There is no GTK, no WebKit, no Tauri. If you want
+the desktop app, install the `.deb` or `.AppImage` from the release page
+instead.
+
+---
+
+## Volume contract — what survives `docker compose pull && up -d`
+
+The image is built so it touches **only** the three named volumes at runtime.
+Everything else (`/opt`, `/usr`, the rootfs) is read-only by design and gets
+fully replaced when you pull a new image.
+
+| Mount | Tier | What lives here | Survives upgrade? | Lose it = |
+|---|---|---|---|---|
+| `/var/lib/nowledge-mem`   | **Irreplaceable** | KuzuDB graph (`NowledgeGraph/nowledge_graph_v2.db/`), content store, persisted thread/source/artifact payloads | yes (named volume) | data loss; restore from backup |
+| `/etc/nowledge-mem`       | **Valuable** | `app-settings.json`, `plugins.json`, `remote-access.json` (the API key), `license.json`, OAuth tokens, remote-LLM creds, AI Now config, scheduler state | yes (named volume) | re-activate license, re-sign-in, re-paste API keys |
+| `/var/cache/nowledge-mem` | **Rebuildable** | `huggingface/` (LLM/embedding weights), `embeddings/` (FastEmbed ONNX), LanceDB search projection | yes (named volume) | one-time slow first search (re-download) |
+
+So: back up `data` and `config`. `cache` is convenience storage; you can wipe
+it any time. The image upgrade contract is:
+
+```bash
+docker compose pull
+docker compose up -d        # restart with new image, all three volumes intact
+```
+
+### The two contracts that make this work — and that we will not break
+
+1. **UID 10001 is forever.** The container runs as `uid=10001 gid=10001`.
+   Files in your volumes are owned by 10001:10001 on the host. Every future
+   release of this image must run as the same UID, otherwise mount-point
+   permissions would break on upgrade. If you ever see a new image fail with
+   permission errors on existing volumes, that is a regression — please file
+   an issue.
+2. **The three mount paths above are part of the public API.** They will not
+   move. The `XDG_*` env vars inside the image will not move either. You can
+   bind your compose volumes to wherever you want on the host without worrying
+   about path drift across releases.
+
+### Air-gapped / pre-baked models
+
+If your deployment has no internet access, pre-populate the `cache` volume
+once on a connected machine:
+
+```bash
+# On a connected machine, with the same image:
+docker compose up -d
+# Trigger a search so embedding weights download:
+docker compose exec mem curl -s -H "Authorization: Bearer $(docker compose exec mem nmem key | tr -d '\r\n')" \
+  "http://127.0.0.1:14242/memories/search?q=warmup&limit=1" >/dev/null
+docker compose down
+
+# Snapshot the cache volume:
+docker run --rm -v nowledge-mem_cache:/cache -v "$PWD":/dst alpine \
+  tar -C /cache -czf /dst/nmem-cache.tgz .
+
+# On the air-gapped machine:
+docker volume create nowledge-mem_cache
+docker run --rm -v nowledge-mem_cache:/cache -v "$PWD":/src alpine \
+  tar -C /cache -xzf /src/nmem-cache.tgz
+docker compose up -d
+```
+
+The cache layout is identical across hosts of the same arch; there's nothing
+machine-specific in there.
+
+---
+
+## Quick start (one command)
+
+```bash
+./bootstrap.sh
+```
+
+That brings the stack up, waits for `/livez`, prints the Access Anywhere API
+key, shows your license tier, and tells you the URL to open.
+
+If you have a license code:
+
+```bash
+./bootstrap.sh activate <BASE64-LICENSE-CODE>
+```
+
+The default `compose.yaml` exposes the server on `0.0.0.0:14242`. To put TLS
+in front, overlay `compose.tls.yaml` and Caddy will obtain a Let's Encrypt
+certificate for you.
+
+### Or do it by hand
+
+```bash
+docker compose up -d
+docker compose logs -f mem                                 # wait for "Application startup complete"
+docker compose exec mem nmem key                           # show the API key
+docker compose exec mem nmem license status                # license tier
+docker compose exec mem nmem license activate <CODE>       # optional
+open http://localhost:14242/app
+```
+
+---
+
+## TLS (Let's Encrypt) via Caddy sidecar
+
+```bash
+export NOWLEDGE_DOMAIN=mem.example.com
+export NOWLEDGE_LE_EMAIL=you@example.com
+
+docker compose -f compose.yaml -f compose.tls.yaml up -d
+```
+
+You need:
+
+- A DNS A/AAAA record for `NOWLEDGE_DOMAIN` pointing at this host.
+- Ports `80` and `443` open to the internet (Let's Encrypt HTTP-01 challenge).
+- Docker Compose **v2.24 or newer** (the overlay uses the `!reset` tag to
+  rebind the upstream port, which earlier versions don't understand).
+
+The mem container is rebound to `127.0.0.1` so the only reachable surface is
+Caddy.
+
+---
+
+## Authentication — the full picture
+
+The server enforces two independent things:
+
+- **A license** (`license.json`) — paid Pro tier vs Free. Free is capped at
+  20 memories; activate a license to lift the cap. License is a file, not a
+  network call, and persists in the `config` volume.
+- **An API key** (`remote-access.json`) — bearer-token auth on every non-public
+  endpoint. The web UI uses the same key.
+
+### What's exempt from auth
+
+Anyone on the LAN can hit these without a key (by design — they're for
+probes, sign-in, and serving static assets):
+
+- `GET /livez` — orchestrator liveness; no DB touch
+- `GET /health` — readiness; DB ping included
+- `GET /capabilities` — feature flags (for the web/MCP client to adapt UI)
+- `GET /app` + `/app/assets/*` — the SPA itself
+
+Everything else requires `Authorization: Bearer <key>` or `X-NMEM-API-Key: <key>`.
+Requests from `127.0.0.1` inside the container (e.g. the Docker `HEALTHCHECK`)
+skip auth by default.
+
+### Where the key lives
+
+```
+/etc/nowledge-mem/co.nowledge.mem.desktop/remote-access.json
+                  ^                       ^
+                  app namespace           mode 0600, owner nowledge:nowledge
+```
+
+This file is generated on first start. Backing up the `config` volume backs
+up the key.
+
+### Common operations
+
+```bash
+# Show the current key
+./bootstrap.sh                            # or: docker compose exec mem nmem key
+
+# Rotate (invalidates the old value immediately; re-paste in clients)
+./bootstrap.sh rotate-key                 # or: docker compose exec mem nmem key --rotate
+
+# Pre-seed a known key (useful for fleets managed by a secret manager).
+# Write the file before first `docker compose up`:
+mkdir -p ./seed/co.nowledge.mem.desktop
+cat > ./seed/co.nowledge.mem.desktop/remote-access.json <<EOF
+{"api_key":"<your-key>","require_auth_loopback":false,"created_at":"$(date -Iseconds)"}
+EOF
+chmod 0600 ./seed/co.nowledge.mem.desktop/remote-access.json
+# Then bind ./seed onto /etc/nowledge-mem in compose.yaml (or copy into the
+# volume with `docker run --rm -v config:/dst -v $PWD/seed:/src alpine cp -a /src/. /dst/`).
+```
+
+### Rate-limit recovery
+
+After 5 invalid-auth attempts from the same client IP, the server blocks
+that IP for **15 minutes**. If you locked yourself out during testing:
+
+```bash
+docker compose restart mem        # clears the in-memory rate-limit window
+```
+
+The block is per-client-IP, not per-key — rotating the key won't unblock you.
+
+### If a key leaks
+
+1. `./bootstrap.sh rotate-key` — issue a new value.
+2. Audit `docker compose logs mem` for `HTTP_REQUEST_SUMMARY` lines with
+   unfamiliar `client_ip` values around the time of the leak.
+3. If the leak is severe, also rotate any provider keys you stored via the
+   web UI (remote-LLM creds, OAuth tokens, Cloudflare tunnel cert).
+
+### Locking down to LAN only
+
+The image listens on `0.0.0.0:14242` so it's reachable from your network.
+If you want to restrict reachability to a specific subnet:
+
+```yaml
+services:
+  mem:
+    environment:
+      # CIDR allowlist; comma-separated. Default = no allowlist (auth-only).
+      NOWLEDGE_IP_ALLOWLIST: "10.0.0.0/24,192.168.1.0/24"
+```
+
+Or front the container with a reverse proxy (Caddy in `compose.tls.yaml`,
+nginx, Traefik, …) and bind the upstream to `127.0.0.1`. The TLS overlay we
+ship already does this.
+
+---
+
+## Verify the image was built by Nowledge Labs
+
+Every published manifest is signed via Sigstore keyless signing. There are no
+public keys to download or rotate — verification uses the GitHub Actions OIDC
+identity that produced the build.
+
+```bash
+cosign verify docker.io/nowledge/mem:0.8.4 \
+  --certificate-identity-regexp='https://github.com/nowledge-co/nowledge-mem/.github/workflows/release-docker.yml@.*' \
+  --certificate-oidc-issuer='https://token.actions.githubusercontent.com'
+```
+
+A passing run prints the certificate chain that bound the signature to the
+release-docker workflow at a specific commit. A failing run means the image
+you pulled was not produced by our pipeline.
+
+`cosign` install: <https://docs.sigstore.dev/cosign/installation/>.
+
+---
+
+## Day-2 operations
+
+### Backup
+
+```bash
+docker run --rm \
+  -v nowledge-mem_data:/data:ro \
+  -v nowledge-mem_config:/config:ro \
+  -v "$PWD":/backup \
+  alpine \
+  tar -C / -czf /backup/nowledge-mem-$(date +%F).tgz data config
+```
+
+Restore by extracting into fresh volumes before the first `docker compose up`.
+
+### Upgrade
+
+```bash
+# Pin to the new version in compose.yaml, then:
+docker compose pull
+docker compose up -d
+```
+
+The backend runs schema migrations on startup. There is **no downgrade path**;
+once a newer image has opened the database, an older image will refuse to.
+
+### Factory reset
+
+```bash
+docker compose down
+docker volume rm nowledge-mem_data nowledge-mem_config nowledge-mem_cache
+docker compose up -d
+```
+
+### Logs
+
+The image emits structured JSON to stdout. The compose file already configures
+rotation (`max-size: 10m`, `max-file: 5`). To follow:
+
+```bash
+docker compose logs -f mem
+```
+
+### Health probes
+
+- `GET /livez` — process is up. Use this for orchestrator liveness restarts.
+- `GET /health` — process is up **and** the database is open. Use this for
+  readiness gating (k8s readinessProbe, load balancer health check).
+
+---
+
+## Secrets
+
+If you'd rather not store the license inside the `config` volume, mount it as
+a Docker secret instead. The path inside the container is unchanged:
+
+```yaml
+services:
+  mem:
+    secrets:
+      - source: nowledge_license
+        target: /etc/nowledge-mem/co.nowledge.mem.desktop/license.json
+        mode: 0400
+
+secrets:
+  nowledge_license:
+    file: ./secrets/license.json
+```
+
+The backend reads the same file; nothing else changes.
+
+---
+
+## What is **not** in this image
+
+- The Tauri desktop GUI. Use the platform installer.
+- Bundled OCR tooling for PDF/image ingestion. API-driven workflows are not
+  affected; only drag-and-drop scanned-document ingest is.
+- Bundled `cloudflared`. Use a Cloudflare Tunnel container as a sidecar if you
+  need that pattern; the headless image is intentionally network-agnostic.
+
+---
+
+## Troubleshooting
+
+**`/health` returns `degraded` shortly after start.** Normal during the first
+~60 s while Kuzu opens and the content store reconciles. The image's
+`start_period` (90 s) accounts for this; `/livez` is green immediately.
+
+**`nmem license activate` says "license file not found".** Make sure the
+`config` volume is mounted (`docker compose config` should list it under the
+`mem` service).
+
+**Web UI loads but says "Web Client Not Available".** The image was built
+without the SPA. This should not happen with the official image; please file a
+bug. If you're building locally, ensure `npm run build:web` produced
+`nowledge-graph/dist-web/`.
+
+**MCP plugins won't install.** Plugin install needs network and may shell out
+to `npx`/`uvx`. The default image trusts outbound HTTPS but does not include
+those CLIs. For now, install plugins on the desktop app and they'll be picked
+up by the server via the shared config volume; first-class headless plugin
+install is on the roadmap.

--- a/docker/README.md
+++ b/docker/README.md
@@ -133,8 +133,10 @@ You need:
 
 - A DNS A/AAAA record for `NOWLEDGE_DOMAIN` pointing at this host.
 - Ports `80` and `443` open to the internet (Let's Encrypt HTTP-01 challenge).
-- Docker Compose **v2.24 or newer** (the overlay uses the `!reset` tag to
-  rebind the upstream port, which earlier versions don't understand).
+- Docker Compose **v2.24.4 or newer**. The overlay uses the `!override`
+  merge tag to rebind the upstream port; this tag (and the related
+  `!reset`) only became reliable in 2.24.4. Earlier 2.24.x versions
+  either fail to parse the file or silently drop the rebind.
 
 The mem container is rebound to `127.0.0.1` so the only reachable surface is
 Caddy.
@@ -150,6 +152,33 @@ The server enforces two independent things:
   network call, and persists in the `config` volume.
 - **An API key** (`remote-access.json`) — bearer-token auth on every non-public
   endpoint. The web UI uses the same key.
+
+### Where is my API key? (read this first)
+
+The image generates an API key on first start. Four ways to retrieve or
+rotate it — pick whichever fits how you got here:
+
+```bash
+# 1. You ran ./bootstrap.sh and missed the output — just rerun it:
+./bootstrap.sh                            # reprints the key, license, URL
+
+# 2. You started with `docker compose up -d` directly:
+docker compose exec -T mem nmem key       # prints the current key
+docker compose exec -T mem nmem key --rotate   # rotates to a new value
+
+# 3. You want to skim the first-run banner:
+docker compose logs mem | grep -A 1 "API Key"
+
+# 4. You prefer one command that handles rotation cleanly:
+./bootstrap.sh rotate-key                 # rotates and reprints
+```
+
+The key is stored at `/etc/nowledge-mem/co.nowledge.mem.desktop/remote-access.json`
+inside the `config` volume; it survives `docker compose pull && up -d`
+upgrades. **Backing up the `config` volume backs up the key.**
+
+If you rotate the key, every existing client (web UI, MCP clients, the
+`nmem` CLI on remote machines) needs the new value pasted in.
 
 ### What's exempt from auth
 

--- a/docker/bootstrap.sh
+++ b/docker/bootstrap.sh
@@ -54,12 +54,14 @@ bring_up_and_wait() {
   "${DC[@]}" up -d
 
   step "Waiting for /livez (up to 120s)"
+  # `i` is 1-indexed and the first probe runs before any sleep, so elapsed
+  # seconds is `(i-1)*2`, not `i*2`. Was off by 2s on the first probe.
   for i in $(seq 1 60); do
     if "${DC[@]}" exec -T "$SVC" \
         /opt/nowledge-mem/python/bin/python3 -c \
           'import urllib.request,sys; sys.exit(0 if urllib.request.urlopen("http://127.0.0.1:14242/livez", timeout=4).status==200 else 1)' \
         >/dev/null 2>&1; then
-      note "ready in $((i*2))s"
+      note "ready in $(( (i - 1) * 2 ))s"
       return 0
     fi
     sleep 2
@@ -69,6 +71,17 @@ bring_up_and_wait() {
   done
 }
 
+# Read the effective NOWLEDGE_DOMAIN that Compose will inject — works whether
+# the operator exported it to the shell or put it in a `.env` next to
+# compose.yaml for Compose interpolation. Returns empty if neither path
+# defines it.
+resolve_tls_domain() {
+  local val
+  val="$("${DC[@]}" config 2>/dev/null \
+        | awk '$1=="NOWLEDGE_DOMAIN:"{gsub(/^[ \t]+|[ \t]+$/, "", $2); print $2; exit}')" || val=""
+  printf '%s\n' "${val%\"}" | sed 's/^"//; s/"$//'
+}
+
 cmd="${1:-up}"
 
 case "$cmd" in
@@ -76,7 +89,10 @@ case "$cmd" in
     bring_up_and_wait
 
     step "Access Anywhere API key (paste into the web UI when prompted)"
-    KEY="$("${DC[@]}" exec -T "$SVC" nmem key 2>/dev/null | tr -d '\r\n')"
+    # `|| KEY=""` so a failing `nmem key` lets the friendly check below
+    # surface the diagnostic instead of `set -e` silently aborting the
+    # script in the middle of a command-substitution pipeline.
+    KEY="$("${DC[@]}" exec -T "$SVC" nmem key 2>/dev/null | tr -d '\r\n')" || KEY=""
     if [[ -z "$KEY" ]]; then
       fail "could not retrieve API key (\`nmem key\` returned empty)."
     fi
@@ -90,9 +106,16 @@ case "$cmd" in
     step "Open the web UI"
     # If the TLS overlay is active, mem is bound to loopback and traffic
     # is supposed to flow through Caddy on 443. Print the HTTPS URL so
-    # operators don't chase a non-routable HTTP endpoint.
-    if [[ "$NMEM_COMPOSE_FILES" == *compose.tls.yaml* && -n "${NOWLEDGE_DOMAIN:-}" ]]; then
-      note "https://${NOWLEDGE_DOMAIN}/app"
+    # operators don't chase a non-routable HTTP endpoint. Ask Compose
+    # for the *merged* NOWLEDGE_DOMAIN so an operator who keeps it in
+    # `.env` (for Compose interpolation, not shell export) is handled
+    # the same as one who `export`s it.
+    TLS_DOMAIN=""
+    if [[ "$NMEM_COMPOSE_FILES" == *compose.tls.yaml* ]]; then
+      TLS_DOMAIN="$(resolve_tls_domain)"
+    fi
+    if [[ -n "$TLS_DOMAIN" ]]; then
+      note "https://${TLS_DOMAIN}/app"
     else
       # Resolve an externally reachable URL hint, best-effort. `hostname -I`
       # is Linux-only and exits non-zero on macOS/BSD; the `|| true` keeps

--- a/docker/bootstrap.sh
+++ b/docker/bootstrap.sh
@@ -1,0 +1,118 @@
+#!/usr/bin/env bash
+#
+# bootstrap.sh — first-launch helper for the Nowledge Mem headless image.
+#
+# Idempotent: safe to run any number of times. On a fresh stack it brings
+# everything up, waits for readiness, prints the Access Anywhere API key, and
+# (optionally) activates a license. On an already-running stack it just
+# re-prints the key and the license status.
+#
+# Usage:
+#   ./bootstrap.sh                                   # bring up + show key
+#   ./bootstrap.sh activate <BASE64_LICENSE_CODE>    # also activate license
+#   ./bootstrap.sh rotate-key                        # rotate the API key
+#
+# Designed to be run from the directory containing compose.yaml.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+cd "$SCRIPT_DIR"
+
+if ! command -v docker >/dev/null 2>&1; then
+  echo "error: docker not found on PATH" >&2
+  exit 1
+fi
+if ! docker compose version >/dev/null 2>&1; then
+  echo "error: 'docker compose' v2 plugin not installed" >&2
+  exit 1
+fi
+if [[ ! -f compose.yaml ]]; then
+  echo "error: compose.yaml not found in $SCRIPT_DIR" >&2
+  exit 1
+fi
+
+# Compose wrapper. Use the local compose.yaml by default; users overlaying TLS
+# can re-export NMEM_COMPOSE_FILES before running:
+#   NMEM_COMPOSE_FILES='-f compose.yaml -f compose.tls.yaml' ./bootstrap.sh
+NMEM_COMPOSE_FILES="${NMEM_COMPOSE_FILES:--f compose.yaml}"
+DC=(docker compose ${NMEM_COMPOSE_FILES})
+
+step() { printf "\n\033[1;34m==>\033[0m %s\n" "$*"; }
+note() { printf "    %s\n" "$*"; }
+fail() { printf "\033[1;31merror:\033[0m %s\n" "$*" >&2; exit 1; }
+
+# Resolve the service name (defaults to "mem" in our compose, but allow overrides).
+SVC="${NMEM_SERVICE:-mem}"
+
+cmd="${1:-up}"
+
+case "$cmd" in
+  up|"")
+    step "Bringing Nowledge Mem up"
+    "${DC[@]}" up -d
+
+    step "Waiting for /livez (up to 120s)"
+    for i in $(seq 1 60); do
+      if "${DC[@]}" exec -T "$SVC" sh -c \
+          'python3 -c "import urllib.request,sys; r=urllib.request.urlopen(\"http://127.0.0.1:14242/livez\", timeout=4); sys.exit(0 if r.status==200 else 1)"' \
+          >/dev/null 2>&1; then
+        note "ready in $((i*2))s"
+        break
+      fi
+      sleep 2
+      if [[ $i -eq 60 ]]; then
+        fail "server did not become live in 120s. Check 'docker compose logs $SVC'."
+      fi
+    done
+
+    step "Access Anywhere API key (paste into the web UI when prompted)"
+    KEY="$("${DC[@]}" exec -T "$SVC" nmem key 2>/dev/null | tr -d '\r\n')"
+    if [[ -z "$KEY" ]]; then
+      fail "could not retrieve API key (\`nmem key\` returned empty)."
+    fi
+    note "$KEY"
+    note "stored at /etc/nowledge-mem/co.nowledge.mem.desktop/remote-access.json (mode 0600)"
+    note "rotate with:  $0 rotate-key"
+
+    step "License status"
+    "${DC[@]}" exec -T "$SVC" nmem license status || true
+
+    # Resolve an externally reachable URL hint, best-effort.
+    if command -v hostname >/dev/null 2>&1; then
+      IP="$(hostname -I 2>/dev/null | awk '{print $1}')"
+    fi
+    : "${IP:=localhost}"
+    step "Open the web UI"
+    note "http://${IP}:14242/app"
+    note "(paste the key above when asked for an API key)"
+    ;;
+
+  activate)
+    code="${2:-}"
+    [[ -n "$code" ]] || fail "usage: $0 activate <BASE64_LICENSE_CODE>"
+    step "Activating license"
+    "${DC[@]}" exec -T "$SVC" nmem license activate "$code"
+    step "License status"
+    "${DC[@]}" exec -T "$SVC" nmem license status
+    ;;
+
+  rotate-key)
+    step "Rotating Access Anywhere API key"
+    note "Old key will stop working immediately. Web-UI sessions and MCP"
+    note "clients must be re-authed with the new value."
+    "${DC[@]}" exec -T "$SVC" nmem key --rotate
+    step "New key"
+    "${DC[@]}" exec -T "$SVC" nmem key
+    ;;
+
+  *)
+    cat <<EOF >&2
+usage:
+  $0                            bring up + print key + license status
+  $0 activate <BASE64_CODE>     activate a license
+  $0 rotate-key                 rotate the Access Anywhere API key
+EOF
+    exit 2
+    ;;
+esac

--- a/docker/bootstrap.sh
+++ b/docker/bootstrap.sh
@@ -87,15 +87,22 @@ case "$cmd" in
     step "License status"
     "${DC[@]}" exec -T "$SVC" nmem license status || true
 
-    # Resolve an externally reachable URL hint, best-effort. `hostname -I` is
-    # Linux-only and exits non-zero on macOS/BSD; the `|| true` keeps that
-    # from tripping `set -euo pipefail` before the localhost fallback runs.
-    if command -v hostname >/dev/null 2>&1; then
-      IP="$(hostname -I 2>/dev/null | awk '{print $1}')" || true
-    fi
-    : "${IP:=localhost}"
     step "Open the web UI"
-    note "http://${IP}:14242/app"
+    # If the TLS overlay is active, mem is bound to loopback and traffic
+    # is supposed to flow through Caddy on 443. Print the HTTPS URL so
+    # operators don't chase a non-routable HTTP endpoint.
+    if [[ "$NMEM_COMPOSE_FILES" == *compose.tls.yaml* && -n "${NOWLEDGE_DOMAIN:-}" ]]; then
+      note "https://${NOWLEDGE_DOMAIN}/app"
+    else
+      # Resolve an externally reachable URL hint, best-effort. `hostname -I`
+      # is Linux-only and exits non-zero on macOS/BSD; the `|| true` keeps
+      # that from tripping `set -euo pipefail` before the localhost fallback.
+      if command -v hostname >/dev/null 2>&1; then
+        IP="$(hostname -I 2>/dev/null | awk '{print $1}')" || true
+      fi
+      : "${IP:=localhost}"
+      note "http://${IP}:14242/app"
+    fi
     note "(paste the key above when asked for an API key)"
     ;;
 
@@ -114,6 +121,10 @@ case "$cmd" in
     ;;
 
   rotate-key)
+    # Same rationale as `activate`: `docker compose exec` requires a
+    # running container, so make rotation work even after `docker
+    # compose down`.
+    bring_up_and_wait
     step "Rotating Access Anywhere API key"
     note "Old key will stop working immediately. Web-UI sessions and MCP"
     note "clients must be re-authed with the new value."

--- a/docker/bootstrap.sh
+++ b/docker/bootstrap.sh
@@ -45,26 +45,35 @@ fail() { printf "\033[1;31merror:\033[0m %s\n" "$*" >&2; exit 1; }
 # Resolve the service name (defaults to "mem" in our compose, but allow overrides).
 SVC="${NMEM_SERVICE:-mem}"
 
+# Bring the stack up and block until /livez answers. Idempotent: a no-op if the
+# service is already running and ready. Used both by the default "up" command
+# and as a prerequisite for "activate" so license activation does not race
+# against a fresh `docker compose down`.
+bring_up_and_wait() {
+  step "Bringing Nowledge Mem up"
+  "${DC[@]}" up -d
+
+  step "Waiting for /livez (up to 120s)"
+  for i in $(seq 1 60); do
+    if "${DC[@]}" exec -T "$SVC" \
+        /opt/nowledge-mem/python/bin/python3 -c \
+          'import urllib.request,sys; sys.exit(0 if urllib.request.urlopen("http://127.0.0.1:14242/livez", timeout=4).status==200 else 1)' \
+        >/dev/null 2>&1; then
+      note "ready in $((i*2))s"
+      return 0
+    fi
+    sleep 2
+    if [[ $i -eq 60 ]]; then
+      fail "server did not become live in 120s. Check '${DC[*]} logs $SVC'."
+    fi
+  done
+}
+
 cmd="${1:-up}"
 
 case "$cmd" in
   up|"")
-    step "Bringing Nowledge Mem up"
-    "${DC[@]}" up -d
-
-    step "Waiting for /livez (up to 120s)"
-    for i in $(seq 1 60); do
-      if "${DC[@]}" exec -T "$SVC" sh -c \
-          'python3 -c "import urllib.request,sys; r=urllib.request.urlopen(\"http://127.0.0.1:14242/livez\", timeout=4); sys.exit(0 if r.status==200 else 1)"' \
-          >/dev/null 2>&1; then
-        note "ready in $((i*2))s"
-        break
-      fi
-      sleep 2
-      if [[ $i -eq 60 ]]; then
-        fail "server did not become live in 120s. Check 'docker compose logs $SVC'."
-      fi
-    done
+    bring_up_and_wait
 
     step "Access Anywhere API key (paste into the web UI when prompted)"
     KEY="$("${DC[@]}" exec -T "$SVC" nmem key 2>/dev/null | tr -d '\r\n')"
@@ -78,9 +87,11 @@ case "$cmd" in
     step "License status"
     "${DC[@]}" exec -T "$SVC" nmem license status || true
 
-    # Resolve an externally reachable URL hint, best-effort.
+    # Resolve an externally reachable URL hint, best-effort. `hostname -I` is
+    # Linux-only and exits non-zero on macOS/BSD; the `|| true` keeps that
+    # from tripping `set -euo pipefail` before the localhost fallback runs.
     if command -v hostname >/dev/null 2>&1; then
-      IP="$(hostname -I 2>/dev/null | awk '{print $1}')"
+      IP="$(hostname -I 2>/dev/null | awk '{print $1}')" || true
     fi
     : "${IP:=localhost}"
     step "Open the web UI"
@@ -91,6 +102,11 @@ case "$cmd" in
   activate)
     code="${2:-}"
     [[ -n "$code" ]] || fail "usage: $0 activate <BASE64_LICENSE_CODE>"
+    # `docker compose exec` only works against a running container. On a
+    # fresh install (or after `docker compose down`) `activate` would
+    # otherwise fail with "service is not running". Bring the stack up
+    # idempotently before issuing the activation.
+    bring_up_and_wait
     step "Activating license"
     "${DC[@]}" exec -T "$SVC" nmem license activate "$code"
     step "License status"

--- a/docker/compose.tls.yaml
+++ b/docker/compose.tls.yaml
@@ -1,0 +1,53 @@
+# TLS overlay — adds a Caddy reverse-proxy sidecar in front of the headless
+# server. Caddy handles automatic Let's Encrypt certificates, HTTP-to-HTTPS
+# redirects, and HSTS.
+#
+# Apply on top of compose.yaml:
+#   NOWLEDGE_DOMAIN=mem.example.com NOWLEDGE_LE_EMAIL=you@example.com \
+#     docker compose -f compose.yaml -f compose.tls.yaml up -d
+#
+# Prerequisites:
+#   - A DNS A/AAAA record for NOWLEDGE_DOMAIN pointing at this host.
+#   - Ports 80 and 443 reachable from the internet (Let's Encrypt challenge).
+#
+# This overlay also rebinds the upstream Mem port to localhost so the only
+# externally reachable surface is Caddy itself.
+
+services:
+  mem:
+    ports: !reset
+      - "127.0.0.1:14242:14242"
+
+  caddy:
+    image: caddy:2-alpine
+    container_name: nowledge-mem-caddy
+    restart: unless-stopped
+    depends_on:
+      mem:
+        condition: service_healthy
+    ports:
+      - "80:80"
+      - "443:443"
+      - "443:443/udp"   # HTTP/3
+    environment:
+      NOWLEDGE_DOMAIN: ${NOWLEDGE_DOMAIN:?set NOWLEDGE_DOMAIN to your fully qualified hostname}
+      NOWLEDGE_LE_EMAIL: ${NOWLEDGE_LE_EMAIL:?set NOWLEDGE_LE_EMAIL for Let's Encrypt account}
+    volumes:
+      - ./Caddyfile:/etc/caddy/Caddyfile:ro
+      - caddy_data:/data           # Let's Encrypt account + certificates
+      - caddy_config:/config
+    cap_drop:
+      - ALL
+    cap_add:
+      - NET_BIND_SERVICE
+    security_opt:
+      - no-new-privileges:true
+    logging:
+      driver: json-file
+      options:
+        max-size: "10m"
+        max-file: "5"
+
+volumes:
+  caddy_data:
+  caddy_config:

--- a/docker/compose.tls.yaml
+++ b/docker/compose.tls.yaml
@@ -15,7 +15,11 @@
 
 services:
   mem:
-    ports: !reset
+    # `!override` replaces the base ports list outright. `!reset` would just
+    # clear it (the base 14242:14242 would be removed and not replaced), which
+    # would leave host-side `curl http://127.0.0.1:14242/health` broken — even
+    # though Caddy still reaches mem internally via the Docker network.
+    ports: !override
       - "127.0.0.1:14242:14242"
 
   caddy:

--- a/docker/compose.tls.yaml
+++ b/docker/compose.tls.yaml
@@ -50,4 +50,6 @@ services:
 
 volumes:
   caddy_data:
+    name: nowledge-mem-caddy-data
   caddy_config:
+    name: nowledge-mem-caddy-config

--- a/docker/compose.yaml
+++ b/docker/compose.yaml
@@ -44,9 +44,10 @@ services:
 
     # Optional knobs. All env vars listed here have sane defaults in the image.
     environment:
-      # Restrict origins permitted through the /remote-api gateway. Comma-
-      # separated CIDR list; unset = no allowlist (gateway still requires a
-      # token; see docs for the auth header contract).
+      # Restrict client source IPs permitted through the /remote-api gateway
+      # (network-level allowlist, not CORS origins). Comma-separated CIDR
+      # list; unset = no allowlist (the gateway still requires a token; see
+      # docs for the auth header contract).
       NOWLEDGE_IP_ALLOWLIST: ""
 
     # ---- Security hardening -------------------------------------------------

--- a/docker/compose.yaml
+++ b/docker/compose.yaml
@@ -42,13 +42,16 @@ services:
       - config:/etc/nowledge-mem
       - cache:/var/cache/nowledge-mem
 
-    # Optional knobs. All env vars listed here have sane defaults in the image.
-    environment:
-      # Restrict client source IPs permitted through the /remote-api gateway
-      # (network-level allowlist, not CORS origins). Comma-separated CIDR
-      # list. Leave unset for no allowlist (the gateway still requires a
-      # token; see docs for the auth header contract). Uncomment to set:
-      # NOWLEDGE_IP_ALLOWLIST: "10.0.0.0/8,192.168.0.0/16"
+    # Optional environment knobs. All env vars listed in the image have sane
+    # defaults; uncomment this block to override any. The image's full
+    # environment surface is documented in community/docker/README.md.
+    #
+    # environment:
+    #   # Restrict client source IPs permitted through the /remote-api gateway
+    #   # (network-level allowlist, not CORS origins). Comma-separated CIDR
+    #   # list. Leave unset for no allowlist (the gateway still requires a
+    #   # token; see docs for the auth header contract).
+    #   NOWLEDGE_IP_ALLOWLIST: "10.0.0.0/8,192.168.0.0/16"
 
     # ---- Security hardening -------------------------------------------------
     # The image is built so it never needs to write outside its named volumes.

--- a/docker/compose.yaml
+++ b/docker/compose.yaml
@@ -89,10 +89,18 @@ services:
       retries: 3
       start_period: 90s
 
-# Named volumes are local-driver by default. Bind to host paths if you prefer
-# a known on-disk location (recommended for backup workflows):
+# Named volumes are local-driver by default. The explicit `name:` keys lock
+# the on-disk identifier so backup/reset commands don't depend on the project
+# name (which Compose derives from the current working directory and would
+# otherwise prefix to bare volume names).
+#
+# Bind to host paths if you prefer a known on-disk location (recommended for
+# backup workflows):
 #   data:    driver_opts: { type: none, o: bind, device: /srv/nowledge/data }
 volumes:
   data:
+    name: nowledge-mem-data
   config:
+    name: nowledge-mem-config
   cache:
+    name: nowledge-mem-cache

--- a/docker/compose.yaml
+++ b/docker/compose.yaml
@@ -16,13 +16,13 @@
 #   docker compose -f compose.yaml -f compose.tls.yaml up -d
 #
 # Verify the image is signed by Nowledge Labs (anyone, anywhere):
-#   cosign verify docker.io/nowledge/mem:0.8.4 \
+#   cosign verify docker.io/nowledgelabs/mem:0.8.4 \
 #     --certificate-identity-regexp='https://github.com/nowledge-co/nowledge-mem/.github/workflows/release-docker.yml@.*' \
 #     --certificate-oidc-issuer='https://token.actions.githubusercontent.com'
 
 services:
   mem:
-    image: docker.io/nowledge/mem:0.8.4
+    image: docker.io/nowledgelabs/mem:0.8.4
     container_name: nowledge-mem
     restart: unless-stopped
 

--- a/docker/compose.yaml
+++ b/docker/compose.yaml
@@ -46,9 +46,9 @@ services:
     environment:
       # Restrict client source IPs permitted through the /remote-api gateway
       # (network-level allowlist, not CORS origins). Comma-separated CIDR
-      # list; unset = no allowlist (the gateway still requires a token; see
-      # docs for the auth header contract).
-      NOWLEDGE_IP_ALLOWLIST: ""
+      # list. Leave unset for no allowlist (the gateway still requires a
+      # token; see docs for the auth header contract). Uncomment to set:
+      # NOWLEDGE_IP_ALLOWLIST: "10.0.0.0/8,192.168.0.0/16"
 
     # ---- Security hardening -------------------------------------------------
     # The image is built so it never needs to write outside its named volumes.

--- a/docker/compose.yaml
+++ b/docker/compose.yaml
@@ -8,8 +8,8 @@
 # Quick start:
 #   docker compose up -d
 #   docker compose logs -f mem
-#   docker compose exec mem nmem license activate <BASE64-CODE>
-#   docker compose exec mem nmem key       # surfaces the web-UI login key
+#   docker compose exec -T mem nmem license activate <BASE64-CODE>
+#   docker compose exec -T mem nmem key      # surfaces the web-UI login key
 #   open http://<host>:14242/app
 #
 # Add TLS by overlaying compose.tls.yaml (Caddy sidecar, auto-Let's-Encrypt):
@@ -17,7 +17,7 @@
 #
 # Verify the image is signed by Nowledge Labs (anyone, anywhere):
 #   cosign verify docker.io/nowledgelabs/mem:0.8.4 \
-#     --certificate-identity-regexp='https://github.com/nowledge-co/nowledge-mem/.github/workflows/release-docker.yml@.*' \
+#     --certificate-identity-regexp='https://github.com/nowledge-co/mem/.github/workflows/release-docker.yml@.*' \
 #     --certificate-oidc-issuer='https://token.actions.githubusercontent.com'
 
 services:

--- a/docker/compose.yaml
+++ b/docker/compose.yaml
@@ -1,0 +1,98 @@
+# Nowledge Mem — headless server reference compose.
+#
+# This is the minimal, opinionated way to run the official image locally or
+# on a single-host server. It is hardened by default: read-only rootfs,
+# nonroot user, all caps dropped, no-new-privileges, pids/memory limits,
+# bounded log rotation.
+#
+# Quick start:
+#   docker compose up -d
+#   docker compose logs -f mem
+#   docker compose exec mem nmem license activate <BASE64-CODE>
+#   docker compose exec mem nmem key       # surfaces the web-UI login key
+#   open http://<host>:14242/app
+#
+# Add TLS by overlaying compose.tls.yaml (Caddy sidecar, auto-Let's-Encrypt):
+#   docker compose -f compose.yaml -f compose.tls.yaml up -d
+#
+# Verify the image is signed by Nowledge Labs (anyone, anywhere):
+#   cosign verify docker.io/nowledge/mem:0.8.4 \
+#     --certificate-identity-regexp='https://github.com/nowledge-co/nowledge-mem/.github/workflows/release-docker.yml@.*' \
+#     --certificate-oidc-issuer='https://token.actions.githubusercontent.com'
+
+services:
+  mem:
+    image: docker.io/nowledge/mem:0.8.4
+    container_name: nowledge-mem
+    restart: unless-stopped
+
+    # The image already listens on 14242 inside the container. Map to the same
+    # port on the host by default. Bind to 127.0.0.1 if you intend to put a
+    # reverse proxy in front (the overlay file does exactly this).
+    ports:
+      - "14242:14242"
+
+    # Three-volume contract:
+    #   data   — irreplaceable (KuzuDB graph, content store)
+    #   config — valuable     (settings, license, OAuth tokens)
+    #   cache  — rebuildable  (embedding models, search index projection)
+    # Back up `data` and `config`. `cache` is safe to wipe.
+    volumes:
+      - data:/var/lib/nowledge-mem
+      - config:/etc/nowledge-mem
+      - cache:/var/cache/nowledge-mem
+
+    # Optional knobs. All env vars listed here have sane defaults in the image.
+    environment:
+      # Restrict origins permitted through the /remote-api gateway. Comma-
+      # separated CIDR list; unset = no allowlist (gateway still requires a
+      # token; see docs for the auth header contract).
+      NOWLEDGE_IP_ALLOWLIST: ""
+
+    # ---- Security hardening -------------------------------------------------
+    # The image is built so it never needs to write outside its named volumes.
+    # If your application data changes that, file a bug — don't relax these.
+    read_only: true
+    tmpfs:
+      - /tmp:size=64m,mode=1777
+    user: "10001:10001"
+    cap_drop:
+      - ALL
+    security_opt:
+      - no-new-privileges:true
+    pids_limit: 512
+
+    # ---- Resource ceilings --------------------------------------------------
+    # The embedding model alone wants ~1 GB of RAM. 4 GB is a comfortable
+    # default for a small personal server; raise for heavy ingestion.
+    mem_limit: 4g
+    mem_reservation: 1g
+    cpus: 2.0
+
+    # ---- Logging ------------------------------------------------------------
+    # Backend already emits JSON to stdout. Let Docker rotate.
+    logging:
+      driver: json-file
+      options:
+        max-size: "10m"
+        max-file: "5"
+        compress: "true"
+
+    # ---- Healthcheck --------------------------------------------------------
+    # The image defines HEALTHCHECK against /livez. Compose can override the
+    # cadence if you want a different policy; the defaults below match the
+    # image. start_period accounts for first-run model warmup and Kuzu open.
+    healthcheck:
+      test: ["CMD", "/opt/nowledge-mem/python/bin/python3", "-c", "import urllib.request,sys; sys.exit(0 if urllib.request.urlopen('http://127.0.0.1:14242/livez', timeout=4).status==200 else 1)"]
+      interval: 30s
+      timeout: 5s
+      retries: 3
+      start_period: 90s
+
+# Named volumes are local-driver by default. Bind to host paths if you prefer
+# a known on-disk location (recommended for backup workflows):
+#   data:    driver_opts: { type: none, o: bind, device: /srv/nowledge/data }
+volumes:
+  data:
+  config:
+  cache:


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Medium risk because this introduces new deployment entrypoints (Compose + Caddy TLS termination) that affect network exposure and operational security defaults, even though it does not change application runtime code.
> 
> **Overview**
> Adds a **Docker Compose reference deployment** for the headless `nowledgelabs/mem` image, including hardened defaults (read-only rootfs, fixed non-root UID, resource/log limits, healthcheck) and a documented 3-volume persistence contract.
> 
> Introduces an **optional TLS overlay** (`compose.tls.yaml` + `Caddyfile`) that fronts the service with a Caddy sidecar for Let’s Encrypt certs and reverse-proxying (including long-lived streaming timeouts), rebinding the upstream container to `127.0.0.1` when enabled.
> 
> Adds an idempotent `bootstrap.sh` to bring the stack up, wait for `/livez`, print/rotate the API key, and optionally activate a license, plus a comprehensive `docker/README.md` covering setup, auth, day-2 ops, and troubleshooting.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8aeda81b37becae56c1544893bed197a88fde461. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive Docker deployment guide covering setup, operations, authentication, upgrades, and troubleshooting.

* **New Features**
  * Added automatic TLS/HTTPS support with Let's Encrypt certificate provisioning and renewal.
  * Added CLI bootstrap script for streamlined container initialization, API key management, and license activation workflows.

* **Chores**
  * Added Docker Compose configuration files for standard and TLS-secured deployments.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/nowledge-co/community/pull/235)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->