### PR TITLE
chore(docker): bump default version pins to 0.8.5

### DIFF
--- a/docker/README.md
+++ b/docker/README.md
@@ -296,7 +296,7 @@ public keys to download or rotate — verification uses the GitHub Actions OIDC
 identity that produced the build.
 
 ```bash
-cosign verify docker.io/nowledgelabs/mem:0.8.4 \
+cosign verify docker.io/nowledgelabs/mem:0.8.5 \
   --certificate-identity-regexp='https://github.com/nowledge-co/mem/.github/workflows/release-docker.yml@.*' \
   --certificate-oidc-issuer='https://token.actions.githubusercontent.com'
 ```
@@ -327,7 +327,7 @@ The image ships a multi-arch manifest for **`linux/amd64`** and
 If you need a specific arch, pin it explicitly:
 
 ```bash
-docker pull --platform linux/amd64 docker.io/nowledgelabs/mem:0.8.4
+docker pull --platform linux/amd64 docker.io/nowledgelabs/mem:0.8.5
 ```
 
 ---
@@ -428,7 +428,7 @@ the time you cloned; `self-update` may bump it but `.env` always wins.
 
 The backend runs schema migrations on startup. There is **no downgrade path**;
 once a newer image has opened the database, an older image will refuse to.
-Skipping versions (0.8.4 → 0.8.6 without 0.8.5) **is supported** — schema
+Skipping versions (0.8.5 → 0.8.7 without 0.8.6) **is supported** — schema
 migrations run forward in order on the new image's first boot.
 
 ### Click-to-update from the web UI (optional)
@@ -492,7 +492,7 @@ volume-level snapshot):
 
 ```bash
 # Roll back the image first (so the migration order matches):
-./nmemctl upgrade 0.8.4    # whatever version you were on
+./nmemctl upgrade 0.8.5    # whatever version you were on
 # Then restore the bind-mount directories from the snapshot:
 ./nmemctl import ./cache/_pre-upgrade-<ts>.tar.gz --force
 ```

--- a/docker/compose.updater.yaml
+++ b/docker/compose.updater.yaml
@@ -38,7 +38,7 @@ services:
       NOWLEDGE_UPDATER_TOKEN: ${NOWLEDGE_UPDATER_TOKEN:?run `./nmemctl auto-update enable` first}
 
   updater:
-    image: docker.io/nowledgelabs/mem-updater:${NMEM_UPDATER_TAG:-0.8.4}
+    image: docker.io/nowledgelabs/mem-updater:${NMEM_UPDATER_TAG:-0.8.5}
     container_name: nowledge-mem-updater
     restart: unless-stopped
 

--- a/docker/compose.yaml
+++ b/docker/compose.yaml
@@ -22,7 +22,7 @@
 #   NMEM_COMPOSE_FILES='-f compose.yaml -f compose.tls.yaml' ./nmemctl up
 #
 # Verify the image is signed by Nowledge Labs (anyone, anywhere):
-#   cosign verify docker.io/nowledgelabs/mem:0.8.4 \
+#   cosign verify docker.io/nowledgelabs/mem:0.8.5 \
 #     --certificate-identity-regexp='https://github.com/nowledge-co/mem/.github/workflows/release-docker.yml@.*' \
 #     --certificate-oidc-issuer='https://token.actions.githubusercontent.com'
 
@@ -32,7 +32,7 @@ services:
     # optional `./nmemctl auto-update` sidecar can flip versions by
     # writing `NMEM_IMAGE_TAG=<ver>` to `.env` (mode 0600, gitignored)
     # without rewriting this file. Fresh installs use the default.
-    image: docker.io/nowledgelabs/mem:${NMEM_IMAGE_TAG:-0.8.4}
+    image: docker.io/nowledgelabs/mem:${NMEM_IMAGE_TAG:-0.8.5}
     container_name: nowledge-mem
     restart: unless-stopped
     labels:


### PR DESCRIPTION
Routine version bump for the 0.8.5 hotfix release. Compose defaults, cosign examples, nmemctl upgrade examples, README version-skip example. Historical "Starting 0.8.4..." feature-introduction line preserved.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Docker image version references to 0.8.5 in compose configurations and documentation.

* **Documentation**
  * Updated examples and migration guides to reflect the latest version.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/nowledge-co/community/pull/242)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->