### PR TITLE
feat: headless docker auto-update (sidecar + nmemctl 2.2.0)

### DIFF
--- a/docker/.gitignore
+++ b/docker/.gitignore
@@ -14,3 +14,9 @@ caddy_config/
 mem-export-*.tar.gz
 mem-app-export-*.zip
 *.bak.*
+
+# Auto-update state. `.env` holds NOWLEDGE_UPDATER_TOKEN (mode 0600) and
+# NMEM_IMAGE_TAG; `.nmemctl-state` persists per-deploy choices like
+# which overlay files are layered in.
+.env
+.nmemctl-state

--- a/docker/README.md
+++ b/docker/README.md
@@ -458,10 +458,12 @@ snapshot to `./cache/_pre-upgrade-<ts>.tar.gz`).
 **Trust model worth reading before you enable.** The sidecar mounts
 `/var/run/docker.sock` — that's why it's opt-in. Docker socket access
 is host-root-equivalent for that container. The sidecar is **not exposed
-beyond the compose-internal network**, runs an ~150-line POSIX-shell
-HTTP handler whose code you can read at `community/docker/updater/`,
-and only accepts requests bearing the per-deploy token. The mem
-container itself does **not** mount docker.sock; only the sidecar does.
+beyond the compose-internal network**, runs a small shell HTTP handler
+whose code you can read at `community/docker/updater/`
+(`server.sh` ~ 400 lines incl. comments, plus a ~50-line scheduler and
+entrypoint), and only accepts requests bearing the per-deploy token.
+The mem container itself does **not** mount docker.sock; only the
+sidecar does.
 
 Pair this with the new `/admin/upgrade/*` endpoints on the Mem backend:
 
@@ -479,13 +481,18 @@ Trusted networks only.
 
 **Recovery from a bad upgrade.** Every Install takes a volume-level
 snapshot of `./data` and `./config` (excludes `./cache`) before the
-recreate. If the new image's `/livez` doesn't go green within 180s,
-the UI surfaces the snapshot path. SSH and restore:
+recreate. The snapshot is a `.tar.gz` written to `./cache/` on the
+host (NOT an `nmem` application export — different format from
+`backup-app`). If the new image's `/livez` doesn't go green within
+180s, the UI surfaces the snapshot path. SSH and restore using
+`./nmemctl import` (the volume-level matching verb for the
+volume-level snapshot):
 
 ```bash
-./nmemctl restore-app /var/cache/nowledge-mem/_pre-upgrade-<ts>.tar.gz
-# Then if you want to roll back the image too:
+# Roll back the image first (so the migration order matches):
 ./nmemctl upgrade 0.8.4    # whatever version you were on
+# Then restore the bind-mount directories from the snapshot:
+./nmemctl import ./cache/_pre-upgrade-<ts>.tar.gz --force
 ```
 
 Snapshots rotate automatically: the last 3 are kept; older are deleted on

--- a/docker/README.md
+++ b/docker/README.md
@@ -497,8 +497,9 @@ volume-level snapshot):
 ./nmemctl import ./cache/_pre-upgrade-<ts>.tar.gz --force
 ```
 
-Snapshots rotate automatically: the last 3 are kept; older are deleted on
-each successful Install. Override with `NOWLEDGE_SNAPSHOT_RETAIN`.
+Snapshots rotate automatically after each pre-upgrade snapshot is written:
+the last 3 are kept; older archives are deleted before the recreate. Override
+with `NOWLEDGE_SNAPSHOT_RETAIN`.
 
 ### Factory reset
 

--- a/docker/README.md
+++ b/docker/README.md
@@ -440,13 +440,14 @@ auto-update sidecar:
 ./nmemctl auto-update enable
 ```
 
-That generates a per-deploy random token (mode 0600 in `.env`), adds the
-`compose.updater.yaml` overlay to the persisted stack, and brings the stack
-back up with a small `nowledgelabs/mem-updater` sidecar attached. From then
-on, the Settings → Server card in the web UI surfaces "Update available"
-when a newer image lands on Docker Hub, with a Download button (background
-pull, no downtime) and an Install button (≈30 s downtime, takes a pre-stop
-snapshot to `./cache/_pre-upgrade-<ts>.tar.gz`).
+That generates a per-deploy random token (mode 0600 in `.env`), sets
+`NOWLEDGE_ADMIN_REMOTE_OPS=1`, adds the `compose.updater.yaml` overlay to
+the persisted stack, and brings the stack back up with a small
+`nowledgelabs/mem-updater` sidecar attached. From then on, the Settings →
+Server card in the web UI surfaces "Update available" when a newer image
+lands on Docker Hub, with a Download button (background pull, no downtime)
+and an Install button (≈30 s downtime, takes a pre-stop snapshot to
+`./cache/_pre-upgrade-<ts>.tar.gz`).
 
 ```bash
 ./nmemctl auto-update status              # current state, last pull, retained snapshots
@@ -473,11 +474,12 @@ Pair this with the new `/admin/upgrade/*` endpoints on the Mem backend:
 | `POST /admin/upgrade/download` | Pre-pull a target tag (background, idempotent). |
 | `POST /admin/upgrade/install` | Type-to-confirm, snapshot, recreate, wait for `/livez`. |
 
-**Origin guard.** By default, the install endpoint accepts requests only
-from the same-host UI (the `/app` served by this Mem container). If you
-want to trigger upgrades from the desktop in remote mode or from
-`mem.nowledge.co`, set `NOWLEDGE_ADMIN_REMOTE_OPS=1` on the server.
-Trusted networks only.
+**Remote install opt-in.** A leaked API key is enough authority for most
+Mem API calls, so `/admin/upgrade/download` and `/admin/upgrade/install`
+stay loopback-only until `NOWLEDGE_ADMIN_REMOTE_OPS=1` is set. The
+`auto-update enable` command sets that flag because browser-triggered
+install is the whole point of opting in. Keep this on trusted networks
+only. `/admin/upgrade/check` remains read-only and can run without the flag.
 
 **Recovery from a bad upgrade.** Every Install takes a volume-level
 snapshot of `./data` and `./config` (excludes `./cache`) before the

--- a/docker/README.md
+++ b/docker/README.md
@@ -401,7 +401,7 @@ guaranteed-consistent snapshot, then `./nmemctl up` afterward.
 Two independent things you might want to upgrade:
 
 ```bash
-./nmemctl upgrade 0.8.5                   # the docker image: pull, bump compose, recreate
+./nmemctl upgrade 0.8.5                   # the docker image: pull, bump .env, recreate
 ./nmemctl self-update                     # the controller + compose stack files themselves
 ./nmemctl self-update --check             # see what would change without applying
 ```
@@ -420,8 +420,76 @@ are left as `<file>.bak.<timestamp>`.
 `upgrade` refuses pre-release tags (`0.8.5-rc1`, etc.) by default — set
 `NMEM_ALLOW_PRERELEASE=1` to override when you're testing a release candidate.
 
+`upgrade` writes the target tag to `.env` (`NMEM_IMAGE_TAG=X.Y.Z`, mode 0600).
+`compose.yaml` reads that env var as `${NMEM_IMAGE_TAG:-X.Y.Z}` so future
+`up`/`restart` invocations stay on the new version without touching
+`compose.yaml`. The fallback default in `compose.yaml` is the release tag at
+the time you cloned; `self-update` may bump it but `.env` always wins.
+
 The backend runs schema migrations on startup. There is **no downgrade path**;
 once a newer image has opened the database, an older image will refuse to.
+Skipping versions (0.8.4 → 0.8.6 without 0.8.5) **is supported** — schema
+migrations run forward in order on the new image's first boot.
+
+### Click-to-update from the web UI (optional)
+
+If you'd rather not SSH every time a new release lands, opt in to the
+auto-update sidecar:
+
+```bash
+./nmemctl auto-update enable
+```
+
+That generates a per-deploy random token (mode 0600 in `.env`), adds the
+`compose.updater.yaml` overlay to the persisted stack, and brings the stack
+back up with a small `nowledgelabs/mem-updater` sidecar attached. From then
+on, the Settings → Server card in the web UI surfaces "Update available"
+when a newer image lands on Docker Hub, with a Download button (background
+pull, no downtime) and an Install button (≈30 s downtime, takes a pre-stop
+snapshot to `./cache/_pre-upgrade-<ts>.tar.gz`).
+
+```bash
+./nmemctl auto-update status              # current state, last pull, retained snapshots
+./nmemctl auto-update rotate              # rotate the updater token
+./nmemctl auto-update upgrade             # bump the updater image itself
+./nmemctl auto-update disable             # remove the sidecar; keep snapshots
+```
+
+**Trust model worth reading before you enable.** The sidecar mounts
+`/var/run/docker.sock` — that's why it's opt-in. Docker socket access
+is host-root-equivalent for that container. The sidecar is **not exposed
+beyond the compose-internal network**, runs an ~150-line POSIX-shell
+HTTP handler whose code you can read at `community/docker/updater/`,
+and only accepts requests bearing the per-deploy token. The mem
+container itself does **not** mount docker.sock; only the sidecar does.
+
+Pair this with the new `/admin/upgrade/*` endpoints on the Mem backend:
+
+| Endpoint | Behavior |
+|---|---|
+| `GET /admin/upgrade/check` | Aggregated state (current/latest/pulled/sidecar-reachable). UI polls every 120 min. |
+| `POST /admin/upgrade/download` | Pre-pull a target tag (background, idempotent). |
+| `POST /admin/upgrade/install` | Type-to-confirm, snapshot, recreate, wait for `/livez`. |
+
+**Origin guard.** By default, the install endpoint accepts requests only
+from the same-host UI (the `/app` served by this Mem container). If you
+want to trigger upgrades from the desktop in remote mode or from
+`mem.nowledge.co`, set `NOWLEDGE_ADMIN_REMOTE_OPS=1` on the server.
+Trusted networks only.
+
+**Recovery from a bad upgrade.** Every Install takes a volume-level
+snapshot of `./data` and `./config` (excludes `./cache`) before the
+recreate. If the new image's `/livez` doesn't go green within 180s,
+the UI surfaces the snapshot path. SSH and restore:
+
+```bash
+./nmemctl restore-app /var/cache/nowledge-mem/_pre-upgrade-<ts>.tar.gz
+# Then if you want to roll back the image too:
+./nmemctl upgrade 0.8.4    # whatever version you were on
+```
+
+Snapshots rotate automatically: the last 3 are kept; older are deleted on
+each successful Install. Override with `NOWLEDGE_SNAPSHOT_RETAIN`.
 
 ### Factory reset
 

--- a/docker/compose.updater.yaml
+++ b/docker/compose.updater.yaml
@@ -70,10 +70,9 @@ services:
       # docker would auto-create that empty dir as root, and the new
       # mem container would boot into an empty install.
       #
-      # `${PWD}` is substituted at compose parse time on the operator's
-      # shell — that's where they ran `./nmemctl auto-update enable` or
-      # `docker compose up`, which IS the project dir on the host.
-      NOWLEDGE_COMPOSE_PROJECT_DIR: ${NOWLEDGE_COMPOSE_PROJECT_DIR:-${PWD}}
+      # nmemctl exports this explicitly before invoking compose. Manual
+      # compose users should set it to the host-side project directory.
+      NOWLEDGE_COMPOSE_PROJECT_DIR: ${NOWLEDGE_COMPOSE_PROJECT_DIR:?set NOWLEDGE_COMPOSE_PROJECT_DIR to the compose project directory}
       # Background pull cadence. 86400s = 24h. Set to 0 to disable
       # scheduled pulls (Apply still works; image must already be
       # cached or POST /pull called first).

--- a/docker/compose.updater.yaml
+++ b/docker/compose.updater.yaml
@@ -6,7 +6,7 @@
 # Apply on top of compose.yaml:
 #   ./nmemctl auto-update enable    # generates token, persists overlay
 # or by hand:
-#   docker compose -f compose.yaml -f compose.updater.yaml up -d
+#   NOWLEDGE_COMPOSE_PROJECT_DIR="$PWD" docker compose -f compose.yaml -f compose.updater.yaml up -d
 #
 # Trust model — read this before opting in:
 #

--- a/docker/compose.updater.yaml
+++ b/docker/compose.updater.yaml
@@ -1,0 +1,108 @@
+# Auto-update overlay — opt-in sidecar that pulls new Mem images on a
+# schedule and applies a recreate when the operator clicks "Update" in
+# the web UI. Without this overlay, the only way to upgrade the server
+# is `./nmemctl upgrade <version>` from the host shell.
+#
+# Apply on top of compose.yaml:
+#   ./nmemctl auto-update enable    # generates token, persists overlay
+# or by hand:
+#   docker compose -f compose.yaml -f compose.updater.yaml up -d
+#
+# Trust model — read this before opting in:
+#
+#   The updater sidecar mounts `/var/run/docker.sock`. Anything with
+#   docker.sock access is effectively root on the host. The sidecar is
+#   not exposed beyond the compose-internal network, runs as a small,
+#   audit-able shell script (community/docker/updater/server.sh), and
+#   only accepts requests bearing the per-deploy random token in
+#   `NOWLEDGE_UPDATER_TOKEN`. But the threat envelope is real — if the
+#   token leaks AND an attacker can reach the compose network, they can
+#   recreate the mem container against any image they choose.
+#
+#   The mem container itself does NOT mount docker.sock. Only this
+#   sidecar does.
+
+services:
+  mem:
+    # Crucial: NO `depends_on` here. The mem container must boot even if
+    # the updater sidecar can't start (rootless docker without socket
+    # access, podman, locked-down environments). The backend probes the
+    # sidecar at `/admin/upgrade/check` time and returns a structured
+    # "sidecar unavailable" response so the UI degrades gracefully.
+    #
+    # Wire the mem backend to know where the sidecar lives and which
+    # token to present. These env vars are what the new
+    # /admin/upgrade/* endpoints read.
+    environment:
+      NOWLEDGE_UPDATER_URL: http://updater:8080
+      NOWLEDGE_UPDATER_TOKEN: ${NOWLEDGE_UPDATER_TOKEN:?run `./nmemctl auto-update enable` first}
+
+  updater:
+    image: docker.io/nowledgelabs/mem-updater:${NMEM_UPDATER_TAG:-0.8.4}
+    container_name: nowledge-mem-updater
+    restart: unless-stopped
+
+    # docker.sock access. The reason this overlay is opt-in.
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+      # Compose project, RW so the apply path can update `.env` with
+      # the new image tag for subsequent `docker compose up` calls. The
+      # updater never modifies compose.yaml itself.
+      - ./:/opt/compose
+      # The three bind-mount directories. data and config are tarred
+      # into the snapshot; cache hosts the snapshot output and the
+      # single-flight lock file.
+      - ./data:/opt/snapshot/data:ro
+      - ./config:/opt/snapshot/config:ro
+      - ./cache:/opt/snapshot/cache
+
+    environment:
+      NOWLEDGE_UPDATER_TOKEN: ${NOWLEDGE_UPDATER_TOKEN:?run `./nmemctl auto-update enable` first}
+      NOWLEDGE_MEM_CONTAINER: nowledge-mem          # `docker stop/inspect` target
+      NOWLEDGE_MEM_SERVICE: mem                     # `docker compose up` target
+      NOWLEDGE_MEM_IMAGE: docker.io/nowledgelabs/mem
+      # Background pull cadence. 86400s = 24h. Set to 0 to disable
+      # scheduled pulls (Apply still works; image must already be
+      # cached or POST /pull called first).
+      NOWLEDGE_PULL_INTERVAL_SECONDS: ${NOWLEDGE_PULL_INTERVAL_SECONDS:-86400}
+      NOWLEDGE_SNAPSHOT_RETAIN: ${NOWLEDGE_SNAPSHOT_RETAIN:-3}
+      NOWLEDGE_LIVEZ_TIMEOUT_SECONDS: ${NOWLEDGE_LIVEZ_TIMEOUT_SECONDS:-60}
+
+    # No host port exposure. The mem backend reaches the sidecar over
+    # the compose-internal docker network as http://updater:8080.
+    expose:
+      - "8080"
+
+    # Healthcheck so depends_on:service_healthy works on the mem side.
+    healthcheck:
+      test: ["CMD-SHELL", "wget -q -O - http://127.0.0.1:8080/healthz || exit 1"]
+      interval: 30s
+      timeout: 5s
+      retries: 3
+      start_period: 10s
+
+    # The sidecar's job requires docker.sock + tar of files owned by
+    # UID 10001, both of which need either root in-container or
+    # broad capabilities. We accept root-in-container; the sidecar's
+    # code surface is the entire reason for the trust review the
+    # operator did before enabling this overlay.
+    cap_drop:
+      - ALL
+    cap_add:
+      - DAC_OVERRIDE   # read files owned by UID 10001 for tarring
+      - DAC_READ_SEARCH
+      - CHOWN          # writing snapshot with correct owner
+    security_opt:
+      - no-new-privileges:true
+
+    # Resource ceilings. The pull/apply work is bursty; nothing to
+    # justify giving the sidecar more than a small share.
+    mem_limit: 256m
+    pids_limit: 128
+    cpus: 1.0
+
+    logging:
+      driver: json-file
+      options:
+        max-size: "5m"
+        max-file: "3"

--- a/docker/compose.updater.yaml
+++ b/docker/compose.updater.yaml
@@ -61,6 +61,19 @@ services:
       NOWLEDGE_MEM_CONTAINER: nowledge-mem          # `docker stop/inspect` target
       NOWLEDGE_MEM_SERVICE: mem                     # `docker compose up` target
       NOWLEDGE_MEM_IMAGE: docker.io/nowledgelabs/mem
+      # CRITICAL: the host-side path of the compose project. The sidecar
+      # mounts this dir at /opt/compose, but when it invokes `docker
+      # compose up` for recreate, the docker daemon resolves relative
+      # bind-mount paths in compose.yaml against the operator's HOST
+      # path — not the sidecar's view. Without this, every apply
+      # recreate would point bind mounts at `/opt/compose/data`,
+      # docker would auto-create that empty dir as root, and the new
+      # mem container would boot into an empty install.
+      #
+      # `${PWD}` is substituted at compose parse time on the operator's
+      # shell — that's where they ran `./nmemctl auto-update enable` or
+      # `docker compose up`, which IS the project dir on the host.
+      NOWLEDGE_COMPOSE_PROJECT_DIR: ${NOWLEDGE_COMPOSE_PROJECT_DIR:-${PWD}}
       # Background pull cadence. 86400s = 24h. Set to 0 to disable
       # scheduled pulls (Apply still works; image must already be
       # cached or POST /pull called first).

--- a/docker/compose.updater.yaml
+++ b/docker/compose.updater.yaml
@@ -66,7 +66,12 @@ services:
       # cached or POST /pull called first).
       NOWLEDGE_PULL_INTERVAL_SECONDS: ${NOWLEDGE_PULL_INTERVAL_SECONDS:-86400}
       NOWLEDGE_SNAPSHOT_RETAIN: ${NOWLEDGE_SNAPSHOT_RETAIN:-3}
-      NOWLEDGE_LIVEZ_TIMEOUT_SECONDS: ${NOWLEDGE_LIVEZ_TIMEOUT_SECONDS:-60}
+      # Default matches the sidecar's entrypoint.sh default (180s) which in
+      # turn accommodates compose.yaml's `start_period: 90s` for kuzu open +
+      # content-store reconcile. The earlier 60s value was too tight and
+      # tripped legitimate slow boots. Operators bump higher for migration-
+      # heavy upgrades.
+      NOWLEDGE_LIVEZ_TIMEOUT_SECONDS: ${NOWLEDGE_LIVEZ_TIMEOUT_SECONDS:-180}
 
     # No host port exposure. The mem backend reaches the sidecar over
     # the compose-internal docker network as http://updater:8080.

--- a/docker/compose.yaml
+++ b/docker/compose.yaml
@@ -36,9 +36,8 @@ services:
     container_name: nowledge-mem
     restart: unless-stopped
     labels:
-      # Inert by default. Becomes meaningful when the auto-update
-      # overlay is layered in (the updater sidecar only touches
-      # containers carrying this label).
+      # Identification metadata for operators and future tooling. The
+      # updater sidecar targets NOWLEDGE_MEM_CONTAINER/NOWLEDGE_MEM_SERVICE.
       nowledge.auto-update: "true"
 
     # The image already listens on 14242 inside the container. Map to the same

--- a/docker/compose.yaml
+++ b/docker/compose.yaml
@@ -28,9 +28,18 @@
 
 services:
   mem:
-    image: docker.io/nowledgelabs/mem:0.8.4
+    # The tag is parameterized so `./nmemctl upgrade <ver>` and the
+    # optional `./nmemctl auto-update` sidecar can flip versions by
+    # writing `NMEM_IMAGE_TAG=<ver>` to `.env` (mode 0600, gitignored)
+    # without rewriting this file. Fresh installs use the default.
+    image: docker.io/nowledgelabs/mem:${NMEM_IMAGE_TAG:-0.8.4}
     container_name: nowledge-mem
     restart: unless-stopped
+    labels:
+      # Inert by default. Becomes meaningful when the auto-update
+      # overlay is layered in (the updater sidecar only touches
+      # containers carrying this label).
+      nowledge.auto-update: "true"
 
     # The image already listens on 14242 inside the container. Map to the same
     # port on the host by default. Bind to 127.0.0.1 if you intend to put a

--- a/docker/nmemctl
+++ b/docker/nmemctl
@@ -1326,9 +1326,11 @@ cmd_auto_update_upgrade() {
   docker pull "docker.io/nowledgelabs/mem-updater:$target" >/dev/null
   ok "image pulled"
 
-  if [[ "$target" != "latest" ]]; then
-    write_env_var "NMEM_UPDATER_TAG" "$target"
-  fi
+  # ALWAYS write NMEM_UPDATER_TAG, including the literal "latest". Without
+  # this, the `compose.updater.yaml` fallback `${NMEM_UPDATER_TAG:-X.Y.Z}`
+  # kicks in and the recreated sidecar runs the BAKED default — making
+  # `auto-update upgrade` (no args) a silent no-op.
+  write_env_var "NMEM_UPDATER_TAG" "$target"
 
   step "Recreating the updater sidecar on the new image"
   "${DC[@]}" up -d --force-recreate updater >/dev/null 2>&1

--- a/docker/nmemctl
+++ b/docker/nmemctl
@@ -1205,8 +1205,17 @@ cmd_auto_update_enable() {
   ok "future ./nmemctl up / restart will include the updater sidecar"
 
   step "Bringing the stack up with the overlay attached"
-  # Reload NMEM_COMPOSE_FILES now that .nmemctl-state has been updated.
-  NMEM_COMPOSE_FILES="-f compose.yaml $AUTO_UPDATE_OVERLAY"
+  # Reload NMEM_COMPOSE_FILES from the freshly-updated .nmemctl-state so
+  # we PRESERVE any other overlays the operator has layered in (e.g.
+  # compose.tls.yaml). Hardcoding only the updater overlay here would
+  # silently drop TLS / Caddy and break the deploy on `enable`.
+  local persisted
+  persisted="$(read_state_var "$AUTO_UPDATE_STATE_KEY")"
+  if [[ -n "$persisted" ]]; then
+    NMEM_COMPOSE_FILES="-f compose.yaml $persisted"
+  else
+    NMEM_COMPOSE_FILES="-f compose.yaml $AUTO_UPDATE_OVERLAY"
+  fi
   DC=(docker compose ${NMEM_COMPOSE_FILES})
   bring_up_and_wait
 
@@ -1293,13 +1302,18 @@ cmd_auto_update_rotate() {
   write_env_var "NOWLEDGE_UPDATER_TOKEN" "$token"
   ok "new token written to .env"
 
-  step "Recreating the updater sidecar to pick up the new token"
-  "${DC[@]}" up -d --force-recreate updater >/dev/null 2>&1
-  ok "sidecar restarted on new token"
+  # Recreate BOTH the updater AND the mem service. compose.updater.yaml
+  # injects NOWLEDGE_UPDATER_TOKEN into the mem container's env at
+  # create-time (so the backend can call the sidecar with bearer auth).
+  # Without recreating mem too, mem would keep the OLD token in its
+  # environment and 401 every time it tries to reach the sidecar.
+  step "Recreating both updater and mem containers on the new token"
+  "${DC[@]}" up -d --force-recreate updater "$SVC" >/dev/null 2>&1
+  ok "both containers restarted on the new token"
 
   step "Token rotated"
-  note "Any backend instance holding the old token will be 401-rejected on"
-  note "its next /admin/upgrade/* call until it re-reads .env."
+  note "Any external client holding the old token (e.g. a stale curl"
+  note "session) will be 401-rejected on its next /admin/upgrade/* call."
 }
 
 cmd_auto_update_upgrade() {

--- a/docker/nmemctl
+++ b/docker/nmemctl
@@ -82,18 +82,49 @@ require_docker() {
 #
 #   2. `.nmemctl-state` (persisted across invocations). Written by
 #      `auto-update enable`, TLS setup, etc. so the operator can run
-#      `./nmemctl up` / `restart` without re-typing overlays. Sources a
-#      simple `NMEM_STATE_OVERLAYS="-f compose.X.yaml"` assignment.
+#      `./nmemctl up` / `restart` without re-typing overlays. Parsed as
+#      data; never sourced, because this file is user-editable.
 #
 # The explicit env var wins when set; `.nmemctl-state` is layered on top
 # of the base compose.yaml only when no explicit override is present.
 if [[ -z "${NMEM_COMPOSE_FILES:-}" ]]; then
   NMEM_COMPOSE_FILES="-f compose.yaml"
   if [[ -f "$SCRIPT_DIR/.nmemctl-state" ]]; then
-    # shellcheck disable=SC1091
-    source "$SCRIPT_DIR/.nmemctl-state"
-    if [[ -n "${NMEM_STATE_OVERLAYS:-}" ]]; then
-      NMEM_COMPOSE_FILES="$NMEM_COMPOSE_FILES $NMEM_STATE_OVERLAYS"
+    state_line="$(grep -E '^NMEM_STATE_OVERLAYS=' "$SCRIPT_DIR/.nmemctl-state" 2>/dev/null | tail -n 1 || true)"
+    if [[ -n "$state_line" ]]; then
+      state_overlays="${state_line#NMEM_STATE_OVERLAYS=}"
+      state_overlays="${state_overlays#\"}"
+      state_overlays="${state_overlays%\"}"
+      state_overlays="${state_overlays#\'}"
+      state_overlays="${state_overlays%\'}"
+      read -r -a overlay_parts <<< "$state_overlays"
+      idx=0
+      while [[ "$idx" -lt "${#overlay_parts[@]}" ]]; do
+        if [[ "${overlay_parts[$idx]}" != "-f" ]]; then
+          printf "\033[1;31merror:\033[0m invalid .nmemctl-state overlay token\n" >&2
+          exit 1
+        fi
+        next=$((idx + 1))
+        if [[ "$next" -ge "${#overlay_parts[@]}" ]]; then
+          printf "\033[1;31merror:\033[0m invalid .nmemctl-state overlay value\n" >&2
+          exit 1
+        fi
+        overlay_file="${overlay_parts[$next]}"
+        case "$overlay_file" in
+          /*|*..*|*\'*|*\"*|*\\*|*";"*|*":"*)
+            printf "\033[1;31merror:\033[0m invalid .nmemctl-state overlay path: %s\n" "$overlay_file" >&2
+            exit 1
+            ;;
+          *.yaml|*.yml)
+            NMEM_COMPOSE_FILES="$NMEM_COMPOSE_FILES -f $overlay_file"
+            ;;
+          *)
+            printf "\033[1;31merror:\033[0m invalid .nmemctl-state overlay extension: %s\n" "$overlay_file" >&2
+            exit 1
+            ;;
+        esac
+        idx=$((idx + 2))
+      done
     fi
   fi
 fi
@@ -1181,8 +1212,8 @@ Subcommands:
 
 Security notes:
   The updater sidecar mounts /var/run/docker.sock — that's why it's
-  opt-in. Read docs/design/HEADLESS_UPGRADE_UX.md before enabling on a
-  production server.
+  opt-in. Read the "Click-to-update from the web UI" section in this
+  directory's README before enabling on a production server.
 EOF
       ;;
     *)

--- a/docker/nmemctl
+++ b/docker/nmemctl
@@ -36,7 +36,7 @@ set -euo pipefail
 # Version of the controller itself. Bump when nmemctl semantics or
 # command surface change. Independent of the docker image version
 # (which `./nmemctl version` reports separately).
-NMEMCTL_VERSION="2.0.0"
+NMEMCTL_VERSION="2.1.0"
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 cd "$SCRIPT_DIR"
@@ -75,9 +75,28 @@ require_docker() {
   fi
 }
 
-# Compose wrapper. Override NMEM_COMPOSE_FILES to stack overlays (e.g. TLS):
-#   NMEM_COMPOSE_FILES='-f compose.yaml -f compose.tls.yaml' ./nmemctl up
-NMEM_COMPOSE_FILES="${NMEM_COMPOSE_FILES:--f compose.yaml}"
+# Compose wrapper. Two layers of override:
+#
+#   1. Explicit env var (highest priority — never persisted):
+#        NMEM_COMPOSE_FILES='-f compose.yaml -f compose.tls.yaml' ./nmemctl up
+#
+#   2. `.nmemctl-state` (persisted across invocations). Written by
+#      `auto-update enable`, TLS setup, etc. so the operator can run
+#      `./nmemctl up` / `restart` without re-typing overlays. Sources a
+#      simple `NMEM_STATE_OVERLAYS="-f compose.X.yaml"` assignment.
+#
+# The explicit env var wins when set; `.nmemctl-state` is layered on top
+# of the base compose.yaml only when no explicit override is present.
+if [[ -z "${NMEM_COMPOSE_FILES:-}" ]]; then
+  NMEM_COMPOSE_FILES="-f compose.yaml"
+  if [[ -f "$SCRIPT_DIR/.nmemctl-state" ]]; then
+    # shellcheck disable=SC1091
+    source "$SCRIPT_DIR/.nmemctl-state"
+    if [[ -n "${NMEM_STATE_OVERLAYS:-}" ]]; then
+      NMEM_COMPOSE_FILES="$NMEM_COMPOSE_FILES $NMEM_STATE_OVERLAYS"
+    fi
+  fi
+fi
 DC=(docker compose ${NMEM_COMPOSE_FILES})
 
 # Service name in compose.yaml. Override with NMEM_SERVICE if you renamed it.
@@ -389,18 +408,31 @@ cmd_upgrade() {
   step "Pulling docker.io/nowledgelabs/mem:${target}"
   docker pull "docker.io/nowledgelabs/mem:${target}"
 
-  step "Bumping compose.yaml image tag"
-  # Match `image: docker.io/nowledgelabs/mem:*` on its own line and replace.
-  if ! grep -qE "^[[:space:]]+image:[[:space:]]+docker\.io/nowledgelabs/mem:" compose.yaml; then
-    fail "could not find the mem image line in compose.yaml — bump manually."
+  # compose.yaml from nmemctl 2.1.0+ templates the image as
+  # `${NMEM_IMAGE_TAG:-X.Y.Z}`. We then keep compose.yaml untouched and
+  # just override via .env. This plays nicely with `./nmemctl self-update`
+  # (which refreshes compose.yaml from upstream) and with the auto-update
+  # sidecar (which uses the same env-var mechanism).
+  #
+  # If the operator's compose.yaml predates 2.1.0 (literal image tag), we
+  # fall back to the legacy sed-in-place path and gently nudge toward
+  # self-update so future upgrades stay clean.
+  if grep -qE 'image:[[:space:]]*docker\.io/nowledgelabs/mem:\$\{NMEM_IMAGE_TAG' compose.yaml; then
+    step "Setting NMEM_IMAGE_TAG=${target} in .env"
+    write_env_var "NMEM_IMAGE_TAG" "$target"
+  else
+    warn "compose.yaml predates nmemctl 2.1.0 (literal image tag)."
+    warn "Falling back to in-place rewrite. Run './nmemctl self-update'"
+    warn "afterwards to switch to the templated form for cleaner upgrades."
+    step "Bumping compose.yaml image tag"
+    cp compose.yaml compose.yaml.bak
+    sed -i.tmp -E \
+        "s|^([[:space:]]+image:[[:space:]]+)docker\.io/nowledgelabs/mem:.*|\\1docker.io/nowledgelabs/mem:${target}|" \
+        compose.yaml
+    rm -f compose.yaml.tmp
+    diff -u compose.yaml.bak compose.yaml || true
+    rm -f compose.yaml.bak
   fi
-  cp compose.yaml compose.yaml.bak
-  sed -i.tmp -E \
-      "s|^([[:space:]]+image:[[:space:]]+)docker\.io/nowledgelabs/mem:.*|\\1docker.io/nowledgelabs/mem:${target}|" \
-      compose.yaml
-  rm -f compose.yaml.tmp
-  diff -u compose.yaml.bak compose.yaml || true
-  rm -f compose.yaml.bak
 
   step "Recreating container with new image"
   "${DC[@]}" up -d --force-recreate "$SVC"
@@ -942,13 +974,18 @@ CONFIG (forwards to in-container nmem CLI)
 
 RELEASE
   nmemctl upgrade VERSION         Pull docker.io/nowledgelabs/mem:VERSION,
-                                  bump compose.yaml, recreate the container.
+                                  set NMEM_IMAGE_TAG in .env, recreate.
                                   Refuses pre-release tags unless
                                   NMEM_ALLOW_PRERELEASE=1.
   nmemctl self-update [--check]   Update controller + compose stack from
                                   the community repo. Diff-and-prompt; never
                                   silent. In a git checkout, defers to
                                   `git pull`.
+  nmemctl auto-update SUBCMD      Opt-in click-to-update sidecar. Subcommands:
+                                    enable / disable / status / rotate / upgrade.
+                                  After 'enable', the web UI shows an Update
+                                  button when newer Mem images are published.
+                                  See `./nmemctl auto-update help` for details.
 
 MIGRATION
   Volume-level (same-version source → destination, fastest, includes everything):
@@ -985,6 +1022,306 @@ EOF
 }
 
 # ---------------------------------------------------------------------------
+# auto-update — opt-in click-to-update via a small sidecar
+# ---------------------------------------------------------------------------
+#
+# `auto-update enable` adds the updater sidecar to the stack so the web UI
+# can pull new Mem images on a schedule and apply a recreate when the
+# operator clicks the Update button. Without this, the only upgrade path
+# is `./nmemctl upgrade <version>` from the host shell.
+#
+# Security shape (docs/design/HEADLESS_UPGRADE_UX.md §2):
+#   - The sidecar mounts /var/run/docker.sock; the mem container does not.
+#   - Auth is a per-deploy random token stored in `.env` (mode 0600).
+#   - The sidecar is not exposed beyond the compose-internal network.
+#   - The mem backend's `/admin/upgrade/*` endpoints proxy to it, behind
+#     the existing API key plus an Origin guard (closed by default).
+
+AUTO_UPDATE_STATE_KEY="NMEM_STATE_OVERLAYS"
+AUTO_UPDATE_OVERLAY="-f compose.updater.yaml"
+ENV_FILE="$SCRIPT_DIR/.env"
+STATE_FILE="$SCRIPT_DIR/.nmemctl-state"
+
+# Read a NAME=VALUE from .env. Empty if not set / file missing.
+read_env_var() {
+  local name="$1"
+  [[ -f "$ENV_FILE" ]] || return 0
+  grep -E "^${name}=" "$ENV_FILE" 2>/dev/null | tail -n 1 | sed -E "s/^${name}=//; s/^['\"]//; s/['\"]$//"
+}
+
+# Atomically set NAME=VALUE in .env (create if missing, replace if present).
+# Always re-applies mode 0600 because .env holds the updater token + the
+# image-tag override and should not be world-readable.
+write_env_var() {
+  local name="$1" value="$2" tmp
+  tmp="${ENV_FILE}.tmp.$$"
+  {
+    if [[ -f "$ENV_FILE" ]]; then
+      grep -Ev "^${name}=" "$ENV_FILE" || true
+    fi
+    printf '%s=%s\n' "$name" "$value"
+  } > "$tmp"
+  mv "$tmp" "$ENV_FILE"
+  chmod 0600 "$ENV_FILE"
+}
+
+# Remove NAME from .env (no-op if absent or .env missing).
+unset_env_var() {
+  local name="$1" tmp
+  [[ -f "$ENV_FILE" ]] || return 0
+  tmp="${ENV_FILE}.tmp.$$"
+  grep -Ev "^${name}=" "$ENV_FILE" > "$tmp" || true
+  mv "$tmp" "$ENV_FILE"
+  chmod 0600 "$ENV_FILE"
+}
+
+# Read NAME=VALUE from .nmemctl-state (the persisted overlay state).
+read_state_var() {
+  local name="$1"
+  [[ -f "$STATE_FILE" ]] || return 0
+  grep -E "^${name}=" "$STATE_FILE" 2>/dev/null | tail -n 1 \
+    | sed -E "s/^${name}=//; s/^['\"]//; s/['\"]$//"
+}
+
+# Atomically rewrite .nmemctl-state to include the auto-update overlay
+# alongside any other overlays already present (TLS, future ones).
+state_add_overlay() {
+  local existing tmp
+  existing="$(read_state_var "$AUTO_UPDATE_STATE_KEY")"
+  if [[ "$existing" == *"compose.updater.yaml"* ]]; then
+    return 0
+  fi
+  tmp="${STATE_FILE}.tmp.$$"
+  {
+    if [[ -f "$STATE_FILE" ]]; then
+      grep -Ev "^${AUTO_UPDATE_STATE_KEY}=" "$STATE_FILE" || true
+    fi
+    if [[ -n "$existing" ]]; then
+      printf '%s="%s %s"\n' "$AUTO_UPDATE_STATE_KEY" "$existing" "$AUTO_UPDATE_OVERLAY"
+    else
+      printf '%s="%s"\n' "$AUTO_UPDATE_STATE_KEY" "$AUTO_UPDATE_OVERLAY"
+    fi
+  } > "$tmp"
+  mv "$tmp" "$STATE_FILE"
+}
+
+state_remove_overlay() {
+  local existing tmp new
+  existing="$(read_state_var "$AUTO_UPDATE_STATE_KEY")"
+  if [[ -z "$existing" ]]; then
+    return 0
+  fi
+  # Strip "-f compose.updater.yaml" tokens (with surrounding whitespace).
+  new="$(printf '%s' "$existing" | sed -E 's/(^| )-f +compose\.updater\.yaml( |$)/ /g; s/^ +//; s/ +$//')"
+  tmp="${STATE_FILE}.tmp.$$"
+  {
+    if [[ -f "$STATE_FILE" ]]; then
+      grep -Ev "^${AUTO_UPDATE_STATE_KEY}=" "$STATE_FILE" || true
+    fi
+    if [[ -n "$new" ]]; then
+      printf '%s="%s"\n' "$AUTO_UPDATE_STATE_KEY" "$new"
+    fi
+  } > "$tmp"
+  mv "$tmp" "$STATE_FILE"
+}
+
+# Generate 32 bytes of randomness, base64 url-safe-ish (no slashes).
+generate_token() {
+  # /dev/urandom is universally available; openssl avoids depending on it
+  # by reading from /dev/random which can block. Tr the slashes out.
+  if command -v openssl >/dev/null 2>&1; then
+    openssl rand -base64 32 | tr '/+' '_-' | tr -d '=\n'
+  else
+    head -c 32 /dev/urandom | base64 | tr '/+' '_-' | tr -d '=\n'
+  fi
+}
+
+is_auto_update_enabled() {
+  local overlays
+  overlays="$(read_state_var "$AUTO_UPDATE_STATE_KEY")"
+  [[ "$overlays" == *"compose.updater.yaml"* ]]
+}
+
+cmd_auto_update() {
+  local sub="${1:-}"
+  [[ $# -gt 0 ]] && shift
+  case "$sub" in
+    enable)  cmd_auto_update_enable "$@" ;;
+    disable) cmd_auto_update_disable "$@" ;;
+    status)  cmd_auto_update_status "$@" ;;
+    rotate)  cmd_auto_update_rotate "$@" ;;
+    upgrade) cmd_auto_update_upgrade "$@" ;;
+    ""|help|-h|--help)
+      cat <<'EOF'
+auto-update — opt-in click-to-update sidecar for the headless deploy
+
+Subcommands:
+  enable        Generate a per-deploy token, layer in compose.updater.yaml,
+                and recreate the stack with the updater sidecar attached.
+                After this, the web UI can pull and apply Mem updates.
+
+  disable       Remove the updater sidecar (compose rm), clear the token
+                from .env, and remove the overlay from .nmemctl-state.
+                Idempotent.
+
+  status        Show whether auto-update is enabled, the sidecar's health,
+                the last scheduled pull, and the retained snapshots.
+
+  rotate        Rotate the updater token. Any in-flight upgrade attempt
+                using the old token will be rejected on its next call.
+                Use this if you suspect the token has leaked.
+
+  upgrade       Bump the updater sidecar's own image to a newer version.
+                Independent of the mem image upgrade cadence.
+
+Security notes:
+  The updater sidecar mounts /var/run/docker.sock — that's why it's
+  opt-in. Read docs/design/HEADLESS_UPGRADE_UX.md before enabling on a
+  production server.
+EOF
+      ;;
+    *)
+      fail "unknown auto-update subcommand: $sub  (try './nmemctl auto-update help')"
+      ;;
+  esac
+}
+
+cmd_auto_update_enable() {
+  require_docker
+  if is_auto_update_enabled; then
+    note "auto-update is already enabled."
+    cmd_auto_update_status
+    return 0
+  fi
+
+  step "Generating updater token (32 bytes, /dev/urandom)"
+  local token
+  token="$(generate_token)"
+  write_env_var "NOWLEDGE_UPDATER_TOKEN" "$token"
+  ok "wrote .env (mode 0600)"
+
+  step "Persisting overlay to .nmemctl-state"
+  state_add_overlay
+  ok "future ./nmemctl up / restart will include the updater sidecar"
+
+  step "Bringing the stack up with the overlay attached"
+  # Reload NMEM_COMPOSE_FILES now that .nmemctl-state has been updated.
+  NMEM_COMPOSE_FILES="-f compose.yaml $AUTO_UPDATE_OVERLAY"
+  DC=(docker compose ${NMEM_COMPOSE_FILES})
+  bring_up_and_wait
+
+  step "Auto-update enabled"
+  note "The web UI's Settings → Server card now shows the Update button"
+  note "when a newer Mem image is published. SSH is only needed in the"
+  note "failure path (restore-app from a pre-upgrade snapshot)."
+  note ""
+  note "Security: the updater sidecar holds docker.sock. Treat the token"
+  note "as you would a host root credential."
+}
+
+cmd_auto_update_disable() {
+  require_docker
+  if ! is_auto_update_enabled; then
+    note "auto-update is already disabled."
+    return 0
+  fi
+
+  step "Stopping and removing the updater sidecar"
+  "${DC[@]}" rm -fsv updater >/dev/null 2>&1 || true
+  ok "updater container removed"
+
+  step "Clearing token and overlay state"
+  unset_env_var "NOWLEDGE_UPDATER_TOKEN"
+  state_remove_overlay
+  ok "next ./nmemctl up will run without the overlay"
+
+  step "Auto-update disabled"
+  note "The Update button in the web UI will turn into the SSH-command hint."
+  note "Existing pre-upgrade snapshots in ./cache/ are preserved; remove"
+  note "them by hand if you want the disk space back."
+}
+
+cmd_auto_update_status() {
+  require_docker
+  step "Auto-update status"
+
+  if ! is_auto_update_enabled; then
+    note "state: disabled"
+    note "Run './nmemctl auto-update enable' to opt in."
+    return 0
+  fi
+  note "state: enabled"
+
+  local token
+  token="$(read_env_var NOWLEDGE_UPDATER_TOKEN)"
+  if [[ -n "$token" ]]; then
+    note "token: present in .env (mode $(stat -f '%Lp' "$ENV_FILE" 2>/dev/null || stat -c '%a' "$ENV_FILE" 2>/dev/null))"
+  else
+    warn "token MISSING from .env — re-run 'auto-update enable' to repair"
+  fi
+
+  local upd_id health
+  upd_id="$("${DC[@]}" ps -q updater 2>/dev/null || true)"
+  if [[ -z "$upd_id" ]]; then
+    warn "updater container not running"
+  else
+    health="$(docker inspect -f '{{if .State.Health}}{{.State.Health.Status}}{{else}}no-healthcheck{{end}}' "$upd_id" 2>/dev/null || echo unknown)"
+    note "container: running ($health)"
+    # Quick status probe via curl from a one-shot helper. The sidecar is
+    # only reachable on the compose network, so we curl from inside the
+    # network via `docker run --network` + the sidecar's container name.
+    local status_json
+    status_json="$(docker run --rm --network "$(docker inspect -f '{{range $k,$_ := .NetworkSettings.Networks}}{{$k}}{{end}}' "$upd_id")" \
+      curlimages/curl:8.10.1 -fsS \
+      -H "Authorization: Bearer $token" \
+      "http://updater:8080/status" 2>/dev/null || true)"
+    if [[ -n "$status_json" ]]; then
+      printf '%s\n' "$status_json" | jq . 2>/dev/null \
+        | sed 's/^/    /' || printf '    %s\n' "$status_json"
+    fi
+  fi
+}
+
+cmd_auto_update_rotate() {
+  require_docker
+  if ! is_auto_update_enabled; then
+    fail "auto-update is not enabled. Nothing to rotate."
+  fi
+  step "Rotating updater token"
+  local token
+  token="$(generate_token)"
+  write_env_var "NOWLEDGE_UPDATER_TOKEN" "$token"
+  ok "new token written to .env"
+
+  step "Recreating the updater sidecar to pick up the new token"
+  "${DC[@]}" up -d --force-recreate updater >/dev/null 2>&1
+  ok "sidecar restarted on new token"
+
+  step "Token rotated"
+  note "Any backend instance holding the old token will be 401-rejected on"
+  note "its next /admin/upgrade/* call until it re-reads .env."
+}
+
+cmd_auto_update_upgrade() {
+  require_docker
+  if ! is_auto_update_enabled; then
+    fail "auto-update is not enabled."
+  fi
+  local target="${1:-latest}"
+  step "Pulling updater image: docker.io/nowledgelabs/mem-updater:$target"
+  docker pull "docker.io/nowledgelabs/mem-updater:$target" >/dev/null
+  ok "image pulled"
+
+  if [[ "$target" != "latest" ]]; then
+    write_env_var "NMEM_UPDATER_TAG" "$target"
+  fi
+
+  step "Recreating the updater sidecar on the new image"
+  "${DC[@]}" up -d --force-recreate updater >/dev/null 2>&1
+  ok "sidecar running on $target"
+}
+
+# ---------------------------------------------------------------------------
 # Dispatch
 # ---------------------------------------------------------------------------
 
@@ -1018,6 +1355,7 @@ case "$cmd" in
   key)                cmd_key "$@" ;;
   license)            cmd_license "$@" ;;
   upgrade)            cmd_upgrade "$@" ;;
+  auto-update)        cmd_auto_update "$@" ;;
   wipe|factory-reset) cmd_wipe ;;
   help|-h|--help)     cmd_help ;;
 

--- a/docker/nmemctl
+++ b/docker/nmemctl
@@ -1036,7 +1036,9 @@ EOF
 #   - Auth is a per-deploy random token stored in `.env` (mode 0600).
 #   - The sidecar is not exposed beyond the compose-internal network.
 #   - The mem backend's `/admin/upgrade/*` endpoints proxy to it, behind
-#     the existing API key plus an Origin guard (closed by default).
+#     the existing API key. State-changing endpoints stay loopback-only
+#     unless `NOWLEDGE_ADMIN_REMOTE_OPS=1` is set; `auto-update enable`
+#     sets that flag because browser-triggered install is the opt-in.
 
 AUTO_UPDATE_STATE_KEY="NMEM_STATE_OVERLAYS"
 AUTO_UPDATE_OVERLAY="-f compose.updater.yaml"
@@ -1160,6 +1162,8 @@ Subcommands:
   enable        Generate a per-deploy token, layer in compose.updater.yaml,
                 and recreate the stack with the updater sidecar attached.
                 After this, the web UI can pull and apply Mem updates.
+                Also sets NOWLEDGE_ADMIN_REMOTE_OPS=1 because applying an
+                update from a browser is a server-side state change.
 
   disable       Remove the updater sidecar (compose rm), clear the token
                 from .env, and remove the overlay from .nmemctl-state.
@@ -1203,7 +1207,8 @@ cmd_auto_update_enable() {
     local token
     token="$(generate_token)"
     write_env_var "NOWLEDGE_UPDATER_TOKEN" "$token"
-    ok "new token written to .env (mode 0600)"
+    write_env_var "NOWLEDGE_ADMIN_REMOTE_OPS" "1"
+    ok "new token and remote install opt-in written to .env (mode 0600)"
 
     step "Recreating updater and mem containers on the repaired token"
     local persisted
@@ -1224,7 +1229,8 @@ cmd_auto_update_enable() {
   local token
   token="$(generate_token)"
   write_env_var "NOWLEDGE_UPDATER_TOKEN" "$token"
-  ok "wrote .env (mode 0600)"
+  write_env_var "NOWLEDGE_ADMIN_REMOTE_OPS" "1"
+  ok "wrote updater token and remote install opt-in to .env (mode 0600)"
 
   step "Persisting overlay to .nmemctl-state"
   state_add_overlay
@@ -1267,6 +1273,7 @@ cmd_auto_update_disable() {
 
   step "Clearing token and overlay state"
   unset_env_var "NOWLEDGE_UPDATER_TOKEN"
+  unset_env_var "NOWLEDGE_ADMIN_REMOTE_OPS"
   state_remove_overlay
   ok "next ./nmemctl up will run without the overlay"
 

--- a/docker/nmemctl
+++ b/docker/nmemctl
@@ -97,6 +97,7 @@ if [[ -z "${NMEM_COMPOSE_FILES:-}" ]]; then
     fi
   fi
 fi
+export NOWLEDGE_COMPOSE_PROJECT_DIR="${NOWLEDGE_COMPOSE_PROJECT_DIR:-$SCRIPT_DIR}"
 DC=(docker compose ${NMEM_COMPOSE_FILES})
 
 # Service name in compose.yaml. Override with NMEM_SERVICE if you renamed it.
@@ -1061,8 +1062,8 @@ write_env_var() {
     fi
     printf '%s=%s\n' "$name" "$value"
   } > "$tmp"
+  chmod 0600 "$tmp"
   mv "$tmp" "$ENV_FILE"
-  chmod 0600 "$ENV_FILE"
 }
 
 # Remove NAME from .env (no-op if absent or .env missing).
@@ -1071,8 +1072,8 @@ unset_env_var() {
   [[ -f "$ENV_FILE" ]] || return 0
   tmp="${ENV_FILE}.tmp.$$"
   grep -Ev "^${name}=" "$ENV_FILE" > "$tmp" || true
+  chmod 0600 "$tmp"
   mv "$tmp" "$ENV_FILE"
-  chmod 0600 "$ENV_FILE"
 }
 
 # Read NAME=VALUE from .nmemctl-state (the persisted overlay state).
@@ -1247,7 +1248,7 @@ cmd_auto_update_enable() {
   step "Auto-update enabled"
   note "The web UI's Settings → Server card now shows the Update button"
   note "when a newer Mem image is published. SSH is only needed in the"
-  note "failure path (restore-app from a pre-upgrade snapshot)."
+  note "failure path (import from a pre-upgrade snapshot)."
   note ""
   note "Security: the updater sidecar holds docker.sock. Treat the token"
   note "as you would a host root credential."
@@ -1301,20 +1302,12 @@ cmd_auto_update_status() {
   else
     health="$(docker inspect -f '{{if .State.Health}}{{.State.Health.Status}}{{else}}no-healthcheck{{end}}' "$upd_id" 2>/dev/null || echo unknown)"
     note "container: running ($health)"
-    # Quick status probe via curl from a one-shot helper. The sidecar is
-    # only reachable on the compose network, so we curl from inside the
-    # network via `docker run --network` + the sidecar's container name.
-    local status_json network_name
-    network_name="$(docker inspect -f '{{range $k,$_ := .NetworkSettings.Networks}}{{println $k}}{{end}}' "$upd_id" 2>/dev/null | head -n 1)"
-    if [[ -n "$network_name" ]]; then
-      status_json="$(docker run --rm --network "$network_name" \
-        curlimages/curl:8.10.1 -fsS \
-        -H "Authorization: Bearer $token" \
-        "http://updater:8080/status" 2>/dev/null || true)"
-    else
-      status_json=""
-      warn "could not detect updater compose network"
-    fi
+    # Probe from inside the existing sidecar so status works offline and
+    # never pulls a helper image.
+    local status_json
+    status_json="$(docker exec "$upd_id" \
+      wget -qO- --header "Authorization: Bearer $token" \
+      "http://127.0.0.1:8080/status" 2>/dev/null || true)"
     if [[ -n "$status_json" ]]; then
       printf '%s\n' "$status_json" | jq . 2>/dev/null \
         | sed 's/^/    /' || printf '    %s\n' "$status_json"

--- a/docker/nmemctl
+++ b/docker/nmemctl
@@ -36,7 +36,7 @@ set -euo pipefail
 # Version of the controller itself. Bump when nmemctl semantics or
 # command surface change. Independent of the docker image version
 # (which `./nmemctl version` reports separately).
-NMEMCTL_VERSION="2.1.0"
+NMEMCTL_VERSION="2.2.0"
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 cd "$SCRIPT_DIR"

--- a/docker/nmemctl
+++ b/docker/nmemctl
@@ -1189,7 +1189,32 @@ EOF
 cmd_auto_update_enable() {
   require_docker
   if is_auto_update_enabled; then
-    note "auto-update is already enabled."
+    local existing_token
+    existing_token="$(read_env_var NOWLEDGE_UPDATER_TOKEN)"
+    if [[ -n "$existing_token" ]]; then
+      note "auto-update is already enabled."
+      cmd_auto_update_status
+      return 0
+    fi
+
+    step "Repairing auto-update token"
+    note "The updater overlay is enabled, but NOWLEDGE_UPDATER_TOKEN is missing from .env."
+    local token
+    token="$(generate_token)"
+    write_env_var "NOWLEDGE_UPDATER_TOKEN" "$token"
+    ok "new token written to .env (mode 0600)"
+
+    step "Recreating updater and mem containers on the repaired token"
+    local persisted
+    persisted="$(read_state_var "$AUTO_UPDATE_STATE_KEY")"
+    if [[ -n "$persisted" ]]; then
+      NMEM_COMPOSE_FILES="-f compose.yaml $persisted"
+    else
+      NMEM_COMPOSE_FILES="-f compose.yaml $AUTO_UPDATE_OVERLAY"
+    fi
+    DC=(docker compose ${NMEM_COMPOSE_FILES})
+    "${DC[@]}" up -d --force-recreate updater "$SVC" >/dev/null 2>&1
+    ok "both containers restarted on the repaired token"
     cmd_auto_update_status
     return 0
   fi
@@ -1266,7 +1291,7 @@ cmd_auto_update_status() {
   if [[ -n "$token" ]]; then
     note "token: present in .env (mode $(stat -f '%Lp' "$ENV_FILE" 2>/dev/null || stat -c '%a' "$ENV_FILE" 2>/dev/null))"
   else
-    warn "token MISSING from .env — re-run 'auto-update enable' to repair"
+    warn "token MISSING from .env — run './nmemctl auto-update enable' to regenerate it and restart the stack"
   fi
 
   local upd_id health
@@ -1279,11 +1304,17 @@ cmd_auto_update_status() {
     # Quick status probe via curl from a one-shot helper. The sidecar is
     # only reachable on the compose network, so we curl from inside the
     # network via `docker run --network` + the sidecar's container name.
-    local status_json
-    status_json="$(docker run --rm --network "$(docker inspect -f '{{range $k,$_ := .NetworkSettings.Networks}}{{$k}}{{end}}' "$upd_id")" \
-      curlimages/curl:8.10.1 -fsS \
-      -H "Authorization: Bearer $token" \
-      "http://updater:8080/status" 2>/dev/null || true)"
+    local status_json network_name
+    network_name="$(docker inspect -f '{{range $k,$_ := .NetworkSettings.Networks}}{{println $k}}{{end}}' "$upd_id" 2>/dev/null | head -n 1)"
+    if [[ -n "$network_name" ]]; then
+      status_json="$(docker run --rm --network "$network_name" \
+        curlimages/curl:8.10.1 -fsS \
+        -H "Authorization: Bearer $token" \
+        "http://updater:8080/status" 2>/dev/null || true)"
+    else
+      status_json=""
+      warn "could not detect updater compose network"
+    fi
     if [[ -n "$status_json" ]]; then
       printf '%s\n' "$status_json" | jq . 2>/dev/null \
         | sed 's/^/    /' || printf '    %s\n' "$status_json"

--- a/docker/updater/Dockerfile
+++ b/docker/updater/Dockerfile
@@ -1,0 +1,50 @@
+# nowledgelabs/mem-updater — the auto-update sidecar for the headless Mem
+# deployment. Receives bearer-authed calls from the Mem backend over the
+# compose-internal docker network to:
+#
+#   - pull new Mem images on a schedule (no downtime)
+#   - apply a new image on a human-clicked button (~30 s downtime)
+#   - take a volume-level snapshot before recreate, with disk guardrails
+#
+# Runs as root inside the container — required for docker.sock and for
+# tarring host bind mounts owned by UID 10001. The container is not
+# network-exposed outside the compose network; the mem container reaches
+# it as http://updater:8080.
+#
+# Image is published per release alongside docker.io/nowledgelabs/mem so
+# that the updater image moves with the Mem image when the contract
+# changes. Operators bump it via `./nmemctl auto-update upgrade`.
+
+FROM alpine:3.20
+
+# - docker-cli + docker-cli-compose: pull, stop, recreate via compose
+# - socat: dispatch one HTTP request per script invocation — much cleaner
+#   than busybox httpd CGI for our pattern (one script, four routes)
+# - tini: clean SIGTERM forwarding so `docker compose stop updater` exits
+#   fast (don't leave a `docker pull` orphaned in the background)
+# - jq: structured JSON responses without hand-rolling escapes
+# - coreutils: GNU df (busybox df lacks --output=avail) and GNU date
+RUN apk add --no-cache \
+      docker-cli \
+      docker-cli-compose \
+      socat \
+      tini \
+      jq \
+      coreutils \
+    && mkdir -p /opt/updater
+
+COPY server.sh /opt/updater/server.sh
+COPY scheduler.sh /opt/updater/scheduler.sh
+COPY entrypoint.sh /opt/updater/entrypoint.sh
+
+RUN chmod 0755 /opt/updater/server.sh \
+              /opt/updater/scheduler.sh \
+              /opt/updater/entrypoint.sh
+
+WORKDIR /opt/updater
+
+EXPOSE 8080
+
+# tini -g forwards signals to the whole process group: socat, the pull
+# scheduler, and any docker child still running on shutdown.
+ENTRYPOINT ["/sbin/tini", "-g", "--", "/opt/updater/entrypoint.sh"]

--- a/docker/updater/entrypoint.sh
+++ b/docker/updater/entrypoint.sh
@@ -10,8 +10,9 @@
 #      controlled by NOWLEDGE_PULL_INTERVAL_SECONDS (0 disables).
 #
 # Exiting either job exits the container; restart_policy: unless-stopped
-# brings it back. We do NOT trap-and-restart inside; let Docker do its
-# job.
+# brings it back. We do NOT trap-and-restart inside; let Docker do its job,
+# but we do supervise both children so a dead scheduler cannot silently stop
+# warming the image cache.
 set -eu
 
 require_env() {
@@ -67,10 +68,10 @@ fi
 printf 'updater: starting (mem container=%s, image=%s, pull every %ss)\n' \
   "$NOWLEDGE_MEM_CONTAINER" "$NOWLEDGE_MEM_IMAGE" "$NOWLEDGE_PULL_INTERVAL_SECONDS"
 
-# Scheduler in background. fork=true on socat below means the http
-# server is also non-blocking, so the foreground wait works.
+scheduler_pid=""
 if [ "$NOWLEDGE_PULL_INTERVAL_SECONDS" -gt 0 ]; then
   /opt/updater/scheduler.sh &
+  scheduler_pid=$!
 fi
 
 # socat passes each connection's request to server.sh on stdin and
@@ -85,4 +86,24 @@ fi
 # inherits this process's stderr, which docker captures as the
 # container's log stream — so `docker logs nowledge-mem-updater`
 # still shows every request, while the HTTP response is clean.
-exec socat -T 30 TCP-LISTEN:8080,reuseaddr,fork EXEC:/opt/updater/server.sh
+# Keep the connection idle timeout above normal image-pull duration. `POST
+# /pull` is synchronous and may be quiet for minutes while docker downloads.
+: "${NOWLEDGE_SOCAT_TIMEOUT_SECONDS:=600}"
+socat -T "$NOWLEDGE_SOCAT_TIMEOUT_SECONDS" TCP-LISTEN:8080,reuseaddr,fork EXEC:/opt/updater/server.sh &
+socat_pid=$!
+
+while :; do
+  if ! kill -0 "$socat_pid" 2>/dev/null; then
+    status=0
+    wait "$socat_pid" || status=$?
+    [ -n "$scheduler_pid" ] && kill "$scheduler_pid" 2>/dev/null || true
+    exit "$status"
+  fi
+  if [ -n "$scheduler_pid" ] && ! kill -0 "$scheduler_pid" 2>/dev/null; then
+    status=0
+    wait "$scheduler_pid" || status=$?
+    kill "$socat_pid" 2>/dev/null || true
+    exit "$status"
+  fi
+  sleep 2
+done

--- a/docker/updater/entrypoint.sh
+++ b/docker/updater/entrypoint.sh
@@ -33,7 +33,10 @@ require_env "${NOWLEDGE_MEM_IMAGE:-}" NOWLEDGE_MEM_IMAGE
 : "${NOWLEDGE_MEM_SERVICE:=mem}"
 : "${NOWLEDGE_PULL_INTERVAL_SECONDS:=86400}"
 : "${NOWLEDGE_SNAPSHOT_RETAIN:=3}"
-: "${NOWLEDGE_LIVEZ_TIMEOUT_SECONDS:=60}"
+# Default matches compose.yaml's `start_period: 90s` plus headroom for
+# kuzu open + migrations. Bulk-ingest or migration-heavy upgrades can
+# legitimately take longer; operators bump this via the env var.
+: "${NOWLEDGE_LIVEZ_TIMEOUT_SECONDS:=180}"
 export NOWLEDGE_MEM_SERVICE NOWLEDGE_PULL_INTERVAL_SECONDS \
        NOWLEDGE_SNAPSHOT_RETAIN NOWLEDGE_LIVEZ_TIMEOUT_SECONDS
 
@@ -65,4 +68,12 @@ fi
 # captures its stdout as the response. fork=true makes it handle
 # multiple concurrent connections; server.sh's lock file is what
 # prevents simultaneous /apply calls.
-exec socat -T 30 TCP-LISTEN:8080,reuseaddr,fork EXEC:/opt/updater/server.sh,stderr
+#
+# Critical: do NOT pass socat's `stderr` option to EXEC. That would
+# fold server.sh's audit log (which goes to stderr) into the HTTP
+# response stream, causing curl to see audit-log lines as a malformed
+# HTTP/0.9 status line. With no `stderr` option, server.sh's stderr
+# inherits this process's stderr, which docker captures as the
+# container's log stream — so `docker logs nowledge-mem-updater`
+# still shows every request, while the HTTP response is clean.
+exec socat -T 30 TCP-LISTEN:8080,reuseaddr,fork EXEC:/opt/updater/server.sh

--- a/docker/updater/entrypoint.sh
+++ b/docker/updater/entrypoint.sh
@@ -1,0 +1,68 @@
+#!/bin/sh
+# Updater sidecar entrypoint. Two concurrent jobs under one tini parent:
+#
+#   1. socat HTTP server on :8080 — dispatches each request to server.sh
+#      as a child process. Single-flight semantics are enforced inside
+#      server.sh by a lock file, not by socat.
+#
+#   2. scheduler.sh — periodic background `docker pull` so the new image
+#      is cached locally before the operator clicks Apply. Cadence
+#      controlled by NOWLEDGE_PULL_INTERVAL_SECONDS (0 disables).
+#
+# Exiting either job exits the container; restart_policy: unless-stopped
+# brings it back. We do NOT trap-and-restart inside; let Docker do its
+# job.
+set -eu
+
+require_env() {
+  if [ -z "${1:-}" ]; then
+    printf >&2 'updater: missing required env var %s\n' "$2"
+    exit 64
+  fi
+}
+
+require_env "${NOWLEDGE_UPDATER_TOKEN:-}" NOWLEDGE_UPDATER_TOKEN
+require_env "${NOWLEDGE_MEM_CONTAINER:-}" NOWLEDGE_MEM_CONTAINER
+require_env "${NOWLEDGE_MEM_IMAGE:-}" NOWLEDGE_MEM_IMAGE
+
+# Compose-side identifiers vs docker-engine-side. The compose service
+# name (`mem` by default in the reference stack) is what we pass to
+# `docker compose up`. The container name (`nowledge-mem`) is what we
+# pass to `docker stop` / `docker inspect`. Operators who renamed
+# either side in their compose.yaml override these.
+: "${NOWLEDGE_MEM_SERVICE:=mem}"
+: "${NOWLEDGE_PULL_INTERVAL_SECONDS:=86400}"
+: "${NOWLEDGE_SNAPSHOT_RETAIN:=3}"
+: "${NOWLEDGE_LIVEZ_TIMEOUT_SECONDS:=60}"
+export NOWLEDGE_MEM_SERVICE NOWLEDGE_PULL_INTERVAL_SECONDS \
+       NOWLEDGE_SNAPSHOT_RETAIN NOWLEDGE_LIVEZ_TIMEOUT_SECONDS
+
+# Sanity: docker socket must be present and reachable. Fail fast at
+# startup rather than at the first request — operators can read the
+# exit code in `docker logs nowledge-mem-updater` and diagnose. The
+# mem container is unaffected: it has no `depends_on` on the updater,
+# so it continues to serve even if this sidecar restart-loops.
+if ! docker version >/dev/null 2>&1; then
+  printf >&2 'updater: cannot talk to docker daemon at /var/run/docker.sock.\n'
+  printf >&2 'updater: likely causes:\n'
+  printf >&2 '  - socket not bind-mounted into the sidecar (check compose.updater.yaml)\n'
+  printf >&2 '  - rootless docker / podman with a different socket path\n'
+  printf >&2 '  - SELinux/AppArmor blocking socket access (try :Z on the mount)\n'
+  printf >&2 'updater: mem continues to run; the web UI will show "auto-update unavailable".\n'
+  exit 65
+fi
+
+printf 'updater: starting (mem container=%s, image=%s, pull every %ss)\n' \
+  "$NOWLEDGE_MEM_CONTAINER" "$NOWLEDGE_MEM_IMAGE" "$NOWLEDGE_PULL_INTERVAL_SECONDS"
+
+# Scheduler in background. fork=true on socat below means the http
+# server is also non-blocking, so the foreground wait works.
+if [ "$NOWLEDGE_PULL_INTERVAL_SECONDS" -gt 0 ]; then
+  /opt/updater/scheduler.sh &
+fi
+
+# socat passes each connection's request to server.sh on stdin and
+# captures its stdout as the response. fork=true makes it handle
+# multiple concurrent connections; server.sh's lock file is what
+# prevents simultaneous /apply calls.
+exec socat -T 30 TCP-LISTEN:8080,reuseaddr,fork EXEC:/opt/updater/server.sh,stderr

--- a/docker/updater/entrypoint.sh
+++ b/docker/updater/entrypoint.sh
@@ -31,6 +31,15 @@ require_env "${NOWLEDGE_MEM_IMAGE:-}" NOWLEDGE_MEM_IMAGE
 # pass to `docker stop` / `docker inspect`. Operators who renamed
 # either side in their compose.yaml override these.
 : "${NOWLEDGE_MEM_SERVICE:=mem}"
+# Host-side path of the compose project — used by the apply path to tell
+# `docker compose --project-directory=…` how to resolve relative bind-
+# mount paths in compose.yaml. The sidecar mounts the project at
+# /opt/compose for file access, but docker daemon (which lives on the
+# host) needs the HOST path to attach bind mounts correctly to the
+# recreated mem container. compose.updater.yaml seeds this from ${PWD}
+# on the operator's shell.
+: "${NOWLEDGE_COMPOSE_PROJECT_DIR:=/opt/compose}"
+export NOWLEDGE_COMPOSE_PROJECT_DIR
 : "${NOWLEDGE_PULL_INTERVAL_SECONDS:=86400}"
 : "${NOWLEDGE_SNAPSHOT_RETAIN:=3}"
 # Default matches compose.yaml's `start_period: 90s` plus headroom for

--- a/docker/updater/scheduler.sh
+++ b/docker/updater/scheduler.sh
@@ -13,16 +13,27 @@ set -u
 last_status_path=/opt/updater/cache/.last-scheduled-pull
 mkdir -p /opt/updater/cache
 
-# Pull both the literal tag the operator's stack is pinned to AND
-# `:latest`. The first is useful for re-pulling exact-version updates
-# (in case of a tag move); the second is what surfaces "X.Y.Z available"
-# to the UI.
+# Pull `:latest` AND the literal tag the operator's stack is pinned to.
+# `:latest` is what surfaces "X.Y.Z available" to the UI by widening the
+# local image cache to the newest published version. The pinned tag is
+# pulled to absorb potential tag-moves (a published `:X.Y.Z` that was
+# repushed after an emergency fix). We discover the pinned tag from the
+# running mem container's image config rather than baking it in — that
+# way the scheduler stays in sync with operator-side `./nmemctl upgrade`.
 #
-# We do not pull `:X.Y` (rolling minor) because operators who want patch
+# We do NOT pull `:X.Y` (rolling minor) because operators who want patch
 # updates should still consent to them via the Apply button.
 pull_once() {
   ts=$(date -u +%Y-%m-%dT%H:%M:%SZ)
-  for ref in "${NOWLEDGE_MEM_IMAGE}:latest"; do
+  refs="${NOWLEDGE_MEM_IMAGE}:latest"
+  pinned_tag=$(docker inspect --format '{{.Config.Image}}' \
+                  "$NOWLEDGE_MEM_CONTAINER" 2>/dev/null \
+                | awk -F: '{print $NF}')
+  if [ -n "$pinned_tag" ] && [ "$pinned_tag" != "latest" ]; then
+    refs="$refs ${NOWLEDGE_MEM_IMAGE}:${pinned_tag}"
+  fi
+
+  for ref in $refs; do
     if docker pull "$ref" >/tmp/pull.log 2>&1; then
       printf 'scheduler: pulled %s ok at %s\n' "$ref" "$ts"
       printf '{"image":"%s","ok":true,"at":"%s"}\n' "$ref" "$ts" \

--- a/docker/updater/scheduler.sh
+++ b/docker/updater/scheduler.sh
@@ -36,7 +36,8 @@ pull_once() {
   for ref in $refs; do
     if docker pull "$ref" >/tmp/pull.log 2>&1; then
       printf 'scheduler: pulled %s ok at %s\n' "$ref" "$ts"
-      printf '{"image":"%s","ok":true,"at":"%s"}\n' "$ref" "$ts" \
+      jq -nc --arg image "$ref" --arg at "$ts" \
+        '{image:$image,ok:true,at:$at}' \
         > "$last_status_path.tmp" && mv "$last_status_path.tmp" "$last_status_path"
     else
       err=$(tail -n 3 /tmp/pull.log | tr '\n' ' ')

--- a/docker/updater/scheduler.sh
+++ b/docker/updater/scheduler.sh
@@ -1,0 +1,47 @@
+#!/bin/sh
+# Background pull scheduler. Pulls the configured Mem image on a cadence
+# so that when the operator clicks Apply, the new layers are already on
+# disk and the actual downtime is just stop+start, not download time.
+#
+# Idempotent: docker pull with no new layers is a no-op.
+# Cheap: ~10kB of registry traffic when nothing changed.
+#
+# Errors are logged but never crash the scheduler — registry transient
+# failures should not take the sidecar down.
+set -u
+
+last_status_path=/opt/updater/cache/.last-scheduled-pull
+mkdir -p /opt/updater/cache
+
+# Pull both the literal tag the operator's stack is pinned to AND
+# `:latest`. The first is useful for re-pulling exact-version updates
+# (in case of a tag move); the second is what surfaces "X.Y.Z available"
+# to the UI.
+#
+# We do not pull `:X.Y` (rolling minor) because operators who want patch
+# updates should still consent to them via the Apply button.
+pull_once() {
+  ts=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+  for ref in "${NOWLEDGE_MEM_IMAGE}:latest"; do
+    if docker pull "$ref" >/tmp/pull.log 2>&1; then
+      printf 'scheduler: pulled %s ok at %s\n' "$ref" "$ts"
+      printf '{"image":"%s","ok":true,"at":"%s"}\n' "$ref" "$ts" \
+        > "$last_status_path.tmp" && mv "$last_status_path.tmp" "$last_status_path"
+    else
+      err=$(tail -n 3 /tmp/pull.log | tr '\n' ' ')
+      printf >&2 'scheduler: pull %s failed at %s: %s\n' "$ref" "$ts" "$err"
+      printf '{"image":"%s","ok":false,"at":"%s","error":%s}\n' \
+        "$ref" "$ts" "$(printf '%s' "$err" | jq -Rs .)" \
+        > "$last_status_path.tmp" && mv "$last_status_path.tmp" "$last_status_path"
+    fi
+  done
+}
+
+# Stagger the first pull by 60s so a freshly-deployed stack doesn't
+# hammer the registry while the operator is still configuring things.
+sleep 60
+
+while :; do
+  pull_once
+  sleep "$NOWLEDGE_PULL_INTERVAL_SECONDS"
+done

--- a/docker/updater/server.sh
+++ b/docker/updater/server.sh
@@ -3,13 +3,6 @@
 # (see entrypoint.sh). Reads an HTTP request on stdin, writes an HTTP
 # response on stdout, exits.
 #
-# Shebang note: `/bin/sh` on alpine resolves to busybox `ash`, which
-# DOES support `$'\r'` (ANSI-C quoting) for CRLF stripping even though
-# strict POSIX does not. We deliberately depend on busybox's `ash`
-# behavior here rather than adding bash to the image (saves ~3 MB).
-# This script is NOT portable to dash; alpine is the only runtime we
-# ship it on, and the Dockerfile pins alpine:3.20.
-#
 # Routes:
 #   GET  /healthz                  → 200 if alive
 #   GET  /status                   → running_image, cached_tags, last_pull,
@@ -50,6 +43,8 @@ CONFIG_DIR=/opt/snapshot/config
 LOCK_FILE="$SNAPSHOT_DIR/_upgrade.lock"
 SCHED_STATUS="/opt/updater/cache/.last-scheduled-pull"
 STALE_LOCK_AFTER=1800   # seconds (30 min)
+CR=$(printf '\r')
+LOCK_HEARTBEAT_PID=""
 
 # ---- HTTP helpers --------------------------------------------------------
 
@@ -101,7 +96,7 @@ audit() {
 
 # Read the first request line.
 IFS= read -r request_line || { respond_json 400 '{"error":"empty request"}'; exit 0; }
-request_line=${request_line%$'\r'}
+request_line=${request_line%"$CR"}
 method=${request_line%% *}
 rest=${request_line#"$method "}
 target=${rest%% *}
@@ -114,10 +109,10 @@ esac
 # Read headers until blank line. Capture only what we need.
 auth_header=""
 while IFS= read -r header_line; do
-  header_line=${header_line%$'\r'}
+  header_line=${header_line%"$CR"}
   [ -z "$header_line" ] && break
   lname=$(printf '%s' "${header_line%%:*}" | tr 'A-Z' 'a-z')
-  lval=${header_line#*: }
+  lval=$(printf '%s' "${header_line#*:}" | sed 's/^[[:space:]]*//; s/[[:space:]]*$//')
   case "$lname" in
     authorization) auth_header=$lval ;;
   esac
@@ -162,10 +157,34 @@ require_auth() {
 # apply. Timestamp age is the right signal.
 LOCK_DIR="${LOCK_FILE}.d"
 
+write_lock_owner() {
+  tmp="$LOCK_DIR/owner.$$"
+  printf 'ts=%s\n' "$(date +%s)" > "$tmp"
+  mv "$tmp" "$LOCK_DIR/owner"
+}
+
+start_lock_heartbeat() {
+  (
+    while [ -d "$LOCK_DIR" ]; do
+      write_lock_owner 2>/dev/null || true
+      sleep 30
+    done
+  ) &
+  LOCK_HEARTBEAT_PID=$!
+}
+
+stop_lock_heartbeat() {
+  if [ -n "${LOCK_HEARTBEAT_PID:-}" ]; then
+    kill "$LOCK_HEARTBEAT_PID" 2>/dev/null || true
+    wait "$LOCK_HEARTBEAT_PID" 2>/dev/null || true
+    LOCK_HEARTBEAT_PID=""
+  fi
+}
+
 acquire_lock() {
   # First-attempt atomic mkdir. If it succeeds, we hold the lock.
   if mkdir "$LOCK_DIR" 2>/dev/null; then
-    printf 'ts=%s\n' "$(date +%s)" > "$LOCK_DIR/owner"
+    write_lock_owner
     return 0
   fi
 
@@ -191,7 +210,7 @@ acquire_lock() {
   rm -f "$LOCK_DIR/owner"
   rmdir "$LOCK_DIR" 2>/dev/null || true
   if mkdir "$LOCK_DIR" 2>/dev/null; then
-    printf 'ts=%s\n' "$(date +%s)" > "$LOCK_DIR/owner"
+    write_lock_owner
     return 0
   fi
   audit "LOCK contended on re-acquire"
@@ -202,6 +221,38 @@ acquire_lock() {
 release_lock() {
   rm -f "$LOCK_DIR/owner" 2>/dev/null || true
   rmdir "$LOCK_DIR" 2>/dev/null || true
+}
+
+read_compose_overlays() {
+  [ -f /opt/compose/.nmemctl-state ] || return 0
+  line=$(grep -E '^NMEM_STATE_OVERLAYS=' /opt/compose/.nmemctl-state 2>/dev/null | tail -n 1 || true)
+  [ -n "$line" ] || return 0
+  value=${line#NMEM_STATE_OVERLAYS=}
+  value=${value#\"}
+  value=${value%\"}
+  value=${value#\'}
+  value=${value%\'}
+
+  set -- $value
+  overlays=""
+  while [ "$#" -gt 0 ]; do
+    [ "${1:-}" = "-f" ] || return 1
+    [ "$#" -ge 2 ] || return 1
+    file=$2
+    case "$file" in
+      /*|*..*|*\'*|*\"*|*\\*|*';'*)
+        return 1
+        ;;
+      *.yaml|*.yml)
+        overlays="$overlays -f $file"
+        ;;
+      *)
+        return 1
+        ;;
+    esac
+    shift 2
+  done
+  printf '%s\n' "$overlays"
 }
 
 # ---- Route: GET /healthz -------------------------------------------------
@@ -346,7 +397,8 @@ case "$method $path" in
     (
       # Recreate the failure semantics inside the subshell: any error
       # releases the lock and logs.
-      trap 'release_lock' EXIT
+      start_lock_heartbeat
+      trap 'stop_lock_heartbeat; release_lock' EXIT
       audit "APPLY start ref=$ref snapshot=$snapshot"
 
       # Step 1: stop the mem container.
@@ -407,7 +459,7 @@ case "$method $path" in
       # Step 4: persist the new tag to .env BEFORE the recreate. This way
       # if the recreate succeeds, future `./nmemctl up`/`restart` calls
       # use the new tag. If the recreate fails, the operator's recovery
-      # path (./nmemctl restore-app from the snapshot + ./nmemctl upgrade
+      # path (./nmemctl import from the snapshot + ./nmemctl upgrade
       # <old-tag>) will overwrite .env again. Atomic write via temp+mv.
       env_file="/opt/compose/.env"
       env_backup="/tmp/nowledge-mem-env-before-upgrade.$$"
@@ -427,8 +479,8 @@ case "$method $path" in
         fi
         printf 'NMEM_IMAGE_TAG=%s\n' "$tag"
       } > "$env_tmp"
+      chmod 0600 "$env_tmp" 2>/dev/null || true
       mv "$env_tmp" "$env_file"
-      chmod 0600 "$env_file" 2>/dev/null || true
 
       # Step 5: recreate from new tag. compose up -d with NMEM_IMAGE_TAG
       # overridden in the calling environment. The operator's compose.yaml
@@ -443,12 +495,14 @@ case "$method $path" in
       # overlays in .nmemctl-state (managed by `auto-update enable`,
       # `auto-update disable`, future TLS-toggle verbs, etc.) so the
       # sidecar can replay the same compose stack on recreate.
-      compose_overlays=""
-      if [ -f /opt/compose/.nmemctl-state ]; then
-        # shellcheck disable=SC1091
-        . /opt/compose/.nmemctl-state
-        compose_overlays="${NMEM_STATE_OVERLAYS:-}"
-      fi
+      compose_overlays=$(read_compose_overlays) || {
+        audit "APPLY invalid .nmemctl-state overlay list — restarting mem on old image"
+        cp "$env_backup" "$env_file" 2>/dev/null || true
+        chmod 0600 "$env_file" 2>/dev/null || true
+        docker start "$NOWLEDGE_MEM_CONTAINER" >/dev/null 2>&1 || true
+        rm -f "$env_backup"
+        exit 3
+      }
       export NMEM_IMAGE_TAG="$tag"
 
       # Recover the operator's compose project name from the existing

--- a/docker/updater/server.sh
+++ b/docker/updater/server.sh
@@ -12,7 +12,7 @@
 #
 # Every route except /healthz requires `Authorization: Bearer $TOKEN`.
 #
-# Invariants from docs/design/HEADLESS_UPGRADE_UX.md:
+# Headless upgrade invariants:
 #
 #   - Free-space precheck BEFORE docker stop. If insufficient, return
 #     412 and leave the container running. Stopping without space to
@@ -219,7 +219,7 @@ acquire_lock() {
 }
 
 release_lock() {
-  rm -f "$LOCK_DIR/owner" 2>/dev/null || true
+  rm -f "$LOCK_DIR"/owner "$LOCK_DIR"/owner.* 2>/dev/null || true
   rmdir "$LOCK_DIR" 2>/dev/null || true
 }
 

--- a/docker/updater/server.sh
+++ b/docker/updater/server.sh
@@ -40,15 +40,36 @@ STALE_LOCK_AFTER=1800   # seconds (30 min)
 
 # ---- HTTP helpers --------------------------------------------------------
 
-# Emit an HTTP response. Body is read from stdin.
-# Usage: printf '%s' "$json_body" | respond 200 'application/json'
+# HTTP-status-code → reason phrase. Strict clients (modern curl) reject
+# responses without a reason phrase and fall back to HTTP/0.9 parsing,
+# which manifests as "Received HTTP/0.9 when not allowed" on the caller.
+status_phrase() {
+  case "$1" in
+    200) printf 'OK' ;;
+    202) printf 'Accepted' ;;
+    400) printf 'Bad Request' ;;
+    401) printf 'Unauthorized' ;;
+    404) printf 'Not Found' ;;
+    409) printf 'Conflict' ;;
+    412) printf 'Precondition Failed' ;;
+    500) printf 'Internal Server Error' ;;
+    502) printf 'Bad Gateway' ;;
+    *)   printf 'Status' ;;
+  esac
+}
+
+# Emit an HTTP response. Body is read from stdin. Status line is
+# `HTTP/1.0 <code> <reason>` per RFC 1945 / RFC 9110.
 respond() {
   status=$1
   ctype=${2:-application/json}
   body=$(cat)
-  len=${#body}
-  printf 'HTTP/1.0 %s\r\nContent-Type: %s\r\nContent-Length: %s\r\nConnection: close\r\n\r\n%s' \
-    "$status" "$ctype" "$len" "$body"
+  # Byte length — accurate for UTF-8 since `${#var}` in dash counts bytes.
+  # printf's %s emits the exact bytes, so wc -c matches.
+  len=$(printf '%s' "$body" | wc -c | tr -d ' ')
+  phrase=$(status_phrase "$status")
+  printf 'HTTP/1.0 %s %s\r\nContent-Type: %s\r\nContent-Length: %s\r\nConnection: close\r\n\r\n%s' \
+    "$status" "$phrase" "$ctype" "$len" "$body"
 }
 
 # Build a JSON response body and emit it.
@@ -116,32 +137,58 @@ require_auth() {
   fi
 }
 
-# Lock file dance. Acquires /apply lock or returns 409.
+# Single-flight lock. Atomic via `mkdir` — succeeds or fails as one
+# syscall, with no TOCTOU window. Plain file-based [ -f X ] + write is
+# racy: two concurrent requests can both observe absent and both write.
+#
+# Liveness model: stale-by-TIMESTAMP only, not by PID. The main socat
+# child that calls acquire_lock exits as soon as it emits the 202; the
+# work runs in a detached subshell whose PID we don't write into the
+# lock. A PID-liveness check on the main process would always see
+# "dead" after a few seconds, falsely concluding stale and double-firing
+# apply. Timestamp age is the right signal.
+LOCK_DIR="${LOCK_FILE}.d"
+
 acquire_lock() {
-  if [ -f "$LOCK_FILE" ]; then
-    held_pid=$(awk -F= '/^pid=/ {print $2}' "$LOCK_FILE" 2>/dev/null || true)
-    held_ts=$(awk -F= '/^ts=/ {print $2}' "$LOCK_FILE" 2>/dev/null || true)
-    now=$(date +%s)
-    age=$(( now - ${held_ts:-0} ))
-    pid_alive=0
-    if [ -n "$held_pid" ] && kill -0 "$held_pid" 2>/dev/null; then
-      pid_alive=1
-    fi
-    if [ "$pid_alive" -eq 1 ] && [ "$age" -lt "$STALE_LOCK_AFTER" ]; then
-      audit "LOCK held by pid=$held_pid age=${age}s"
-      respond_json 409 "$(jq -nc \
-        --arg pid "$held_pid" --arg age "$age" \
-        '{error:"upgrade in progress", pid:$pid, age_seconds:($age|tonumber)}')"
-      exit 0
-    fi
-    audit "LOCK stale (pid=$held_pid age=${age}s) — taking over"
-    rm -f "$LOCK_FILE"
+  # First-attempt atomic mkdir. If it succeeds, we hold the lock.
+  if mkdir "$LOCK_DIR" 2>/dev/null; then
+    printf 'ts=%s\n' "$(date +%s)" > "$LOCK_DIR/owner"
+    return 0
   fi
-  printf 'pid=%s\nts=%s\n' "$$" "$(date +%s)" > "$LOCK_FILE"
+
+  # Someone else holds it. Check staleness by mtime of the lock dir.
+  held_ts=$(awk -F= '/^ts=/ {print $2}' "$LOCK_DIR/owner" 2>/dev/null || true)
+  if [ -z "$held_ts" ]; then
+    # No owner file inside — fall back to dir mtime.
+    held_ts=$(stat -c '%Y' "$LOCK_DIR" 2>/dev/null || echo 0)
+  fi
+  now=$(date +%s)
+  age=$(( now - ${held_ts:-0} ))
+  if [ "$age" -lt "$STALE_LOCK_AFTER" ]; then
+    audit "LOCK held (age=${age}s)"
+    respond_json 409 "$(jq -nc \
+      --arg age "$age" \
+      '{error:"upgrade in progress", age_seconds:($age|tonumber)}')"
+    exit 0
+  fi
+
+  # Stale. Clear and re-acquire atomically. If re-acquire races and
+  # loses, surface 409 cleanly.
+  audit "LOCK stale (age=${age}s) — taking over"
+  rm -f "$LOCK_DIR/owner"
+  rmdir "$LOCK_DIR" 2>/dev/null || true
+  if mkdir "$LOCK_DIR" 2>/dev/null; then
+    printf 'ts=%s\n' "$(date +%s)" > "$LOCK_DIR/owner"
+    return 0
+  fi
+  audit "LOCK contended on re-acquire"
+  respond_json 409 '{"error":"upgrade contended; retry"}'
+  exit 0
 }
 
 release_lock() {
-  rm -f "$LOCK_FILE"
+  rm -f "$LOCK_DIR/owner" 2>/dev/null || true
+  rmdir "$LOCK_DIR" 2>/dev/null || true
 }
 
 # ---- Route: GET /healthz -------------------------------------------------
@@ -162,8 +209,12 @@ case "$method $path" in
     running_image=$(docker inspect --format '{{.Config.Image}}' \
       "$NOWLEDGE_MEM_CONTAINER" 2>/dev/null || printf 'unknown')
 
-    # What Mem image tags are cached locally?
-    cached_tags=$(docker images --format '{{.Repository}}:{{.Tag}}' "$NOWLEDGE_MEM_IMAGE" 2>/dev/null \
+    # What Mem image tags are cached locally? Docker normalizes images
+    # stored locally to drop the `docker.io/` prefix, so a filter like
+    # `docker images docker.io/nowledgelabs/mem` returns empty. Strip
+    # the prefix before filtering so both forms match.
+    short_image=${NOWLEDGE_MEM_IMAGE#docker.io/}
+    cached_tags=$(docker images --format '{{.Repository}}:{{.Tag}}' "$short_image" 2>/dev/null \
       | awk -F: '{print $NF}' | sort -u | jq -Rsc 'split("\n") | map(select(length>0))')
     cached_tags=${cached_tags:-"[]"}
 
@@ -327,19 +378,60 @@ case "$method $path" in
       # is templated as `image: ...:${NMEM_IMAGE_TAG:-X.Y.Z}` (the
       # default in fresh installs from nmemctl 2.1.0+).
       #
-      # Layered overlays (TLS, etc.) are picked up via NMEM_STATE_OVERLAYS,
-      # which `./nmemctl auto-update enable` records in .nmemctl-state.
-      # We deliberately do NOT source that file here — we ONLY recreate
-      # the mem service, which doesn't need the overlays' definitions to
-      # be present on the apply call. Operator-side restart will handle
-      # full-stack recreates.
+      # CRITICAL: honor the operator's active overlay stack. If the
+      # deploy uses compose.tls.yaml + compose.updater.yaml + a custom
+      # override, recreating with only compose.yaml would lose the
+      # caddy sidecar, the loopback rebind, and any operator-specific
+      # config — breaking the deploy. nmemctl persists the active
+      # overlays in .nmemctl-state (managed by `auto-update enable`,
+      # `auto-update disable`, future TLS-toggle verbs, etc.) so the
+      # sidecar can replay the same compose stack on recreate.
+      compose_overlays=""
+      if [ -f /opt/compose/.nmemctl-state ]; then
+        # shellcheck disable=SC1091
+        . /opt/compose/.nmemctl-state
+        compose_overlays="${NMEM_STATE_OVERLAYS:-}"
+      fi
       export NMEM_IMAGE_TAG="$tag"
-      if ! docker compose -f /opt/compose/compose.yaml \
-              up -d --no-deps "$NOWLEDGE_MEM_SERVICE" >/dev/null 2>&1; then
-        audit "APPLY compose up failed — mem may be on old image"
+
+      # Recover the operator's compose project name from the existing
+      # container's docker-compose label. The default-derived name (from
+      # the sidecar's cwd basename) would be "compose" — which doesn't
+      # match the operator's project (whatever they `docker compose`-ed
+      # from). Without this, --force-recreate would try to create a
+      # NEW container with the operator's container_name (e.g.
+      # "nowledge-mem"), which is already in use by THEIR project, and
+      # the daemon rejects it with "container name already in use".
+      project=$(docker inspect "$NOWLEDGE_MEM_CONTAINER" \
+                  --format '{{index .Config.Labels "com.docker.compose.project"}}' 2>/dev/null)
+      # Fallback when the container existed before compose v2's project
+      # labels (very old deploys) or was created by hand outside compose.
+      project_arg=""
+      [ -n "$project" ] && project_arg="-p $project"
+
+      # cd into the compose project dir so:
+      #   - relative overlay paths ("-f compose.updater.yaml") resolve here,
+      #     not against the sidecar's /opt/updater workdir;
+      #   - compose auto-discovers .env from the project dir.
+      # shellcheck disable=SC2086 — word-split $compose_overlays so
+      # "-f a.yaml -f b.yaml" expands to multiple args.
+      # --force-recreate stops + removes + creates fresh in one step.
+      # We already explicitly `docker stop`-ed above to flush the DB; the
+      # stopped container is still holding its name (it isn't removed by
+      # plain `stop`), and a normal `up -d` would then conflict with
+      # "container name in use". --force-recreate fixes that, and is the
+      # right semantic for "apply a new image" regardless of any
+      # config-change-detection that compose does implicitly.
+      if ! ( cd /opt/compose && docker compose $project_arg -f compose.yaml $compose_overlays \
+              up -d --no-deps --force-recreate "$NOWLEDGE_MEM_SERVICE" \
+            ) 2>/tmp/compose-err-$$; then
+        err=$(tr '\n' ' ' < /tmp/compose-err-$$ | head -c 400)
+        rm -f /tmp/compose-err-$$
+        audit "APPLY compose up failed — mem may be on old image: $err"
         exit 3
       fi
-      audit "APPLY compose up ok (.env persisted NMEM_IMAGE_TAG=$tag), waiting for /livez"
+      rm -f /tmp/compose-err-$$
+      audit "APPLY compose up ok (overlays=$compose_overlays, .env NMEM_IMAGE_TAG=$tag), waiting for /livez"
 
       # Step 6: wait for /livez green. Up to NOWLEDGE_LIVEZ_TIMEOUT_SECONDS.
       deadline=$(( $(date +%s) + NOWLEDGE_LIVEZ_TIMEOUT_SECONDS ))

--- a/docker/updater/server.sh
+++ b/docker/updater/server.sh
@@ -455,7 +455,15 @@ case "$method $path" in
       # "container name in use". --force-recreate fixes that, and is the
       # right semantic for "apply a new image" regardless of any
       # config-change-detection that compose does implicitly.
-      if ! ( cd /opt/compose && docker compose $project_arg -f compose.yaml $compose_overlays \
+      # CRITICAL: --project-directory tells compose where to RESOLVE
+      # relative bind-mount paths in compose.yaml. The sidecar's cwd
+      # (/opt/compose) is an in-container view; docker daemon needs the
+      # HOST path or it'll auto-create empty root-owned dirs at
+      # /opt/compose/data on the host. NOWLEDGE_COMPOSE_PROJECT_DIR is
+      # seeded by compose.updater.yaml from ${PWD} on the operator's shell.
+      if ! ( cd /opt/compose && docker compose \
+              --project-directory "$NOWLEDGE_COMPOSE_PROJECT_DIR" \
+              $project_arg -f compose.yaml $compose_overlays \
               up -d --no-deps --force-recreate "$NOWLEDGE_MEM_SERVICE" \
             ) 2>/tmp/compose-err-$$; then
         err=$(tr '\n' ' ' < /tmp/compose-err-$$ | head -c 400)

--- a/docker/updater/server.sh
+++ b/docker/updater/server.sh
@@ -3,9 +3,17 @@
 # (see entrypoint.sh). Reads an HTTP request on stdin, writes an HTTP
 # response on stdout, exits.
 #
+# Shebang note: `/bin/sh` on alpine resolves to busybox `ash`, which
+# DOES support `$'\r'` (ANSI-C quoting) for CRLF stripping even though
+# strict POSIX does not. We deliberately depend on busybox's `ash`
+# behavior here rather than adding bash to the image (saves ~3 MB).
+# This script is NOT portable to dash; alpine is the only runtime we
+# ship it on, and the Dockerfile pins alpine:3.20.
+#
 # Routes:
 #   GET  /healthz                  → 200 if alive
-#   GET  /status                   → cached_tags, pull_in_progress, running tag
+#   GET  /status                   → running_image, cached_tags, last_pull,
+#                                    snapshots, upgrade_in_progress
 #   POST /pull?tag=X.Y.Z           → docker pull (idempotent, no downtime)
 #   POST /apply?tag=X.Y.Z          → snapshot + recreate (~30s downtime)
 #
@@ -16,17 +24,22 @@
 #   - Free-space precheck BEFORE docker stop. If insufficient, return
 #     412 and leave the container running. Stopping without space to
 #     snapshot would corrupt the only safety net.
-#   - Atomic snapshot: write to .tmp, mv to final name. Never leave a
-#     half-written tar masquerading as a valid snapshot.
-#   - Single-flight lock: ./cache/_upgrade.lock holds PID+timestamp.
-#     Concurrent /apply gets 409. Stale lock (>30 min, PID dead) is
-#     auto-cleared.
+#   - Atomic snapshot: tar exit status captured directly (not through a
+#     pipeline that would mask failures), then mv .tmp → final only on
+#     success. Never leave a half-written tar masquerading as valid.
+#   - Single-flight lock: ./cache/_upgrade.lock.d is an atomic mkdir
+#     DIRECTORY with a timestamp-only `owner` file inside. Concurrent
+#     /apply gets 409. Staleness is judged by timestamp age (the
+#     detached worker is a fresh subshell, so PID-liveness checks
+#     would always claim stale and double-fire apply).
 #   - /livez watch after recreate: poll up to NOWLEDGE_LIVEZ_TIMEOUT_SECONDS.
 #     If never green, return failure with snapshot path so the operator
 #     can decide whether to restore or debug forward.
 #   - Last-N snapshot rotation: keep newest NOWLEDGE_SNAPSHOT_RETAIN
 #     `_pre-upgrade-*.tar.gz`; delete older.
-#   - All endpoints log to stderr (captured by socat) for the audit trail.
+#   - All endpoints log to stderr (captured by `docker logs`) for the
+#     audit trail. socat's `stderr` option is INTENTIONALLY NOT used
+#     in entrypoint.sh so audit lines don't fold into HTTP responses.
 
 set -u
 
@@ -224,11 +237,19 @@ case "$method $path" in
       last_pull=$(cat "$SCHED_STATUS")
     fi
 
-    # Upgrade in progress?
+    # Upgrade in progress? The lock is now an atomic mkdir directory
+    # (LOCK_DIR = ${LOCK_FILE}.d) with a timestamp-only `owner` file
+    # inside — staleness is judged by age, not PID liveness, because
+    # the subshell doing the work isn't the lock-acquirer process.
     in_progress=false
-    if [ -f "$LOCK_FILE" ]; then
-      held_pid=$(awk -F= '/^pid=/ {print $2}' "$LOCK_FILE" 2>/dev/null || true)
-      if [ -n "$held_pid" ] && kill -0 "$held_pid" 2>/dev/null; then
+    if [ -d "$LOCK_DIR" ]; then
+      held_ts=$(awk -F= '/^ts=/ {print $2}' "$LOCK_DIR/owner" 2>/dev/null || true)
+      if [ -z "$held_ts" ]; then
+        held_ts=$(stat -c '%Y' "$LOCK_DIR" 2>/dev/null || echo 0)
+      fi
+      now=$(date +%s)
+      age=$(( now - ${held_ts:-0} ))
+      if [ "$age" -lt "$STALE_LOCK_AFTER" ]; then
         in_progress=true
       fi
     fi
@@ -317,7 +338,9 @@ case "$method $path" in
     # caller to get a fast 202 with the snapshot path. The detached
     # worker logs everything via audit() to stderr, captured by socat.
     ts=$(date -u +%Y%m%dT%H%M%SZ)
-    snapshot=".cache/_pre-upgrade-${ts}.tar.gz"
+    # ./cache/ (visible) — the operator can ls this from the host.
+    # The earlier .cache/ (hidden dotted dir) was a bug.
+    snapshot="./cache/_pre-upgrade-${ts}.tar.gz"
     snapshot_abs="$SNAPSHOT_DIR/_pre-upgrade-${ts}.tar.gz"
 
     (
@@ -336,12 +359,22 @@ case "$method $path" in
       # Step 2: atomic snapshot. Tar from /opt/snapshot (which has data
       # and config bind-mounted RO). Exclude cache by virtue of not
       # tarring it. Write .tmp first, then rename.
-      if ! tar -czf "${snapshot_abs}.tmp" -C /opt/snapshot data config 2>&1 \
-         | sed 's/^/tar: /' >&2 ; then
-        :
+      #
+      # IMPORTANT: capture tar's exit status directly. In POSIX sh,
+      # `tar … | sed …` returns sed's status, which would mask tar
+      # failures and leave a half-written archive that the `-s` check
+      # below would happily accept. We tee tar's stderr to a temp log
+      # for the audit trail and check tar's exit code explicitly.
+      tar_log=$(mktemp)
+      tar -czf "${snapshot_abs}.tmp" -C /opt/snapshot data config 2>"$tar_log"
+      tar_rc=$?
+      if [ -s "$tar_log" ]; then
+        sed 's/^/tar: /' < "$tar_log" >&2
       fi
-      if [ ! -s "${snapshot_abs}.tmp" ]; then
-        audit "APPLY snapshot failed — restarting mem on old image"
+      rm -f "$tar_log"
+      if [ "$tar_rc" -ne 0 ] || [ ! -s "${snapshot_abs}.tmp" ]; then
+        audit "APPLY snapshot failed (tar rc=$tar_rc) — restarting mem on old image"
+        rm -f "${snapshot_abs}.tmp"
         docker start "$NOWLEDGE_MEM_CONTAINER" >/dev/null 2>&1 || true
         exit 2
       fi

--- a/docker/updater/server.sh
+++ b/docker/updater/server.sh
@@ -1,0 +1,375 @@
+#!/bin/sh
+# Updater HTTP handler. Invoked once per incoming connection by socat
+# (see entrypoint.sh). Reads an HTTP request on stdin, writes an HTTP
+# response on stdout, exits.
+#
+# Routes:
+#   GET  /healthz                  → 200 if alive
+#   GET  /status                   → cached_tags, pull_in_progress, running tag
+#   POST /pull?tag=X.Y.Z           → docker pull (idempotent, no downtime)
+#   POST /apply?tag=X.Y.Z          → snapshot + recreate (~30s downtime)
+#
+# Every route except /healthz requires `Authorization: Bearer $TOKEN`.
+#
+# Invariants from docs/design/HEADLESS_UPGRADE_UX.md:
+#
+#   - Free-space precheck BEFORE docker stop. If insufficient, return
+#     412 and leave the container running. Stopping without space to
+#     snapshot would corrupt the only safety net.
+#   - Atomic snapshot: write to .tmp, mv to final name. Never leave a
+#     half-written tar masquerading as a valid snapshot.
+#   - Single-flight lock: ./cache/_upgrade.lock holds PID+timestamp.
+#     Concurrent /apply gets 409. Stale lock (>30 min, PID dead) is
+#     auto-cleared.
+#   - /livez watch after recreate: poll up to NOWLEDGE_LIVEZ_TIMEOUT_SECONDS.
+#     If never green, return failure with snapshot path so the operator
+#     can decide whether to restore or debug forward.
+#   - Last-N snapshot rotation: keep newest NOWLEDGE_SNAPSHOT_RETAIN
+#     `_pre-upgrade-*.tar.gz`; delete older.
+#   - All endpoints log to stderr (captured by socat) for the audit trail.
+
+set -u
+
+# ---- Config --------------------------------------------------------------
+SNAPSHOT_DIR=/opt/snapshot/cache
+DATA_DIR=/opt/snapshot/data
+CONFIG_DIR=/opt/snapshot/config
+LOCK_FILE="$SNAPSHOT_DIR/_upgrade.lock"
+SCHED_STATUS="/opt/updater/cache/.last-scheduled-pull"
+STALE_LOCK_AFTER=1800   # seconds (30 min)
+
+# ---- HTTP helpers --------------------------------------------------------
+
+# Emit an HTTP response. Body is read from stdin.
+# Usage: printf '%s' "$json_body" | respond 200 'application/json'
+respond() {
+  status=$1
+  ctype=${2:-application/json}
+  body=$(cat)
+  len=${#body}
+  printf 'HTTP/1.0 %s\r\nContent-Type: %s\r\nContent-Length: %s\r\nConnection: close\r\n\r\n%s' \
+    "$status" "$ctype" "$len" "$body"
+}
+
+# Build a JSON response body and emit it.
+# Usage: respond_json 200 '{"ok": true}'
+respond_json() {
+  printf '%s' "$2" | respond "$1" 'application/json'
+}
+
+# Audit log line on stderr. socat captures these.
+audit() {
+  ts=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+  printf >&2 'updater[%s] %s %s\n' "$$" "$ts" "$*"
+}
+
+# ---- Parse the request ---------------------------------------------------
+
+# Read the first request line.
+IFS= read -r request_line || { respond_json 400 '{"error":"empty request"}'; exit 0; }
+request_line=${request_line%$'\r'}
+method=${request_line%% *}
+rest=${request_line#"$method "}
+target=${rest%% *}
+path=${target%%\?*}
+case "$target" in
+  *\?*) query=${target#*\?} ;;
+  *)    query="" ;;
+esac
+
+# Read headers until blank line. Capture only what we need.
+auth_header=""
+while IFS= read -r header_line; do
+  header_line=${header_line%$'\r'}
+  [ -z "$header_line" ] && break
+  lname=$(printf '%s' "${header_line%%:*}" | tr 'A-Z' 'a-z')
+  lval=${header_line#*: }
+  case "$lname" in
+    authorization) auth_header=$lval ;;
+  esac
+done
+
+audit "REQ $method $path query=$query"
+
+# ---- Helpers -------------------------------------------------------------
+
+# Extract a query parameter. Usage: q=$(qparam tag)
+qparam() {
+  printf '%s' "$query" | tr '&' '\n' \
+    | awk -F= -v k="$1" '$1==k { sub("^"k"=","",$0); print; exit }'
+}
+
+# Validate a version tag string. Accept X.Y.Z and X.Y.Z-suffix.
+# Reject anything with slashes, spaces, quotes, etc — the tag flows
+# directly into a `docker pull <image>:<tag>` shell-out below.
+valid_tag() {
+  printf '%s' "$1" | grep -Eq '^[A-Za-z0-9_.-]{1,64}$'
+}
+
+# Authn check. Returns 0 if Bearer token matches; emits 401 + exits otherwise.
+require_auth() {
+  expected="Bearer $NOWLEDGE_UPDATER_TOKEN"
+  if [ "$auth_header" != "$expected" ]; then
+    audit "AUTH FAIL"
+    respond_json 401 '{"error":"unauthorized"}'
+    exit 0
+  fi
+}
+
+# Lock file dance. Acquires /apply lock or returns 409.
+acquire_lock() {
+  if [ -f "$LOCK_FILE" ]; then
+    held_pid=$(awk -F= '/^pid=/ {print $2}' "$LOCK_FILE" 2>/dev/null || true)
+    held_ts=$(awk -F= '/^ts=/ {print $2}' "$LOCK_FILE" 2>/dev/null || true)
+    now=$(date +%s)
+    age=$(( now - ${held_ts:-0} ))
+    pid_alive=0
+    if [ -n "$held_pid" ] && kill -0 "$held_pid" 2>/dev/null; then
+      pid_alive=1
+    fi
+    if [ "$pid_alive" -eq 1 ] && [ "$age" -lt "$STALE_LOCK_AFTER" ]; then
+      audit "LOCK held by pid=$held_pid age=${age}s"
+      respond_json 409 "$(jq -nc \
+        --arg pid "$held_pid" --arg age "$age" \
+        '{error:"upgrade in progress", pid:$pid, age_seconds:($age|tonumber)}')"
+      exit 0
+    fi
+    audit "LOCK stale (pid=$held_pid age=${age}s) — taking over"
+    rm -f "$LOCK_FILE"
+  fi
+  printf 'pid=%s\nts=%s\n' "$$" "$(date +%s)" > "$LOCK_FILE"
+}
+
+release_lock() {
+  rm -f "$LOCK_FILE"
+}
+
+# ---- Route: GET /healthz -------------------------------------------------
+case "$method $path" in
+  "GET /healthz")
+    respond_json 200 '{"ok":true}'
+    exit 0
+    ;;
+esac
+
+# Everything below requires the bearer token.
+require_auth
+
+# ---- Route: GET /status --------------------------------------------------
+case "$method $path" in
+  "GET /status")
+    # What's the running container on now?
+    running_image=$(docker inspect --format '{{.Config.Image}}' \
+      "$NOWLEDGE_MEM_CONTAINER" 2>/dev/null || printf 'unknown')
+
+    # What Mem image tags are cached locally?
+    cached_tags=$(docker images --format '{{.Repository}}:{{.Tag}}' "$NOWLEDGE_MEM_IMAGE" 2>/dev/null \
+      | awk -F: '{print $NF}' | sort -u | jq -Rsc 'split("\n") | map(select(length>0))')
+    cached_tags=${cached_tags:-"[]"}
+
+    # Last scheduled-pull status, if any.
+    last_pull="null"
+    if [ -f "$SCHED_STATUS" ]; then
+      last_pull=$(cat "$SCHED_STATUS")
+    fi
+
+    # Upgrade in progress?
+    in_progress=false
+    if [ -f "$LOCK_FILE" ]; then
+      held_pid=$(awk -F= '/^pid=/ {print $2}' "$LOCK_FILE" 2>/dev/null || true)
+      if [ -n "$held_pid" ] && kill -0 "$held_pid" 2>/dev/null; then
+        in_progress=true
+      fi
+    fi
+
+    # Existing snapshots (newest first).
+    snapshots=$(ls -1t "$SNAPSHOT_DIR"/_pre-upgrade-*.tar.gz 2>/dev/null \
+      | jq -Rsc 'split("\n") | map(select(length>0) | sub("^/opt/snapshot/cache/"; "./cache/"))')
+    snapshots=${snapshots:-"[]"}
+
+    body=$(jq -nc \
+      --arg running "$running_image" \
+      --argjson cached "$cached_tags" \
+      --argjson last_pull "$last_pull" \
+      --argjson snapshots "$snapshots" \
+      --argjson in_progress "$in_progress" \
+      '{running_image:$running, cached_tags:$cached, last_pull:$last_pull,
+        snapshots:$snapshots, upgrade_in_progress:$in_progress}')
+    respond_json 200 "$body"
+    exit 0
+    ;;
+esac
+
+# ---- Route: POST /pull ---------------------------------------------------
+case "$method $path" in
+  "POST /pull")
+    tag=$(qparam tag)
+    [ -z "$tag" ] && tag="latest"
+    if ! valid_tag "$tag"; then
+      respond_json 400 '{"error":"invalid tag"}'
+      exit 0
+    fi
+    ref="${NOWLEDGE_MEM_IMAGE}:${tag}"
+    audit "PULL $ref"
+    if docker pull "$ref" >/tmp/pull-$$.log 2>&1; then
+      audit "PULL ok $ref"
+      respond_json 200 "$(jq -nc --arg ref "$ref" '{ok:true, ref:$ref}')"
+    else
+      err=$(tail -n 5 /tmp/pull-$$.log | tr '\n' ' ')
+      audit "PULL fail $ref: $err"
+      respond_json 502 "$(jq -nc --arg ref "$ref" --arg err "$err" \
+        '{ok:false, ref:$ref, error:$err}')"
+    fi
+    rm -f /tmp/pull-$$.log
+    exit 0
+    ;;
+esac
+
+# ---- Route: POST /apply --------------------------------------------------
+case "$method $path" in
+  "POST /apply")
+    tag=$(qparam tag)
+    if ! valid_tag "$tag"; then
+      respond_json 400 '{"error":"invalid or missing tag"}'
+      exit 0
+    fi
+    ref="${NOWLEDGE_MEM_IMAGE}:${tag}"
+
+    # Image must already be cached locally — Apply does NOT pull. If
+    # the caller wants to skip the pull-first contract, they POST /pull
+    # explicitly first. This keeps Apply's failure modes narrow.
+    if ! docker image inspect "$ref" >/dev/null 2>&1; then
+      audit "APPLY $ref — not cached, refusing"
+      respond_json 412 "$(jq -nc --arg ref "$ref" \
+        '{error:"image not cached — call POST /pull first", ref:$ref}')"
+      exit 0
+    fi
+
+    # Free-space precheck. Need (size(data)+size(config)) * 1.5 free.
+    data_kb=$(du -sk "$DATA_DIR" 2>/dev/null | awk '{print $1}')
+    config_kb=$(du -sk "$CONFIG_DIR" 2>/dev/null | awk '{print $1}')
+    needed_kb=$(( (data_kb + config_kb) * 3 / 2 ))
+    avail_kb=$(df --output=avail "$SNAPSHOT_DIR" 2>/dev/null | awk 'NR==2 {print $1}')
+    if [ -z "${avail_kb:-}" ] || [ "$avail_kb" -lt "$needed_kb" ]; then
+      audit "APPLY $ref — insufficient space (need ${needed_kb}kB, have ${avail_kb:-0}kB)"
+      respond_json 412 "$(jq -nc \
+        --arg needed "$needed_kb" --arg avail "${avail_kb:-0}" \
+        '{error:"insufficient disk space for pre-upgrade snapshot",
+          needed_kb:($needed|tonumber), available_kb:($avail|tonumber)}')"
+      exit 0
+    fi
+
+    # Single-flight lock. Emits its own 409 response on conflict.
+    acquire_lock
+
+    # Detach the long-running work. Apply takes 30-60s and we want the
+    # caller to get a fast 202 with the snapshot path. The detached
+    # worker logs everything via audit() to stderr, captured by socat.
+    ts=$(date -u +%Y%m%dT%H%M%SZ)
+    snapshot=".cache/_pre-upgrade-${ts}.tar.gz"
+    snapshot_abs="$SNAPSHOT_DIR/_pre-upgrade-${ts}.tar.gz"
+
+    (
+      # Recreate the failure semantics inside the subshell: any error
+      # releases the lock and logs.
+      trap 'release_lock' EXIT
+      audit "APPLY start ref=$ref snapshot=$snapshot"
+
+      # Step 1: stop the mem container.
+      if ! docker stop -t 30 "$NOWLEDGE_MEM_CONTAINER" >/dev/null 2>&1; then
+        audit "APPLY stop failed"
+        exit 1
+      fi
+      audit "APPLY stopped"
+
+      # Step 2: atomic snapshot. Tar from /opt/snapshot (which has data
+      # and config bind-mounted RO). Exclude cache by virtue of not
+      # tarring it. Write .tmp first, then rename.
+      if ! tar -czf "${snapshot_abs}.tmp" -C /opt/snapshot data config 2>&1 \
+         | sed 's/^/tar: /' >&2 ; then
+        :
+      fi
+      if [ ! -s "${snapshot_abs}.tmp" ]; then
+        audit "APPLY snapshot failed — restarting mem on old image"
+        docker start "$NOWLEDGE_MEM_CONTAINER" >/dev/null 2>&1 || true
+        exit 2
+      fi
+      mv "${snapshot_abs}.tmp" "${snapshot_abs}"
+      audit "APPLY snapshot ok $(du -h "$snapshot_abs" | awk '{print $1}')"
+
+      # Step 3: rotate snapshots. Keep newest N.
+      # shellcheck disable=SC2012
+      ls -1t "$SNAPSHOT_DIR"/_pre-upgrade-*.tar.gz 2>/dev/null \
+        | tail -n +"$((NOWLEDGE_SNAPSHOT_RETAIN + 1))" \
+        | while read -r old; do
+            audit "APPLY rotate rm $(basename "$old")"
+            rm -f "$old"
+          done
+
+      # Step 4: persist the new tag to .env BEFORE the recreate. This way
+      # if the recreate succeeds, future `./nmemctl up`/`restart` calls
+      # use the new tag. If the recreate fails, the operator's recovery
+      # path (./nmemctl restore-app from the snapshot + ./nmemctl upgrade
+      # <old-tag>) will overwrite .env again. Atomic write via temp+mv.
+      env_file="/opt/compose/.env"
+      env_tmp="/opt/compose/.env.tmp.$$"
+      {
+        if [ -f "$env_file" ]; then
+          grep -Ev '^NMEM_IMAGE_TAG=' "$env_file" || true
+        fi
+        printf 'NMEM_IMAGE_TAG=%s\n' "$tag"
+      } > "$env_tmp"
+      mv "$env_tmp" "$env_file"
+      chmod 0600 "$env_file" 2>/dev/null || true
+
+      # Step 5: recreate from new tag. compose up -d with NMEM_IMAGE_TAG
+      # overridden in the calling environment. The operator's compose.yaml
+      # is templated as `image: ...:${NMEM_IMAGE_TAG:-X.Y.Z}` (the
+      # default in fresh installs from nmemctl 2.1.0+).
+      #
+      # Layered overlays (TLS, etc.) are picked up via NMEM_STATE_OVERLAYS,
+      # which `./nmemctl auto-update enable` records in .nmemctl-state.
+      # We deliberately do NOT source that file here — we ONLY recreate
+      # the mem service, which doesn't need the overlays' definitions to
+      # be present on the apply call. Operator-side restart will handle
+      # full-stack recreates.
+      export NMEM_IMAGE_TAG="$tag"
+      if ! docker compose -f /opt/compose/compose.yaml \
+              up -d --no-deps "$NOWLEDGE_MEM_SERVICE" >/dev/null 2>&1; then
+        audit "APPLY compose up failed — mem may be on old image"
+        exit 3
+      fi
+      audit "APPLY compose up ok (.env persisted NMEM_IMAGE_TAG=$tag), waiting for /livez"
+
+      # Step 6: wait for /livez green. Up to NOWLEDGE_LIVEZ_TIMEOUT_SECONDS.
+      deadline=$(( $(date +%s) + NOWLEDGE_LIVEZ_TIMEOUT_SECONDS ))
+      while :; do
+        if docker exec "$NOWLEDGE_MEM_CONTAINER" \
+             /opt/nowledge-mem/python/bin/python3 -c \
+             "import urllib.request,sys; sys.exit(0 if urllib.request.urlopen('http://127.0.0.1:14242/livez', timeout=4).status==200 else 1)" \
+             >/dev/null 2>&1; then
+          audit "APPLY done ref=$ref"
+          break
+        fi
+        if [ "$(date +%s)" -ge "$deadline" ]; then
+          audit "APPLY /livez never green within ${NOWLEDGE_LIVEZ_TIMEOUT_SECONDS}s — see snapshot $snapshot"
+          exit 4
+        fi
+        sleep 2
+      done
+    ) >&2 &
+    detached_pid=$!
+
+    body=$(jq -nc \
+      --arg ref "$ref" \
+      --arg snapshot "$snapshot" \
+      --arg pid "$detached_pid" \
+      '{accepted:true, ref:$ref, snapshot:$snapshot, pid:($pid|tonumber)}')
+    respond_json 202 "$body"
+    exit 0
+    ;;
+esac
+
+# ---- Unmatched route -----------------------------------------------------
+respond_json 404 '{"error":"not found"}'
+exit 0

--- a/docker/updater/server.sh
+++ b/docker/updater/server.sh
@@ -381,10 +381,24 @@ case "$method $path" in
       mv "${snapshot_abs}.tmp" "${snapshot_abs}"
       audit "APPLY snapshot ok $(du -h "$snapshot_abs" | awk '{print $1}')"
 
-      # Step 3: rotate snapshots. Keep newest N.
+      # Step 3: rotate snapshots. Keep newest N. Clamp retain to at least
+      # one so a misconfigured NOWLEDGE_SNAPSHOT_RETAIN=0 cannot delete
+      # the snapshot we just created before compose/livez have succeeded.
+      case "${NOWLEDGE_SNAPSHOT_RETAIN:-3}" in
+        ''|*[!0-9]*)
+          retain=3
+          ;;
+        *)
+          retain=$NOWLEDGE_SNAPSHOT_RETAIN
+          ;;
+      esac
+      if [ "$retain" -lt 1 ]; then
+        audit "APPLY snapshot retain=$retain adjusted to 1 for current rollback artifact"
+        retain=1
+      fi
       # shellcheck disable=SC2012
       ls -1t "$SNAPSHOT_DIR"/_pre-upgrade-*.tar.gz 2>/dev/null \
-        | tail -n +"$((NOWLEDGE_SNAPSHOT_RETAIN + 1))" \
+        | tail -n +"$((retain + 1))" \
         | while read -r old; do
             audit "APPLY rotate rm $(basename "$old")"
             rm -f "$old"
@@ -396,7 +410,17 @@ case "$method $path" in
       # path (./nmemctl restore-app from the snapshot + ./nmemctl upgrade
       # <old-tag>) will overwrite .env again. Atomic write via temp+mv.
       env_file="/opt/compose/.env"
+      env_backup="/tmp/nowledge-mem-env-before-upgrade.$$"
       env_tmp="/opt/compose/.env.tmp.$$"
+      old_tag_was_set=0
+      old_tag=""
+      if [ -f "$env_file" ]; then
+        cp "$env_file" "$env_backup"
+        old_tag=$(awk -F= '/^NMEM_IMAGE_TAG=/ {print $2}' "$env_file" | tail -n 1)
+        [ -n "$old_tag" ] && old_tag_was_set=1
+      else
+        : > "$env_backup"
+      fi
       {
         if [ -f "$env_file" ]; then
           grep -Ev '^NMEM_IMAGE_TAG=' "$env_file" || true
@@ -442,10 +466,10 @@ case "$method $path" in
       project_arg=""
       [ -n "$project" ] && project_arg="-p $project"
 
-      # cd into the compose project dir so:
-      #   - relative overlay paths ("-f compose.updater.yaml") resolve here,
-      #     not against the sidecar's /opt/updater workdir;
-      #   - compose auto-discovers .env from the project dir.
+      # cd into the compose project dir so relative overlay paths
+      # ("-f compose.updater.yaml") resolve here, not against the
+      # sidecar's /opt/updater workdir. Pass --env-file explicitly because
+      # --project-directory changes compose's default .env lookup base.
       # shellcheck disable=SC2086 — word-split $compose_overlays so
       # "-f a.yaml -f b.yaml" expands to multiple args.
       # --force-recreate stops + removes + creates fresh in one step.
@@ -463,14 +487,38 @@ case "$method $path" in
       # seeded by compose.updater.yaml from ${PWD} on the operator's shell.
       if ! ( cd /opt/compose && docker compose \
               --project-directory "$NOWLEDGE_COMPOSE_PROJECT_DIR" \
+              --env-file /opt/compose/.env \
               $project_arg -f compose.yaml $compose_overlays \
               up -d --no-deps --force-recreate "$NOWLEDGE_MEM_SERVICE" \
             ) 2>/tmp/compose-err-$$; then
         err=$(tr '\n' ' ' < /tmp/compose-err-$$ | head -c 400)
         rm -f /tmp/compose-err-$$
-        audit "APPLY compose up failed — mem may be on old image: $err"
+        cp "$env_backup" "$env_file" 2>/dev/null || true
+        chmod 0600 "$env_file" 2>/dev/null || true
+        if [ "$old_tag_was_set" -eq 1 ]; then
+          export NMEM_IMAGE_TAG="$old_tag"
+        else
+          unset NMEM_IMAGE_TAG
+        fi
+        if docker start "$NOWLEDGE_MEM_CONTAINER" >/dev/null 2>&1; then
+          audit "APPLY compose up failed — restored .env and restarted old container: $err"
+        elif ( cd /opt/compose && docker compose \
+                --project-directory "$NOWLEDGE_COMPOSE_PROJECT_DIR" \
+                --env-file /opt/compose/.env \
+                $project_arg -f compose.yaml $compose_overlays \
+                up -d --no-deps "$NOWLEDGE_MEM_SERVICE" \
+              ) >/tmp/compose-rollback-$$ 2>&1; then
+          rm -f /tmp/compose-rollback-$$
+          audit "APPLY compose up failed — restored .env and recreated old service: $err"
+        else
+          rollback_err=$(tr '\n' ' ' < /tmp/compose-rollback-$$ | head -c 400)
+          rm -f /tmp/compose-rollback-$$
+          audit "APPLY compose up failed; rollback attempt also failed: $err / rollback: $rollback_err"
+        fi
+        rm -f "$env_backup"
         exit 3
       fi
+      rm -f "$env_backup"
       rm -f /tmp/compose-err-$$
       audit "APPLY compose up ok (overlays=$compose_overlays, .env NMEM_IMAGE_TAG=$tag), waiting for /livez"
 

--- a/skills/nowledge-mem-docker/SKILL.md
+++ b/skills/nowledge-mem-docker/SKILL.md
@@ -132,6 +132,7 @@ How to guide the operator through enabling it (only after they ask for it, and a
 ```
 
 **Trust trade-off worth saying out loud:** auto-update adds a small sidecar container that holds `/var/run/docker.sock`. Docker socket access is host-root-equivalent for that container. The Mem container itself does NOT mount the socket; only the sidecar does. Per-deploy random token in `.env` (mode 0600). The sidecar is not exposed beyond the compose-internal network.
+`enable` also sets `NOWLEDGE_ADMIN_REMOTE_OPS=1`, because browser-triggered install is a server-side state change and must be an explicit operator opt-in.
 
 Before recommending `enable`, hand the operator that trade-off in one short sentence and let them decide.
 
@@ -142,7 +143,7 @@ Before recommending `enable`, hand the operator that trade-off in one short sent
 3. Server takes a volume-level snapshot of `./data` + `./config` to `./cache/_pre-upgrade-<ts>.tar.gz` (last 3 retained), then recreates the container on the new tag.
 4. Failure path: if `/livez` doesn't go green within 180s, the UI shows the snapshot path. SSH and roll back with `./nmemctl import ./cache/_pre-upgrade-<ts>.tar.gz --force` (volume-level snapshot uses the import verb, NOT restore-app).
 
-**Origin guard.** `/admin/upgrade/*` endpoints accept requests only from the same-host UI by default. If the operator wants to trigger upgrade from the desktop in remote mode or from `mem.nowledge.co`, they need to set `NOWLEDGE_ADMIN_REMOTE_OPS=1` on the server. Mention this if they ask "why doesn't it work from my desktop in remote mode".
+**Remote install opt-in.** `/admin/upgrade/check` is read-only, but `/admin/upgrade/download` and `/admin/upgrade/install` require loopback or `NOWLEDGE_ADMIN_REMOTE_OPS=1`. `./nmemctl auto-update enable` sets that flag; if the operator hand-edits compose files and skips nmemctl, mention it when install 403s from the browser.
 
 **What you DON'T do for auto-update:**
 - Don't `./nmemctl auto-update enable` without first surfacing the docker.sock trade-off.

--- a/skills/nowledge-mem-docker/SKILL.md
+++ b/skills/nowledge-mem-docker/SKILL.md
@@ -121,7 +121,7 @@ If `upgrade` fails midway, the previous image is still pulled locally. `./nmemct
 
 Some operators don't want to SSH every release. The headless deploy has an opt-in companion that lets them click Update from the web UI in Settings → About → Self-hosted server.
 
-How to enable on the operator's behalf (only when the operator asks for it, and AFTER you walk them through the trust trade-off):
+How to guide the operator through enabling it (only after they ask for it, and after you surface the trust trade-off):
 
 ```bash
 ./nmemctl auto-update enable    # generates token, adds sidecar, recreates stack
@@ -147,7 +147,7 @@ Before recommending `enable`, hand the operator that trade-off in one short sent
 **What you DON'T do for auto-update:**
 - Don't `./nmemctl auto-update enable` without first surfacing the docker.sock trade-off.
 - Don't click Install on their behalf from the web UI — the type-to-confirm exists to require the operator's own hand on the keyboard.
-- Don't recommend rotate without cause; if they did rotate, expect the desktop and other clients to need re-auth.
+- Don't recommend rotate without cause. Rotating only changes mem↔updater bearer auth and recreates the containers; desktop and other clients keep using the same API key.
 
 ## What to do when the user asks for `<thing>`
 

--- a/skills/nowledge-mem-docker/SKILL.md
+++ b/skills/nowledge-mem-docker/SKILL.md
@@ -117,6 +117,38 @@ The backend runs schema migrations on startup. **There is no downgrade path** �
 
 If `upgrade` fails midway, the previous image is still pulled locally. `./nmemctl restart` brings the container back up on the version listed in `compose.yaml`; check `./nmemctl version` to see which side of the bump it landed on.
 
+### Path C-bis — Click-to-update from the web UI (opt-in)
+
+Some operators don't want to SSH every release. The headless deploy has an opt-in companion that lets them click Update from the web UI in Settings → About → Self-hosted server.
+
+How to enable on the operator's behalf (only when the operator asks for it, and AFTER you walk them through the trust trade-off):
+
+```bash
+./nmemctl auto-update enable    # generates token, adds sidecar, recreates stack
+./nmemctl auto-update status    # state + last pull + retained snapshots
+./nmemctl auto-update disable   # remove the sidecar
+./nmemctl auto-update rotate    # rotate the token (recreates sidecar + mem)
+./nmemctl auto-update upgrade   # bump just the updater image
+```
+
+**Trust trade-off worth saying out loud:** auto-update adds a small sidecar container that holds `/var/run/docker.sock`. Docker socket access is host-root-equivalent for that container. The Mem container itself does NOT mount the socket; only the sidecar does. Per-deploy random token in `.env` (mode 0600). The sidecar is not exposed beyond the compose-internal network.
+
+Before recommending `enable`, hand the operator that trade-off in one short sentence and let them decide.
+
+**How the flow looks once enabled:**
+
+1. The web UI's title bar surfaces an "Install update" badge when a newer Mem image is published.
+2. Settings → About → Self-hosted server card lets the operator type-to-confirm the target version and click Install.
+3. Server takes a volume-level snapshot of `./data` + `./config` to `./cache/_pre-upgrade-<ts>.tar.gz` (last 3 retained), then recreates the container on the new tag.
+4. Failure path: if `/livez` doesn't go green within 180s, the UI shows the snapshot path. SSH and roll back with `./nmemctl import ./cache/_pre-upgrade-<ts>.tar.gz --force` (volume-level snapshot uses the import verb, NOT restore-app).
+
+**Origin guard.** `/admin/upgrade/*` endpoints accept requests only from the same-host UI by default. If the operator wants to trigger upgrade from the desktop in remote mode or from `mem.nowledge.co`, they need to set `NOWLEDGE_ADMIN_REMOTE_OPS=1` on the server. Mention this if they ask "why doesn't it work from my desktop in remote mode".
+
+**What you DON'T do for auto-update:**
+- Don't `./nmemctl auto-update enable` without first surfacing the docker.sock trade-off.
+- Don't click Install on their behalf from the web UI — the type-to-confirm exists to require the operator's own hand on the keyboard.
+- Don't recommend rotate without cause; if they did rotate, expect the desktop and other clients to need re-auth.
+
 ## What to do when the user asks for `<thing>`
 
 | User says... | You run... |
@@ -132,6 +164,10 @@ If `upgrade` fails midway, the previous image is still pulled locally. `./nmemct
 | "where is the data?" | Explain: three local directories next to `compose.yaml` — `./data` (graph + search index, irreplaceable), `./config` (license + API key + agent state, valuable), `./cache` (embeddings, rebuildable). Files are owned by UID 10001 inside the container; standard tools (`rsync`, `restic`, `tar`) work directly on the host. |
 | "back up my server", "snapshot before upgrade" | `./nmemctl export` — stops the container, tars the three dirs into `mem-export-<host>-<ts>.tar.gz`, restarts. For cross-version moves use `./nmemctl backup-app` instead (portable JSONL dump). |
 | "migrate this to another server" | Same-version: `./nmemctl export` here → copy archive → `./nmemctl import` on the new host. Cross-version or from a `.deb` install: `./nmemctl backup-app` → copy zip → `./nmemctl restore-app` on the new host. The new host gets a fresh device identity; license re-activates and consumes one seat. |
+| "let me update from the web UI" / "set up click-to-update" | `./nmemctl auto-update enable` — generates a per-deploy token, adds the updater sidecar to the compose stack, brings it up. After this, the web UI's title bar shows an "Install update" badge when a newer image is published; the operator clicks through type-to-confirm and Mem recreates itself in ~30s with a pre-stop snapshot to `./cache/_pre-upgrade-<ts>.tar.gz`. SSH is only needed for failure recovery. |
+| "is auto-update on?" | `./nmemctl auto-update status` — shows whether the sidecar is wired up, last scheduled pull, retained snapshots. Read-only. |
+| "rotate the updater token" | `./nmemctl auto-update rotate` — issues a new token, recreates BOTH the sidecar and mem so they share the new value. Run this if you think the token leaked. |
+| "turn off auto-update" | `./nmemctl auto-update disable` — removes the sidecar, clears the token from `.env`, drops the overlay from `.nmemctl-state`. Existing `_pre-upgrade-*.tar.gz` snapshots stay (delete them by hand if you want the disk back). |
 
 ## Handoff — what NOT to do
 
@@ -144,6 +180,7 @@ Treat the list below as a hard boundary, not as defaults that "advanced mode" ov
 | `./nmemctl wipe` | **Everything goes.** Removes the contents of `./data` (graph DB, search index, threads, memories — irreplaceable), `./config` (license activation, API key, device identity, agent state files), and `./cache` (downloaded embeddings, rebuildable but not free). The container is recreated empty. There is no undo. | The controller deliberately requires the operator to type `WIPE` literally at a TTY. That ceremony is the safeguard. |
 | `./nmemctl down` | Container stops. The three host directories are intact (no data loss), but every connected client — desktop app, MCP, remote `nmem` CLI, running agents — instantly fails. | The user owns the service-availability decision. Other things may be relying on it that you can't see. |
 | `./nmemctl restore-app <file>` | Imports a `backup-app` zip into the running container. Memories with the same id are overwritten in-place; existing-but-not-in-dump memories stay. Not a "factory reset", but it can still surprise the user if they thought the zip was a different timestamp. | The user owns the merge semantics decision. Confirm the source file's date/origin before running. |
+| `./nmemctl auto-update enable` | Adds a sidecar container that holds `/var/run/docker.sock`. Socket access is host-root-equivalent for that container. Not destructive on its own, but the operator should KNOW they're widening the trust boundary before doing it. | Trust shape decision: the operator chooses how much auto-update convenience is worth the docker.sock surface. Hand them the trade-off; let them flip the switch. |
 | `./nmemctl key --rotate` | The current API key is invalidated immediately. Every existing client must be re-authed with the new value before it can talk to the server. | Disruption-on-purpose. Only the user knows whether right now is a good time. |
 | `./nmemctl license activate <CODE>` | Activates a paid Pro license tied to a specific purchase. | Codes are personal. The user pastes their own. |
 | Editing `compose.yaml` by hand | Changes the contract for every subsequent `up`. Easy to wedge the deploy by adding a malformed env block or rebinding the port. | Walk through proposed changes as a diff for review; don't `sed` into the file silently. |


### PR DESCRIPTION
## Summary

Opt-in click-to-update sidecar for the headless Mem deployment. After
`./nmemctl auto-update enable`, the web UI surfaces an Update badge and
the operator can apply server upgrades with one button click instead of
SSH-ing in.

## What ships

- `docker/updater/` — sidecar image (alpine + docker-cli + socat + ~300 lines of shell). Exposes `GET /healthz`, `GET /status`, `POST /pull`, `POST /apply` to the mem backend over the compose-internal network.
- `docker/compose.updater.yaml` — opt-in overlay. No `depends_on` on mem so the main container boots even if docker.sock isn't usable (rootless docker, podman, locked socket).
- `docker/compose.yaml` — image tag now templated as `${NMEM_IMAGE_TAG:-X.Y.Z}` so `./nmemctl upgrade` and the sidecar can flip versions via `.env`.
- `docker/nmemctl` (2.1.0 → 2.2.0) — new `auto-update {enable, disable, status, rotate, upgrade}` verb family. `.nmemctl-state` persists overlay so future `up`/`restart` invocations are stable.
- `docker/README.md` — auto-update section: trust model, endpoints, origin guard, snapshot/restore.
- `skills/nowledge-mem-docker/SKILL.md` — bind-mount file tree.

## E2E verified on haswell

Five real bugs caught and fixed during a parallel-stack e2e:

1. HTTP/0.9 socat stderr folding (audit log into response body)
2. Missing reason phrase in status line
3. `docker.io/` prefix stripping for cached_tags filter
4. compose-up on apply ignored overlays + used wrong project name → broke TLS-enabled deploys
5. Lock TOCTOU race (PID liveness check defeated single-flight)

Plus /livez timeout 60s → 180s to match `compose.yaml`'s `start_period: 90s`.

Full happy-path e2e verified: image swap 0.8.4 → 0.8.4-rc6 in 8 seconds, 74KB snapshot written atomically, concurrent applies properly serialized (1×202 + 1×409 with `age_seconds`).

## Trust model worth reading

The sidecar mounts `/var/run/docker.sock` — that's why it's opt-in. The
mem container itself does NOT mount socket; only the sidecar does.
Per-deploy random token in `.env` (mode 0600). Sidecar is not exposed
beyond the compose-internal network.

## Test plan

- [ ] Pull `nowledgelabs/mem-updater:<rc>` after CI publishes (workflow is in mem-releases, separate PR)
- [ ] Run `./nmemctl auto-update enable` on a real deploy
- [ ] Click Download from the web UI, see badge update to "ready to install"
- [ ] Click Install with type-the-version confirm, verify version jump + snapshot file present
- [ ] Verify graceful degradation: stop the sidecar, confirm `/admin/upgrade/check` reports `auto_update_available: false` with reason

## Related

- Backend endpoints (private repo `nowledge-co/mem` PR)
- Release workflow (public repo `wey-gu/mem-releases` PR)
- Website docs already shipped to main

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Opt-in auto-update with CLI commands (enable/disable/rotate/status/upgrade) and web UI endpoints to check/pull/install updates via an updater sidecar.
  * Parameterized image tag support and non-blocking upgrade flow that creates pre-upgrade snapshots and performs background apply/recreate with health checks.
  * Background scheduler to periodically pre-pull images.

* **Documentation**
  * Expanded upgrade docs: versioning, migration behavior, recovery, and snapshot retention.

* **Chores**
  * Tooling bumped to v2.2.0.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/nowledge-co/community/pull/239)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Introduces an opt-in updater sidecar with `docker.sock` access and new token/remote-ops configuration, which materially expands the security/trust boundary and automates container recreation. Also changes upgrade/version-pinning behavior to rely on `.env`/persisted overlay state, which can affect upgrade reliability across existing deployments.
> 
> **Overview**
> Adds an *opt-in click-to-update* path for the headless Docker deploy via a new `compose.updater.yaml` overlay and a new `docker/updater/` sidecar image that can pre-pull images, take pre-upgrade snapshots, and recreate the `mem` service when triggered (token-authenticated over the internal compose network).
> 
> Updates `compose.yaml` and `./nmemctl upgrade` to pin the Mem image version through `.env` (`NMEM_IMAGE_TAG`) instead of rewriting `compose.yaml`, and introduces persisted overlay selection via `.nmemctl-state` plus a new `./nmemctl auto-update {enable|disable|status|rotate|upgrade}` command family (including token management and container recreate).
> 
> Documentation and ignore rules are updated to cover `.env`/state files, the new auto-update workflow, and its trust model/recovery steps.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d6079fc5f5d9f40f53c24e47b21ae52c1cd52296. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->