### PR TITLE
Handle fully quoted Codex MCP tables

### DIFF
--- a/integrations.json
+++ b/integrations.json
@@ -147,7 +147,7 @@
       "name": "Codex CLI",
       "category": "coding",
       "type": "plugin",
-      "version": "0.1.11",
+      "version": "0.1.12",
       "directory": "nowledge-mem-codex-plugin",
 
       "legacyDirectory": "nowledge-mem-codex-prompts",

--- a/nowledge-mem-codex-plugin/.codex-plugin/plugin.json
+++ b/nowledge-mem-codex-plugin/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "nowledge-mem",
-  "version": "0.1.11",
+  "version": "0.1.12",
   "description": "Your Codex agent remembers past decisions, finds relevant context, and learns from every session, across all your AI tools.",
   "skills": "./skills/",
   "mcpServers": "./.mcp.json",

--- a/nowledge-mem-codex-plugin/CHANGELOG.md
+++ b/nowledge-mem-codex-plugin/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [0.1.12] - 2026-05-15
+
+### Fixed
+
+- Codex setup now also recognizes fully quoted TOML MCP table headers such as `["mcp_servers"."nowledge-mem"]` as user-owned config. This prevents setup from appending a duplicate managed table when users already have a valid quoted Codex MCP block.
+
 ## [0.1.11] - 2026-05-15
 
 ### Fixed

--- a/nowledge-mem-codex-plugin/scripts/install_hooks.py
+++ b/nowledge-mem-codex-plugin/scripts/install_hooks.py
@@ -27,6 +27,7 @@ NOWLEDGE_HOOK_MARKERS = ("nowledge-mem-stop-save.py", "nmem-stop-save.py")
 MCP_MANAGED_BEGIN = "# BEGIN Nowledge Mem MCP (managed by nowledge-mem-codex-plugin)"
 MCP_MANAGED_END = "# END Nowledge Mem MCP"
 TOML_KEY_SEGMENT = r"(?:[A-Za-z0-9_-]+|\"(?:\\.|[^\"])*\"|'[^']*')"
+TOML_MCP_SERVERS_KEY = r"(?:mcp_servers|\"mcp_servers\"|'mcp_servers')"
 TOML_NOWLEDGE_MEM_KEY = r"(?:nowledge-mem|\"nowledge-mem\"|'nowledge-mem')"
 TOML_SECTION_HEADER_RE = re.compile(
     rf"^(?:\[\s*{TOML_KEY_SEGMENT}(?:\s*\.\s*{TOML_KEY_SEGMENT})*\s*\]"
@@ -34,7 +35,7 @@ TOML_SECTION_HEADER_RE = re.compile(
     r"\s*(?:#.*)?$"
 )
 NOWLEDGE_MCP_SECTION_RE = re.compile(
-    rf"^\s*\[\s*mcp_servers\s*\.\s*{TOML_NOWLEDGE_MEM_KEY}"
+    rf"^\s*\[\s*{TOML_MCP_SERVERS_KEY}\s*\.\s*{TOML_NOWLEDGE_MEM_KEY}"
     rf"(?:\s*\.\s*{TOML_KEY_SEGMENT})*\s*\]\s*(?:#.*)?$"
 )
 

--- a/nowledge-mem-codex-plugin/scripts/validate-plugin.mjs
+++ b/nowledge-mem-codex-plugin/scripts/validate-plugin.mjs
@@ -8,7 +8,7 @@ import { fileURLToPath } from "node:url";
 const scriptDir = path.dirname(fileURLToPath(import.meta.url));
 const pluginRoot = path.resolve(scriptDir, "..");
 const repoRoot = path.resolve(pluginRoot, "..");
-const expectedVersion = "0.1.11";
+const expectedVersion = "0.1.12";
 
 const fail = (message) => {
   console.error(`FAIL: ${message}`);

--- a/nowledge-mem-codex-plugin/tests/test_codex_plugin.py
+++ b/nowledge-mem-codex-plugin/tests/test_codex_plugin.py
@@ -346,6 +346,43 @@ class InstallHookTests(unittest.TestCase):
         self.assertNotIn(self.module.MCP_MANAGED_BEGIN, updated)
         self.assertNotIn("nmem_test", updated)
 
+    def test_install_codex_mcp_config_preserves_fully_quoted_user_owned_mcp_override(self):
+        self.module.CONFIG_FILE.parent.mkdir(parents=True, exist_ok=True)
+        self.module.CONFIG_FILE.write_text(
+            "\n".join(
+                [
+                    '["mcp_servers"."nowledge-mem"]',
+                    'url = "https://user.example/mcp/"',
+                    "",
+                    '["mcp_servers"."nowledge-mem".http_headers]',
+                    'APP = "Codex"',
+                    "",
+                ]
+            ),
+            encoding="utf-8",
+        )
+        payload = {
+            "apiKeyConfigured": True,
+            "warnings": [],
+            "rendered": "\n".join(
+                [
+                    "[mcp_servers.nowledge-mem]",
+                    'url = "http://127.0.0.1:14242/mcp/"',
+                    "",
+                    "[mcp_servers.nowledge-mem.http_headers]",
+                    'Authorization = "Bearer nmem_test"',
+                ]
+            ),
+        }
+
+        with mock.patch.object(self.module, "_load_codex_mcp_payload", return_value=payload):
+            self.assertFalse(self.module.install_codex_mcp_config())
+
+        updated = self.module.CONFIG_FILE.read_text(encoding="utf-8")
+        self.assertIn('["mcp_servers"."nowledge-mem"]', updated)
+        self.assertNotIn(self.module.MCP_MANAGED_BEGIN, updated)
+        self.assertNotIn("nmem_test", updated)
+
     def test_install_codex_mcp_config_skips_default_local_without_key(self):
         payload = {
             "apiKeyConfigured": False,


### PR DESCRIPTION
## Summary

Follow-up to #240 for a post-merge Codex review finding.

Changes:
- bump Codex plugin to `0.1.12`
- recognize fully quoted TOML MCP table roots such as `["mcp_servers"."nowledge-mem"]` as existing user-owned Nowledge Mem MCP config
- add a regression test so setup leaves that config untouched and does not append a managed duplicate table

## Validation

- `python3 -m unittest community/nowledge-mem-codex-plugin/tests/test_codex_plugin.py`
- `python3 -m py_compile community/nowledge-mem-codex-plugin/scripts/install_hooks.py community/nowledge-mem-codex-plugin/hooks/nmem-stop-save.py`
- `node community/nowledge-mem-codex-plugin/scripts/validate-plugin.mjs`
- `cd community && uv run --with pytest pytest tests/plugin_e2e -q`
- isolated `CODEX_HOME` installer smoke: config mode `0600`, `codex mcp list --json` reports `auth_status: "bearer_token"`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Updates the Codex plugin installer’s TOML table detection for `mcp_servers.nowledge-mem`, which affects whether user `~/.codex/config.toml` is modified; risk is limited but could impact setup behavior for edge-case configs.
> 
> **Overview**
> Prevents the Codex plugin setup from appending a duplicate **managed** MCP block when users already have a valid *fully quoted* TOML table like `["mcp_servers"."nowledge-mem"]`.
> 
> This updates the MCP section regex in `scripts/install_hooks.py`, adds a regression unit test for the fully quoted form, and bumps the Codex CLI integration/plugin version to `0.1.12` (including `validate-plugin.mjs` and `CHANGELOG`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a084c3243e5d8cce1c48068732742383421c193d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->