### PR TITLE
Fix OpenClaw per-turn thread capture

### DIFF
--- a/integrations.json
+++ b/integrations.json
@@ -313,7 +313,7 @@
       "name": "OpenClaw",
       "category": "coding",
       "type": "plugin",
-      "version": "0.8.23",
+      "version": "0.8.24",
       "directory": "nowledge-mem-openclaw-plugin",
       "transport": "cli",
       "capabilities": {

--- a/nowledge-mem-openclaw-plugin/CHANGELOG.md
+++ b/nowledge-mem-openclaw-plugin/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to the Nowledge Mem OpenClaw plugin will be documented in th
 
 ## Unreleased
 
+## [0.8.24] - 2026-05-15
+
+### Fixed
+
+- OpenClaw session capture now handles newer per-turn `agent_end` hook payloads from Codex app-server runtimes. The plugin no longer mistakes those shorter batches for transcript compaction, so continued turns keep syncing into the same Mem thread after an OpenClaw upgrade.
+- Captured Codex app-server messages now use OpenClaw's stable mirror identity for Mem-side dedupe, keeping Context Engine `afterTurn` and hook backstop capture idempotent when both paths see the same turn.
+- Capture setup no longer depends on runtime-only OpenClaw SDK imports, keeping the plugin loadable on existing OpenClaw installer builds while still matching the host session-key contract.
+
 ## [0.8.23] - 2026-05-02
 
 ### Fixed

--- a/nowledge-mem-openclaw-plugin/openclaw.plugin.json
+++ b/nowledge-mem-openclaw-plugin/openclaw.plugin.json
@@ -2,7 +2,7 @@
 	"id": "openclaw-nowledge-mem",
 	"name": "Nowledge Mem",
 	"description": "Cross-tool knowledge graph memory for OpenClaw with Working Memory, graph search, and session distillation.",
-  "version": "0.8.23",
+	"version": "0.8.24",
 	"kind": ["memory", "context-engine"],
 	"skills": [
 		"skills/memory-guide"

--- a/nowledge-mem-openclaw-plugin/package-lock.json
+++ b/nowledge-mem-openclaw-plugin/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "@nowledge/openclaw-nowledge-mem",
-	"version": "0.8.23",
+	"version": "0.8.24",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "@nowledge/openclaw-nowledge-mem",
-			"version": "0.8.23",
+			"version": "0.8.24",
 			"license": "MIT",
 			"devDependencies": {
 				"@biomejs/biome": "^1.9.0"

--- a/nowledge-mem-openclaw-plugin/package.json
+++ b/nowledge-mem-openclaw-plugin/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@nowledge/openclaw-nowledge-mem",
 	"displayName": "Nowledge Mem for OpenClaw",
-	"version": "0.8.23",
+	"version": "0.8.24",
 	"type": "module",
 	"description": "Nowledge Mem memory plugin for OpenClaw, local-first personal knowledge base",
 	"author": {

--- a/nowledge-mem-openclaw-plugin/src/hooks/capture.js
+++ b/nowledge-mem-openclaw-plugin/src/hooks/capture.js
@@ -1,9 +1,6 @@
-import { readFile } from "node:fs/promises";
 import { createHash } from "node:crypto";
-import { isCronSessionKey, isSubagentSessionKey } from "openclaw/plugin-sdk/routing";
-import {
-	buildStableThreadId,
-} from "./thread-identity.js";
+import { readFile } from "node:fs/promises";
+import { buildStableThreadId } from "./thread-identity.js";
 export {
 	_resetConversationRoots,
 	buildStableThreadId,
@@ -29,6 +26,38 @@ const _lastCaptureAt = new Map();
 const _MAX_COOLDOWN_ENTRIES = 200;
 const _syncedMessageCounts = new Map();
 const _MAX_SYNC_CURSOR_ENTRIES = 500;
+const CAPTURE_MESSAGE_MODE_AUTO = "auto";
+const CAPTURE_MESSAGE_MODE_SNAPSHOT = "snapshot";
+const CAPTURE_MESSAGE_MODE_DELTA = "delta";
+
+function parseAgentSessionKey(sessionKey) {
+	const raw = String(sessionKey || "")
+		.trim()
+		.toLowerCase();
+	if (!raw) return null;
+	const parts = raw.split(":").filter(Boolean);
+	if (parts.length < 3 || parts[0] !== "agent") return null;
+	const agentId = parts[1];
+	const rest = parts.slice(2).join(":");
+	if (!agentId || !rest) return null;
+	return { agentId, rest };
+}
+
+function isAgentCronSessionKey(sessionKey) {
+	const parsed = parseAgentSessionKey(sessionKey);
+	return parsed?.rest?.startsWith("cron:") === true;
+}
+
+function isSubagentSessionKey(sessionKey) {
+	const raw = String(sessionKey || "")
+		.trim()
+		.toLowerCase();
+	if (!raw) return false;
+	if (raw.startsWith("subagent:")) return true;
+	const parsed = parseAgentSessionKey(raw);
+	return parsed?.rest?.startsWith("subagent:") === true;
+}
+
 function _setLastCapture(threadId, now) {
 	_lastCaptureAt.set(threadId, now);
 	// Opportunistic eviction: sweep stale entries when map grows large
@@ -68,11 +97,7 @@ function _compileGlob(pattern) {
 	let re = _compiledPatterns.get(key);
 	if (!re) {
 		re = new RegExp(
-			"^" +
-				key
-					.replace(/[.+?^${}()|[\]\\]/g, "\\$&")
-					.replace(/\*/g, "[^:]*") +
-				"$",
+			`^${key.replace(/[.+?^${}()|[\]\\]/g, "\\$&").replace(/\*/g, "[^:]*")}$`,
 		);
 		_compiledPatterns.set(key, re);
 	}
@@ -95,12 +120,11 @@ export function matchesExcludePattern(sessionKey, patterns) {
 /**
  * Whether automatic thread capture should skip this OpenClaw session.
  *
- * - Agent-scoped cron / isolated-agent keys are classified by
- *   `isCronSessionKey` from `openclaw/plugin-sdk/routing` (same implementation
- *   the gateway uses). Requires OpenClaw >=2026.3.22.
+ * - Agent-scoped cron / isolated-agent keys follow OpenClaw's canonical
+ *   `agent:<id>:cron:*` session-key shape.
  * - Bare `cron:*` keys are still excluded: some internal paths (e.g. delivery /
  *   failure bookkeeping) use that shape without the `agent:` prefix, and
- *   `isCronSessionKey` only parses agent-scoped keys.
+ *   agent-scoped parsing intentionally does not classify bare keys.
  */
 export function isCronCaptureSessionKey(sessionKey) {
 	const raw = String(sessionKey || "")
@@ -108,7 +132,7 @@ export function isCronCaptureSessionKey(sessionKey) {
 		.toLowerCase();
 	if (!raw) return false;
 	if (raw.startsWith("cron:")) return true;
-	return isCronSessionKey(raw);
+	return isAgentCronSessionKey(raw);
 }
 
 /**
@@ -118,7 +142,8 @@ export function isCronCaptureSessionKey(sessionKey) {
  * Exported for reuse by Context Engine and other capture paths.
  */
 export function hasSkipMarker(messages, marker) {
-	if (!marker || typeof marker !== "string" || !Array.isArray(messages)) return false;
+	if (!marker || typeof marker !== "string" || !Array.isArray(messages))
+		return false;
 	const markerLc = marker.toLowerCase();
 	return messages.some((msg) => {
 		const text = extractText(msg?.content ?? msg?.message?.content);
@@ -225,17 +250,45 @@ export function normalizeRoleMessage(
 		timestamp = msg.timestamp;
 	}
 
+	const openclawMeta =
+		msg.__openclaw && typeof msg.__openclaw === "object"
+			? msg.__openclaw
+			: raw.__openclaw && typeof raw.__openclaw === "object"
+				? raw.__openclaw
+				: null;
+	const msgMetadata =
+		msg.metadata && typeof msg.metadata === "object" ? msg.metadata : null;
+	const rawMetadata =
+		raw.metadata && typeof raw.metadata === "object" ? raw.metadata : null;
 	const externalHint = [
+		openclawMeta?.mirrorIdentity,
+		openclawMeta?.idempotencyKey,
+		msg.idempotencyKey,
+		msg.idempotency_key,
 		msg.external_id,
 		msg.externalId,
 		msg.message_id,
 		msg.messageId,
+		msg.openclaw_entry_id,
+		msg.openclawEntryId,
 		msg.id,
+		raw.idempotencyKey,
+		raw.idempotency_key,
 		raw.external_id,
 		raw.externalId,
 		raw.message_id,
 		raw.messageId,
+		raw.openclaw_entry_id,
+		raw.openclawEntryId,
 		raw.id,
+		msgMetadata?.external_id,
+		msgMetadata?.externalId,
+		msgMetadata?.message_id,
+		msgMetadata?.messageId,
+		rawMetadata?.external_id,
+		rawMetadata?.externalId,
+		rawMetadata?.message_id,
+		rawMetadata?.messageId,
 	]
 		.find((v) => typeof v === "string" && v.trim().length > 0)
 		?.trim();
@@ -263,11 +316,30 @@ function sanitizeIdPart(input, max = 48) {
 	return normalized.slice(0, max);
 }
 
-function buildExternalId({ normalized, index, threadId, sessionKey }) {
+function buildExternalId({
+	normalized,
+	index,
+	threadId,
+	sessionKey,
+	event,
+	ctx,
+	messageMode,
+}) {
 	if (normalized.externalHint) {
 		return `oc:${sanitizeIdPart(normalized.externalHint, 96)}`;
 	}
-	const seed = `${threadId}|${sessionKey}|${index}|${normalized.role}|${normalized.content}`;
+	const runId =
+		messageMode === CAPTURE_MESSAGE_MODE_DELTA
+			? String(ctx?.runId || event?.runId || "").trim()
+			: "";
+	const seed = [
+		threadId,
+		sessionKey,
+		runId ? `run:${runId}` : "",
+		index,
+		normalized.role,
+		normalized.content,
+	].join("|");
 	const digest = createHash("sha1").update(seed).digest("hex");
 	return `oc-msg:${digest}`;
 }
@@ -284,6 +356,18 @@ function buildAppendIdempotencyKey(threadId, reason, messages) {
 			: [],
 	};
 	return `oc-batch:${createHash("sha1").update(JSON.stringify(seed)).digest("hex")}`;
+}
+
+function hasStableExternalHints(normalized) {
+	return (
+		Array.isArray(normalized) &&
+		normalized.length > 0 &&
+		normalized.every(
+			(message) =>
+				typeof message?.externalHint === "string" &&
+				message.externalHint.trim().length > 0,
+		)
+	);
 }
 
 async function loadMessagesFromSessionFile(sessionFile) {
@@ -328,6 +412,7 @@ export async function appendOrCreateThread({
 	reason,
 	maxMessageChars = DEFAULT_MAX_MESSAGE_CHARS,
 	resolvedMessages,
+	messageMode = CAPTURE_MESSAGE_MODE_SNAPSHOT,
 }) {
 	const rawMessages = resolvedMessages ?? (await resolveHookMessages(event));
 	if (!Array.isArray(rawMessages) || rawMessages.length === 0) return;
@@ -341,28 +426,100 @@ export async function appendOrCreateThread({
 		.filter(Boolean);
 	if (normalized.length === 0) return;
 
-	const allMessages = normalized.map((message, index) => ({
-		role: message.role,
-		content: message.content,
-		timestamp: message.timestamp,
-		metadata: {
-			external_id: buildExternalId({
-				normalized: message,
-				index,
-				threadId,
-				sessionKey,
-			}),
-			source: "openclaw",
-			session_key: sessionKey,
-			session_id: sessionId || undefined,
-		},
-	}));
+	const buildMessages = (resolvedMessageMode) =>
+		normalized.map((message, index) => ({
+			role: message.role,
+			content: message.content,
+			timestamp: message.timestamp,
+			metadata: {
+				external_id: buildExternalId({
+					normalized: message,
+					index,
+					threadId,
+					sessionKey,
+					event,
+					ctx,
+					messageMode: resolvedMessageMode,
+				}),
+				source: "openclaw",
+				session_key: sessionKey,
+				session_id: sessionId || undefined,
+			},
+		}));
+
+	let allMessages = buildMessages(
+		messageMode === CAPTURE_MESSAGE_MODE_DELTA
+			? CAPTURE_MESSAGE_MODE_DELTA
+			: CAPTURE_MESSAGE_MODE_SNAPSHOT,
+	);
 
 	let syncedCount = _syncedMessageCounts.get(threadId);
 	if (syncedCount === undefined) {
 		syncedCount = await client.getThreadMessageCount(threadId);
 		if (syncedCount !== null) {
 			_setSyncedMessageCount(threadId, syncedCount);
+		}
+	}
+
+	const resolvedMessageMode =
+		messageMode === CAPTURE_MESSAGE_MODE_DELTA ||
+		(messageMode === CAPTURE_MESSAGE_MODE_AUTO &&
+			(hasStableExternalHints(normalized) ||
+				(typeof syncedCount === "number" && syncedCount > allMessages.length)))
+			? CAPTURE_MESSAGE_MODE_DELTA
+			: CAPTURE_MESSAGE_MODE_SNAPSHOT;
+	if (resolvedMessageMode === CAPTURE_MESSAGE_MODE_DELTA) {
+		allMessages = buildMessages(CAPTURE_MESSAGE_MODE_DELTA);
+		const idempotencyKey = buildAppendIdempotencyKey(
+			threadId,
+			reason,
+			allMessages,
+		);
+		try {
+			const appended = await client.appendThread({
+				threadId,
+				messages: allMessages,
+				deduplicate: true,
+				idempotencyKey,
+			});
+			const added = appended.messagesAdded ?? 0;
+			const total =
+				Number.isFinite(appended.totalMessages) && appended.totalMessages >= 0
+					? appended.totalMessages
+					: typeof syncedCount === "number"
+						? syncedCount + added
+						: allMessages.length;
+			_setSyncedMessageCount(threadId, total);
+			logger.info(
+				`capture: appended ${added} delta messages to ${threadId} (${reason || "event"})`,
+			);
+			return { threadId, normalized, messagesAdded: added };
+		} catch (err) {
+			if (!client.isThreadNotFoundError(err)) {
+				const message = err instanceof Error ? err.message : String(err);
+				logger.warn(
+					`capture: thread append failed for ${threadId}: ${message}`,
+				);
+				return null;
+			}
+		}
+
+		try {
+			const createdId = await client.createThread({
+				threadId,
+				title,
+				messages: allMessages,
+				source: "openclaw",
+			});
+			_setSyncedMessageCount(threadId, allMessages.length);
+			logger.info(
+				`capture: created thread ${createdId} with ${allMessages.length} delta messages (${reason || "event"})`,
+			);
+			return { threadId, normalized, messagesAdded: allMessages.length };
+		} catch (err) {
+			const message = err instanceof Error ? err.message : String(err);
+			logger.warn(`capture: thread create failed for ${threadId}: ${message}`);
+			return null;
 		}
 	}
 
@@ -563,9 +720,7 @@ export function buildAgentEndCaptureHandler(client, cfg, logger) {
 		// Layer 2: marker-based exclusion (user typed #nmem-skip in conversation)
 		const resolvedMessages = await resolveHookMessages(event);
 		if (hasSkipMarker(resolvedMessages, cfg.captureSkipMarker)) {
-			logger.debug?.(
-				`capture: skipped session with skip marker ${sessionKey}`,
-			);
+			logger.debug?.(`capture: skipped session with skip marker ${sessionKey}`);
 			return;
 		}
 
@@ -577,6 +732,7 @@ export function buildAgentEndCaptureHandler(client, cfg, logger) {
 			reason: "agent_end",
 			maxMessageChars: cfg.maxThreadMessageChars,
 			resolvedMessages,
+			messageMode: CAPTURE_MESSAGE_MODE_AUTO,
 		});
 
 		await triageAndDistill({ client, cfg, logger, captureResult, ctx });
@@ -614,9 +770,7 @@ export function buildBeforeResetCaptureHandler(client, cfg, logger) {
 		// Layer 2: marker-based exclusion
 		const resolvedMessages = await resolveHookMessages(event);
 		if (hasSkipMarker(resolvedMessages, cfg.captureSkipMarker)) {
-			logger.debug?.(
-				`capture: skipped session with skip marker ${sessionKey}`,
-			);
+			logger.debug?.(`capture: skipped session with skip marker ${sessionKey}`);
 			return;
 		}
 

--- a/nowledge-mem-openclaw-plugin/src/hooks/capture.js
+++ b/nowledge-mem-openclaw-plugin/src/hooks/capture.js
@@ -464,8 +464,7 @@ export async function appendOrCreateThread({
 	const resolvedMessageMode =
 		messageMode === CAPTURE_MESSAGE_MODE_DELTA ||
 		(messageMode === CAPTURE_MESSAGE_MODE_AUTO &&
-			(hasStableExternalHints(normalized) ||
-				(typeof syncedCount === "number" && syncedCount > allMessages.length)))
+			hasStableExternalHints(normalized))
 			? CAPTURE_MESSAGE_MODE_DELTA
 			: CAPTURE_MESSAGE_MODE_SNAPSHOT;
 	if (resolvedMessageMode === CAPTURE_MESSAGE_MODE_DELTA) {

--- a/nowledge-mem-openclaw-plugin/tests/capture-append-mode.test.mjs
+++ b/nowledge-mem-openclaw-plugin/tests/capture-append-mode.test.mjs
@@ -235,6 +235,31 @@ test("snapshot capture still treats a shorter transcript as compaction shrink", 
 	assert.equal(client.createCalls.length, 0);
 });
 
+test("auto capture requires stable identities before treating a short batch as delta", async () => {
+	const client = new FakeThreadClient({ existingCount: 6 });
+	const result = await appendOrCreateThread({
+		client,
+		logger,
+		event: {
+			messages: [
+				message("user", "short prompt without host identity"),
+				message("assistant", "short answer without host identity"),
+			],
+		},
+		ctx: {
+			sessionId: "session-auto-short-unknown",
+			sessionKey: "agent:main:telegram:direct:auto-short-unknown",
+			runId: "run-2",
+		},
+		reason: "agent_end",
+		messageMode: "auto",
+	});
+
+	assert.equal(result.messagesAdded, 0);
+	assert.equal(client.appendCalls.length, 0);
+	assert.equal(client.createCalls.length, 0);
+});
+
 test("snapshot capture appends only the tail of full-transcript hook payloads", async () => {
 	const client = new FakeThreadClient({ existingCount: 2 });
 	const result = await appendOrCreateThread({

--- a/nowledge-mem-openclaw-plugin/tests/capture-append-mode.test.mjs
+++ b/nowledge-mem-openclaw-plugin/tests/capture-append-mode.test.mjs
@@ -1,0 +1,275 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+	appendOrCreateThread,
+	normalizeRoleMessage,
+} from "../src/hooks/capture.js";
+
+const logger = {
+	info() {},
+	warn() {},
+	debug() {},
+};
+
+function message(role, content, extra = {}) {
+	return {
+		role,
+		content,
+		...extra,
+	};
+}
+
+class FakeThreadClient {
+	constructor({ existingCount = null, existingExternalIds = [] } = {}) {
+		this.existingCount = existingCount;
+		this.existingExternalIds = new Set(existingExternalIds);
+		this.appendCalls = [];
+		this.createCalls = [];
+	}
+
+	async getThreadMessageCount() {
+		return this.existingCount;
+	}
+
+	async appendThread(request) {
+		this.appendCalls.push(request);
+		const messagesToAdd = request.deduplicate
+			? request.messages.filter((message) => {
+					const externalId = message?.metadata?.external_id;
+					if (typeof externalId !== "string" || !externalId) return true;
+					if (this.existingExternalIds.has(externalId)) return false;
+					this.existingExternalIds.add(externalId);
+					return true;
+				})
+			: request.messages;
+		const messagesAdded = messagesToAdd.length;
+		const totalMessages =
+			typeof this.existingCount === "number"
+				? this.existingCount + messagesAdded
+				: messagesAdded;
+		this.existingCount = totalMessages;
+		return { messagesAdded, totalMessages };
+	}
+
+	async createThread(request) {
+		this.createCalls.push(request);
+		this.existingCount = request.messages.length;
+		return request.threadId;
+	}
+
+	isThreadNotFoundError(error) {
+		return error?.code === "thread_not_found";
+	}
+}
+
+test("auto capture appends latest OpenClaw Codex per-turn agent_end batches", async () => {
+	const client = new FakeThreadClient({ existingCount: 6 });
+	const result = await appendOrCreateThread({
+		client,
+		logger,
+		event: {
+			messages: [
+				message("user", "continue", {
+					__openclaw: { mirrorIdentity: "turn-2:prompt" },
+				}),
+				message("assistant", [{ type: "text", text: "done" }], {
+					__openclaw: { mirrorIdentity: "turn-2:assistant" },
+				}),
+			],
+			success: true,
+		},
+		ctx: {
+			sessionId: "session-auto-delta",
+			sessionKey: "agent:main:telegram:direct:auto-delta",
+			runId: "run-2",
+		},
+		reason: "agent_end",
+		messageMode: "auto",
+	});
+
+	assert.equal(result.messagesAdded, 2);
+	assert.equal(client.createCalls.length, 0);
+	assert.equal(client.appendCalls.length, 1);
+	assert.deepEqual(
+		client.appendCalls[0].messages.map((msg) => msg.metadata.external_id),
+		["oc:turn-2-prompt", "oc:turn-2-assistant"],
+	);
+});
+
+test("auto capture appends same-length Codex per-turn batches when messages have stable identities", async () => {
+	const client = new FakeThreadClient({ existingCount: 2 });
+	const result = await appendOrCreateThread({
+		client,
+		logger,
+		event: {
+			messages: [
+				message("user", "repeat the next step", {
+					__openclaw: { mirrorIdentity: "turn-2:prompt" },
+				}),
+				message("assistant", "next step", {
+					__openclaw: { mirrorIdentity: "turn-2:assistant" },
+				}),
+			],
+			success: true,
+		},
+		ctx: {
+			sessionId: "session-auto-equal-delta",
+			sessionKey: "agent:main:telegram:direct:auto-equal-delta",
+			runId: "run-2",
+		},
+		reason: "agent_end",
+		messageMode: "auto",
+	});
+
+	assert.equal(result.messagesAdded, 2);
+	assert.equal(client.appendCalls.length, 1);
+	assert.deepEqual(
+		client.appendCalls[0].messages.map((msg) => msg.metadata.external_id),
+		["oc:turn-2-prompt", "oc:turn-2-assistant"],
+	);
+});
+
+test("auto capture appends all stable per-turn Codex messages even when the batch is longer than the synced prefix", async () => {
+	const client = new FakeThreadClient({ existingCount: 2 });
+	const result = await appendOrCreateThread({
+		client,
+		logger,
+		event: {
+			messages: [
+				message("user", "run tools", {
+					__openclaw: { mirrorIdentity: "turn-2:prompt" },
+				}),
+				message("assistant", "reasoning", {
+					__openclaw: { mirrorIdentity: "turn-2:reasoning" },
+				}),
+				message("assistant", "tool result", {
+					__openclaw: { mirrorIdentity: "turn-2:tool:call-1:result" },
+				}),
+				message("assistant", "done", {
+					__openclaw: { mirrorIdentity: "turn-2:assistant" },
+				}),
+			],
+			success: true,
+		},
+		ctx: {
+			sessionId: "session-auto-longer-delta",
+			sessionKey: "agent:main:telegram:direct:auto-longer-delta",
+			runId: "run-2",
+		},
+		reason: "agent_end",
+		messageMode: "auto",
+	});
+
+	assert.equal(result.messagesAdded, 4);
+	assert.equal(client.appendCalls.length, 1);
+	assert.deepEqual(
+		client.appendCalls[0].messages.map((msg) => msg.metadata.external_id),
+		[
+			"oc:turn-2-prompt",
+			"oc:turn-2-reasoning",
+			"oc:turn-2-tool-call-1-result",
+			"oc:turn-2-assistant",
+		],
+	);
+});
+
+test("auto capture remains idempotent when a stable full transcript is emitted", async () => {
+	const client = new FakeThreadClient({
+		existingCount: 2,
+		existingExternalIds: ["oc:turn-1-prompt", "oc:turn-1-assistant"],
+	});
+	const result = await appendOrCreateThread({
+		client,
+		logger,
+		event: {
+			messages: [
+				message("user", "first", {
+					__openclaw: { mirrorIdentity: "turn-1:prompt" },
+				}),
+				message("assistant", "second", {
+					__openclaw: { mirrorIdentity: "turn-1:assistant" },
+				}),
+				message("user", "third", {
+					__openclaw: { mirrorIdentity: "turn-2:prompt" },
+				}),
+				message("assistant", "fourth", {
+					__openclaw: { mirrorIdentity: "turn-2:assistant" },
+				}),
+			],
+		},
+		ctx: {
+			sessionId: "session-auto-full-snapshot",
+			sessionKey: "agent:main:telegram:direct:auto-full-snapshot",
+			runId: "run-2",
+		},
+		reason: "agent_end",
+		messageMode: "auto",
+	});
+
+	assert.equal(result.messagesAdded, 2);
+	assert.equal(client.appendCalls.length, 1);
+	assert.equal(client.appendCalls[0].messages.length, 4);
+});
+
+test("snapshot capture still treats a shorter transcript as compaction shrink", async () => {
+	const client = new FakeThreadClient({ existingCount: 6 });
+	const result = await appendOrCreateThread({
+		client,
+		logger,
+		event: {
+			messages: [
+				message("user", "summarized prompt"),
+				message("assistant", "summarized answer"),
+			],
+		},
+		ctx: {
+			sessionId: "session-compacted",
+			sessionKey: "agent:main:telegram:direct:compacted",
+		},
+		reason: "after_compaction",
+	});
+
+	assert.equal(result.messagesAdded, 0);
+	assert.equal(client.appendCalls.length, 0);
+	assert.equal(client.createCalls.length, 0);
+});
+
+test("snapshot capture appends only the tail of full-transcript hook payloads", async () => {
+	const client = new FakeThreadClient({ existingCount: 2 });
+	const result = await appendOrCreateThread({
+		client,
+		logger,
+		event: {
+			messages: [
+				message("user", "first"),
+				message("assistant", "second"),
+				message("user", "third"),
+				message("assistant", "fourth"),
+			],
+		},
+		ctx: {
+			sessionId: "session-snapshot",
+			sessionKey: "agent:main:telegram:direct:snapshot",
+		},
+		reason: "agent_end",
+	});
+
+	assert.equal(result.messagesAdded, 2);
+	assert.equal(client.appendCalls.length, 1);
+	assert.deepEqual(
+		client.appendCalls[0].messages.map((msg) => msg.content),
+		["third", "fourth"],
+	);
+});
+
+test("OpenClaw mirror identity wins over transcript idempotency key for stable dedupe", () => {
+	const normalized = normalizeRoleMessage({
+		role: "user",
+		content: "hello",
+		idempotencyKey: "codex-app-server:thread-a:turn-1:prompt",
+		__openclaw: { mirrorIdentity: "turn-1:prompt" },
+	});
+
+	assert.equal(normalized.externalHint, "turn-1:prompt");
+});

--- a/tests/plugin_e2e/test_key_plugins_e2e.py
+++ b/tests/plugin_e2e/test_key_plugins_e2e.py
@@ -58,6 +58,28 @@ def _nmem_json(args: list[str], *, env: dict[str, str], timeout: int = 30) -> An
     return json.loads(stdout) if stdout else {}
 
 
+def _delete_marker_data(*, marker: str, space: str, env: dict[str, str]) -> None:
+    # Host hooks can flush a thread a moment after a failed assertion. Cleanup
+    # therefore does a short best-effort sweep before deleting the temporary
+    # space, instead of assuming data is already visible on the first search.
+    for attempt in range(5):
+        deleted_any = False
+        search = _nmem_json(["t", "search", marker, "--space", space, "-n", "50"], env=env)
+        for thread in search.get("threads", []):
+            thread_id = thread.get("id")
+            if thread_id:
+                _run(["nmem", "t", "delete", thread_id, "--space", space, "-f"], env=env, timeout=30)
+                deleted_any = True
+        memories = _nmem_json(["m", "search", marker, "--space", space, "-n", "50"], env=env)
+        memory_ids = [memory.get("id") for memory in memories.get("memories", []) if memory.get("id")]
+        if memory_ids:
+            _run(["nmem", "m", "delete", *memory_ids, "--space", space, "-f"], env=env, timeout=30)
+            deleted_any = True
+        if not deleted_any and attempt >= 1:
+            return
+        time.sleep(2)
+
+
 def _bool_env(name: str, *, default: bool = False) -> bool:
     value = os.environ.get(name)
     if value is None:
@@ -141,15 +163,7 @@ def e2e_context() -> E2EContext:
     if _bool_env("NMEM_E2E_KEEP_DATA"):
         return
     try:
-        search = _nmem_json(["t", "search", marker, "--space", space, "-n", "50"], env=env)
-        for thread in search.get("threads", []):
-            thread_id = thread.get("id")
-            if thread_id:
-                _run(["nmem", "t", "delete", thread_id, "--space", space, "-f"], env=env, timeout=30)
-        memories = _nmem_json(["m", "search", marker, "--space", space, "-n", "50"], env=env)
-        memory_ids = [memory.get("id") for memory in memories.get("memories", []) if memory.get("id")]
-        if memory_ids:
-            _run(["nmem", "m", "delete", *memory_ids, "--space", space, "-f"], env=env, timeout=30)
+        _delete_marker_data(marker=marker, space=space, env=env)
     finally:
         if owns_space:
             _run(
@@ -558,13 +572,9 @@ def test_openclaw_live_hooks_and_context_engine_capture(e2e_context: E2EContext,
             "*.log",
         ),
     )
-    # OpenClaw profiles isolate config, not the installed extension directory.
-    # Install a package-shaped copy with --force so the safety scanner sees what
-    # users receive from npm/ClawHub instead of checkout-only test fixtures.
-    _run([*base, "plugins", "install", str(plugin_copy), "--force"], env=e2e_context.env, timeout=120)
-
     default_config = Path.home() / ".openclaw" / "openclaw.json"
     default_config_backup = default_config.read_bytes() if not profile and default_config.exists() else None
+    default_config_existed = default_config_backup is not None
     config_ops: list[dict[str, Any]] = [
         {"path": "plugins.entries.openclaw-nowledge-mem.enabled", "value": True},
         {"path": "plugins.entries.openclaw-nowledge-mem.config.sessionDigest", "value": True},
@@ -591,6 +601,10 @@ def test_openclaw_live_hooks_and_context_engine_capture(e2e_context: E2EContext,
     batch_file = tmp_path / "openclaw-config.json"
     batch_file.write_text(json.dumps(config_ops), encoding="utf-8")
     try:
+        # OpenClaw profiles isolate config, not the installed extension directory.
+        # Install a package-shaped copy with --force so the safety scanner sees what
+        # users receive from npm/ClawHub instead of checkout-only test fixtures.
+        _run([*base, "plugins", "install", str(plugin_copy), "--force"], env=e2e_context.env, timeout=120)
         _run([*base, "config", "set", "--batch-file", str(batch_file)], env=e2e_context.env, timeout=60)
 
         prompt = f"Reply with exactly: done {e2e_context.marker}"
@@ -610,7 +624,6 @@ def test_openclaw_live_hooks_and_context_engine_capture(e2e_context: E2EContext,
             env=e2e_context.env,
             timeout=int(os.environ.get("NMEM_E2E_OPENCLAW_TIMEOUT_SECONDS", "180")) + 30,
         )
-        assert e2e_context.marker in (result.stdout + result.stderr)
         _poll_thread(
             marker=e2e_context.marker,
             source="openclaw",
@@ -620,6 +633,8 @@ def test_openclaw_live_hooks_and_context_engine_capture(e2e_context: E2EContext,
     finally:
         if default_config_backup is not None:
             default_config.write_bytes(default_config_backup)
+        elif not profile and not default_config_existed and default_config.exists():
+            default_config.unlink()
 
 
 @pytest.mark.skipif(_skip_live_host("hermes"), reason="Hermes live E2E not requested")

--- a/tests/plugin_e2e/test_key_plugins_e2e.py
+++ b/tests/plugin_e2e/test_key_plugins_e2e.py
@@ -64,17 +64,30 @@ def _delete_marker_data(*, marker: str, space: str, env: dict[str, str]) -> None
     # space, instead of assuming data is already visible on the first search.
     for attempt in range(5):
         deleted_any = False
-        search = _nmem_json(["t", "search", marker, "--space", space, "-n", "50"], env=env)
-        for thread in search.get("threads", []):
-            thread_id = thread.get("id")
-            if thread_id:
-                _run(["nmem", "t", "delete", thread_id, "--space", space, "-f"], env=env, timeout=30)
-                deleted_any = True
-        memories = _nmem_json(["m", "search", marker, "--space", space, "-n", "50"], env=env)
-        memory_ids = [memory.get("id") for memory in memories.get("memories", []) if memory.get("id")]
-        if memory_ids:
-            _run(["nmem", "m", "delete", *memory_ids, "--space", space, "-f"], env=env, timeout=30)
-            deleted_any = True
+        try:
+            search = _nmem_json(["t", "search", marker, "--space", space, "-n", "50"], env=env)
+            for thread in search.get("threads", []):
+                thread_id = thread.get("id")
+                if not thread_id:
+                    continue
+                try:
+                    _run(["nmem", "t", "delete", thread_id, "--space", space, "-f"], env=env, timeout=30)
+                    deleted_any = True
+                except Exception:
+                    pass
+        except Exception:
+            pass
+        try:
+            memories = _nmem_json(["m", "search", marker, "--space", space, "-n", "50"], env=env)
+            memory_ids = [memory.get("id") for memory in memories.get("memories", []) if memory.get("id")]
+            if memory_ids:
+                try:
+                    _run(["nmem", "m", "delete", *memory_ids, "--space", space, "-f"], env=env, timeout=30)
+                    deleted_any = True
+                except Exception:
+                    pass
+        except Exception:
+            pass
         if not deleted_any and attempt >= 1:
             return
         time.sleep(2)


### PR DESCRIPTION
## Summary
- bump OpenClaw plugin to 0.8.24
- treat stable Codex `agent_end` payloads as delta capture so newer OpenClaw per-turn batches keep syncing
- preserve OpenClaw mirror identities for Mem-side dedupe across Context Engine and hook fallback
- harden the live OpenClaw E2E cleanup/config restore path

## Validation
- `cd nowledge-mem-openclaw-plugin && npm test`
- `cd nowledge-mem-openclaw-plugin && npm run validate`
- `cd nowledge-mem-openclaw-plugin && npm pack --dry-run`
- `uv run --with pytest pytest tests/plugin_e2e -q`
- `node nowledge-mem-codex-plugin/scripts/validate-plugin.mjs`
- live OpenClaw E2E: `NMEM_PLUGIN_E2E=1 NMEM_PLUGIN_E2E_HOSTS=openclaw ... uv run --with pytest pytest tests/plugin_e2e -q -s` -> `4 passed, 4 skipped`; Mem/OpenClaw config hashes restored unchanged

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  - Fixed thread synchronization issues that could occur after OpenClaw upgrades by improving handling of per-turn hook payload batching
  - Enhanced message capture deduplication and idempotency using stable identity mechanisms for more reliable message tracking

* **Chores**
  - Version updated to 0.8.24

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/nowledge-co/community/pull/246)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes OpenClaw thread-capture dedupe/append logic to treat newer per-turn `agent_end` batches as delta appends and alters external-id generation; regressions could cause missed or duplicate thread messages.
> 
> **Overview**
> Fixes OpenClaw session capture so newer Codex app-server per-turn `agent_end` hook payloads are treated as **delta appends** (vs being misread as transcript compaction), keeping subsequent turns syncing into the same Mem thread.
> 
> Improves message idempotency by deriving `external_id` from OpenClaw-provided stable identities (e.g. `__openclaw.mirrorIdentity`) when available and adding a new auto/snapshot/delta capture mode plus append idempotency keys. Removes runtime dependency on `openclaw/plugin-sdk/routing` by inlining session-key parsing.
> 
> Bumps the OpenClaw integration/plugin version to `0.8.24`, adds targeted unit tests for the new append modes, and makes OpenClaw live E2E teardown/config restore more resilient (retrying marker cleanup and cleaning up temporary `openclaw.json` writes).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ba18c1b6fb0332fcd85d6f070f8519e957df2316. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->