### PR TITLE
Fix OpenClaw snapshot external ID compatibility

### DIFF
--- a/nowledge-mem-openclaw-plugin/src/hooks/capture.js
+++ b/nowledge-mem-openclaw-plugin/src/hooks/capture.js
@@ -332,14 +332,10 @@ function buildExternalId({
 		messageMode === CAPTURE_MESSAGE_MODE_DELTA
 			? String(ctx?.runId || event?.runId || "").trim()
 			: "";
-	const seed = [
-		threadId,
-		sessionKey,
-		runId ? `run:${runId}` : "",
-		index,
-		normalized.role,
-		normalized.content,
-	].join("|");
+	const seedParts = [threadId, sessionKey];
+	if (runId) seedParts.push(`run:${runId}`);
+	seedParts.push(index, normalized.role, normalized.content);
+	const seed = seedParts.join("|");
 	const digest = createHash("sha1").update(seed).digest("hex");
 	return `oc-msg:${digest}`;
 }

--- a/nowledge-mem-openclaw-plugin/tests/capture-append-mode.test.mjs
+++ b/nowledge-mem-openclaw-plugin/tests/capture-append-mode.test.mjs
@@ -1,4 +1,5 @@
 import assert from "node:assert/strict";
+import { createHash } from "node:crypto";
 import test from "node:test";
 
 import {
@@ -18,6 +19,10 @@ function message(role, content, extra = {}) {
 		content,
 		...extra,
 	};
+}
+
+function fallbackExternalId(seed) {
+	return `oc-msg:${createHash("sha1").update(seed).digest("hex")}`;
 }
 
 class FakeThreadClient {
@@ -285,6 +290,61 @@ test("snapshot capture appends only the tail of full-transcript hook payloads", 
 	assert.deepEqual(
 		client.appendCalls[0].messages.map((msg) => msg.content),
 		["third", "fourth"],
+	);
+});
+
+test("snapshot fallback external IDs preserve the legacy seed shape", async () => {
+	const sessionKey = "agent:main:telegram:direct:snapshot-fallback";
+	const client = new FakeThreadClient({ existingCount: 0 });
+	const result = await appendOrCreateThread({
+		client,
+		logger,
+		event: {
+			messages: [message("user", "legacy fallback")],
+		},
+		ctx: {
+			sessionId: "session-snapshot-fallback",
+			sessionKey,
+			runId: "run-ignored-in-snapshot",
+		},
+		reason: "after_turn",
+	});
+
+	assert.equal(result.messagesAdded, 1);
+	assert.equal(client.appendCalls.length, 1);
+	assert.equal(
+		client.appendCalls[0].messages[0].metadata.external_id,
+		fallbackExternalId(
+			`${result.threadId}|${sessionKey}|0|user|legacy fallback`,
+		),
+	);
+});
+
+test("delta fallback external IDs include run id when available", async () => {
+	const sessionKey = "agent:main:telegram:direct:delta-fallback";
+	const client = new FakeThreadClient({ existingCount: 0 });
+	const result = await appendOrCreateThread({
+		client,
+		logger,
+		event: {
+			messages: [message("assistant", "delta fallback")],
+		},
+		ctx: {
+			sessionId: "session-delta-fallback",
+			sessionKey,
+			runId: "run-42",
+		},
+		reason: "agent_end",
+		messageMode: "delta",
+	});
+
+	assert.equal(result.messagesAdded, 1);
+	assert.equal(client.appendCalls.length, 1);
+	assert.equal(
+		client.appendCalls[0].messages[0].metadata.external_id,
+		fallbackExternalId(
+			`${result.threadId}|${sessionKey}|run:run-42|0|assistant|delta fallback`,
+		),
 	);
 });
 


### PR DESCRIPTION
## Summary
- preserve the legacy fallback external-id seed shape for snapshot/full-transcript captures
- keep run-id salting only for true delta captures
- add regression tests for snapshot compatibility and delta fallback uniqueness

## Validation
- npm test --prefix nowledge-mem-openclaw-plugin
- npx biome check src/hooks/capture.js tests/capture-append-mode.test.mjs (from nowledge-mem-openclaw-plugin)
- npm run validate --prefix nowledge-mem-openclaw-plugin
- npm pack --dry-run --prefix nowledge-mem-openclaw-plugin
- uv run --with pytest pytest tests/plugin_e2e -q
- node nowledge-mem-codex-plugin/scripts/validate-plugin.mjs

Fixes the unresolved Bugbot follow-up from #246.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how fallback `external_id` hashes are generated, which can affect message deduplication and potentially cause duplicates or missed merges if the seed shape is wrong. Scope is limited and covered by new regression tests for snapshot vs delta behavior.
> 
> **Overview**
> Fixes OpenClaw fallback `external_id` generation to **preserve the legacy snapshot/full-transcript hash seed shape**, while still **including `runId` salting only for true delta captures**.
> 
> Adds regression tests asserting the snapshot fallback hash omits `runId` and the delta fallback hash includes it when available, preventing compatibility regressions in dedupe behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d869aff4660ead2a7dbae2cf075d1b652113a876. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->