### PR TITLE
fix(hooks): add required `version` field to cursor hooks.json

### DIFF
--- a/integrations.json
+++ b/integrations.json
@@ -214,7 +214,7 @@
       "name": "Cursor",
       "category": "coding",
       "type": "plugin",
-      "version": "0.1.4",
+      "version": "0.1.5",
       "directory": "nowledge-mem-cursor-plugin",
       "transport": "mcp",
       "capabilities": {

--- a/nowledge-mem-cursor-plugin/.cursor-plugin/plugin.json
+++ b/nowledge-mem-cursor-plugin/.cursor-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "nowledge-mem-cursor",
   "description": "Bring Working Memory, memory recall, and handoff summaries into Cursor with Nowledge Mem.",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "author": {
     "name": "Nowledge Labs",
     "email": "hello@nowledge-labs.ai",

--- a/nowledge-mem-cursor-plugin/CHANGELOG.md
+++ b/nowledge-mem-cursor-plugin/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [0.1.5] - 2026-05-20
+
+### Fixed
+
+- Added the required top-level `version` field to `hooks/hooks.json` so current Cursor plugin loaders accept the hook configuration.
+
 ## [0.1.4] - 2026-04-08
 
 ### Fixed

--- a/nowledge-mem-cursor-plugin/hooks/hooks.json
+++ b/nowledge-mem-cursor-plugin/hooks/hooks.json
@@ -1,4 +1,5 @@
 {
+  "version": 1,
   "hooks": {
     "sessionStart": [
       {


### PR DESCRIPTION
## Problem
After installing `nowledge-mem-cursor`, Cursor's **Hooks** settings show a Configuration Error (see screenshot):
> **Invalid hooks.json found** — We detected a hooks.json file that could not be loaded.
>
> `Plugin nowledge-mem-cursor hooks: Config version must be a number`
As a result, the plugin's `sessionStart` hook never loads, and `read_working_memory` is not invoked at the start of a Cursor session.
## Root cause
`hooks/hooks.json` was missing the top-level `version` field. Cursor's hooks loader validates `version` as a `number`; when it is `undefined`, the whole config is rejected.


<img width="1724" height="512" alt="Clipboard_Screenshot_1779095629" src="https://github.com/user-attachments/assets/96f2693f-c633-4e6a-b281-a568357362bd" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added a top-level configuration version for plugin hooks to ensure hook configs are recognized.
  * Bumped the integration and plugin release to v0.1.5.
  * Updated the changelog with the 0.1.5 entry documenting the hook config version addition.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/nowledge-co/community/pull/255?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->