### PR TITLE
Fix Windows nmem.cmd invocation in Copilot CLI hook

### DIFF
--- a/integrations.json
+++ b/integrations.json
@@ -58,7 +58,7 @@
       "name": "Copilot CLI",
       "category": "coding",
       "type": "plugin",
-      "version": "0.1.1",
+      "version": "0.1.2",
       "directory": "nowledge-mem-copilot-cli-plugin",
       "transport": "cli",
       "capabilities": {

--- a/nowledge-mem-copilot-cli-plugin/.claude-plugin/plugin.json
+++ b/nowledge-mem-copilot-cli-plugin/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "nowledge-mem",
   "description": "Personal knowledge graph for GitHub Copilot CLI — remembers decisions, searches past work, captures sessions",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "author": {
     "name": "Nowledge Labs",
     "email": "hello@nowledge-labs.ai",

--- a/nowledge-mem-copilot-cli-plugin/CHANGELOG.md
+++ b/nowledge-mem-copilot-cli-plugin/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to the Nowledge Mem Copilot CLI plugin will be documented in
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.1.2] - 2026-05-20
+
+### Fixed
+
+- Fixed Windows `nmem.cmd` hook invocation by passing the command and arguments to `cmd.exe` as argv entries, avoiding double command-line quoting.
+
 ## [0.1.1] - 2026-04-27
 
 ### Added

--- a/nowledge-mem-copilot-cli-plugin/hooks/copilot-stop-save.py
+++ b/nowledge-mem-copilot-cli-plugin/hooks/copilot-stop-save.py
@@ -198,12 +198,7 @@ def has_sensitive_content(text: str) -> bool:
 
 def build_nmem_command(nmem_bin: str, *args: str) -> list[str]:
     if nmem_bin.lower().endswith(".cmd"):
-        return [
-            "cmd.exe",
-            "/s",
-            "/c",
-            subprocess.list2cmdline([nmem_bin, *args]),
-        ]
+        return ["cmd.exe", "/d", "/c", "call", nmem_bin, *args]
     return [nmem_bin, *args]
 
 

--- a/nowledge-mem-copilot-cli-plugin/tests/test_copilot_plugin.py
+++ b/nowledge-mem-copilot-cli-plugin/tests/test_copilot_plugin.py
@@ -592,6 +592,4 @@ class TestBuildNmemCommand:
 
     def test_windows_cmd(self):
         cmd = copilot_stop_save.build_nmem_command("C:\\nmem.cmd", "--json", "wm", "read")
-        assert cmd[0] == "cmd.exe"
-        assert cmd[1] == "/s"
-        assert cmd[2] == "/c"
+        assert cmd == ["cmd.exe", "/d", "/c", "call", "C:\\nmem.cmd", "--json", "wm", "read"]


### PR DESCRIPTION
## Summary

- Fixes a Windows-specific `nmem.cmd` invocation failure in the Copilot CLI hook.
- Keeps `cmd.exe`, `nmem.cmd`, and the remaining CLI arguments as separate argv entries.
- Avoids pre-formatting the command with `subprocess.list2cmdline`, because `subprocess.run([...])` performs Windows command-line conversion again.

## Original Error

```text
RuntimeError: '"C:\Users\xxxxxxxx\AppData\Local\Nowledge Mem\cli\nmem.CMD"' 不是内部或外部命令，也不是可运行的程序或批处理文件。
```

## Reproduction

1. Use Windows with the Nowledge Mem desktop app installed, so `nmem.CMD` resolves to a path like:

   ```text
   C:\Users\<user>\AppData\Local\Nowledge Mem\cli\nmem.CMD
   ```

2. Run the Copilot CLI plugin hook path that saves or imports a session through `nowledge-mem-copilot-cli-plugin/hooks/copilot-stop-save.py`.
3. The hook builds the `.cmd` invocation with `subprocess.list2cmdline(...)`, then passes that preformatted command string inside an argv list to `subprocess.run(...)`.
4. On Windows, `subprocess.run([...])` converts argv to a command line again, so `cmd.exe` receives an over-quoted command name and fails with the error above.

## Testing

```bash
uv run --with pytest pytest tests/test_copilot_plugin.py::TestBuildNmemCommand -v
```

The targeted command-building tests pass.

Note: running the full `tests/test_copilot_plugin.py` file locally on Windows also passes the updated command-building tests, but one unrelated existing test fails because `hooks.json` is read with the default GBK locale instead of UTF-8.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Windows command invocation to prevent quoting/execution issues when running the CLI hook, improving reliability on Windows.

* **Chores**
  * Bumped plugin/integration version to 0.1.2 and added a 0.1.2 changelog entry documenting the Windows fix.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/nowledge-co/community/pull/257?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->