### PR TITLE
chore(claude-code): use git subdir plugin source

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -20,7 +20,11 @@
       },
       "homepage": "https://mem.nowledge.co/",
       "tags": ["ai-powered", "knowledge-management", "context-management", "memory-management"],
-      "source": "./nowledge-mem-claude-code-plugin"
+      "source": {
+        "source": "git-subdir",
+        "url": "nowledge-co/community",
+        "path": "nowledge-mem-claude-code-plugin"
+      }
     }
   ]
 }

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -12,7 +12,7 @@
     {
       "name": "nowledge-mem",
       "description": "Personal knowledge graph for Claude Code — remembers decisions, searches past work, captures sessions",
-      "version": "0.7.5",
+      "version": "0.7.10",
       "author": {
         "name": "Nowledge Labs",
         "url": "https://www.nowledge-labs.ai/",

--- a/integrations.json
+++ b/integrations.json
@@ -8,7 +8,7 @@
       "name": "Claude Code",
       "category": "coding",
       "type": "plugin",
-      "version": "0.7.9",
+      "version": "0.7.10",
       "directory": "nowledge-mem-claude-code-plugin",
       "transport": "cli",
       "capabilities": {

--- a/nowledge-mem-claude-code-plugin/.claude-plugin/plugin.json
+++ b/nowledge-mem-claude-code-plugin/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "nowledge-mem",
   "description": "Personal knowledge graph for Claude Code \u2014 remembers decisions, searches past work, captures sessions",
-  "version": "0.7.9",
+  "version": "0.7.10",
   "author": {
     "name": "Nowledge Labs",
     "email": "hello@nowledge-labs.ai",

--- a/nowledge-mem-claude-code-plugin/CHANGELOG.md
+++ b/nowledge-mem-claude-code-plugin/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to the Nowledge Mem Claude Code plugin will be documented in
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.7.10] - 2026-05-20
+
+### Changed
+
+- Updated the Claude Code marketplace listing to use the repository subdirectory source, so marketplace installs fetch only the Claude Code plugin package instead of exposing sparse repository root files.
+
 ## [0.7.9] - 2026-05-12
 
 ### Changed

--- a/nowledge-mem-claude-code-plugin/README.md
+++ b/nowledge-mem-claude-code-plugin/README.md
@@ -110,7 +110,6 @@ Shared spaces, default retrieval, and agent guidance still live in Mem's own spa
 ## Update
 
 ```bash
-claude plugin marketplace add nowledge-co/community
 claude plugin marketplace update nowledge-community
 claude plugin update nowledge-mem@nowledge-community
 # Restart Claude Code to apply changes


### PR DESCRIPTION
## Summary

- change the Claude Code marketplace entry to install `nowledge-mem` from the `nowledge-mem-claude-code-plugin` git subdirectory
- keep the user-facing Claude Code install command unchanged
- avoid requiring users to know sparse checkout flags for this plugin

## Verification

- parsed `.claude-plugin/marketplace.json` as JSON
- checked the plugin source resolves to `git-subdir` with path `nowledge-mem-claude-code-plugin`
- reviewed the focused git diff

Closes #252