### PR TITLE
docs(docker): flag arm64 as experimental

### DIFF
--- a/docker/README.md
+++ b/docker/README.md
@@ -284,6 +284,29 @@ you pulled was not produced by our pipeline.
 
 ---
 
+## Architecture support
+
+The image ships a multi-arch manifest for **`linux/amd64`** and
+**`linux/arm64`**. Docker pulls the matching variant automatically.
+
+- **`amd64` — primary supported target.** Every release runs the full
+  ingest/agent/search loop on amd64 before tagging.
+- **`arm64` — experimental.** The build succeeds and all native
+  dependency wheels (Kuzu/ladybug, ONNX, tokenizers, BGE-m3) exist for
+  arm64, but we don't yet routinely exercise full agent flows on this
+  arch. Expected hosts: Ampere/Graviton VPS, Apple Silicon under
+  Docker Desktop, Raspberry Pi 5 with 8 GiB RAM. If you hit
+  arch-specific behaviour, please file an issue with `arch: arm64`
+  in the body so we can fold it into the supported set.
+
+If you need a specific arch, pin it explicitly:
+
+```bash
+docker pull --platform linux/amd64 docker.io/nowledgelabs/mem:0.8.4
+```
+
+---
+
 ## Day-2 operations
 
 ### Backup


### PR DESCRIPTION
## Summary

Follow-up to #235. amd64 is the primary tested target. arm64 ships in the same multi-arch manifest but we have not yet run end-to-end agent/ingest flows on it — the build succeeds and the native wheels are present (f-real-ladybug, ONNX, tokenizers, BGE-m3), so this is a "no certification yet" caveat, not a known-broken flag.

## Why this matters

The original README said the image is built for amd64 and arm64 without any caveat. A prosumer pulling on Raspberry Pi / Ampere / Apple Silicon under Docker Desktop would reasonably read that as "fully supported." If arm64 surprises them in a way that wouldn't surprise us on amd64, the docs were misleading.

This PR adds a short "Architecture support" section right after the cosign verify block, plus a tip on pinning `--platform linux/amd64` while arm64 stabilizes.

## Test plan

- [x] Read the new section in rendered form on GitHub
- [ ] Once arm64 build artifacts publish (run 25790420797 in nowledge-co/mem), pull and exercise the documented paths on an arm64 host; remove the "experimental" caveat in a follow-up when verified

🤖 Generated with [Claude Code](https://claude.com/claude-code)