### PR TITLE
docs: add Arch Linux nmem CLI install guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ Direct MCP clients do not read `~/.nowledge-mem/config.json` automatically; past
 ## Requirements
 
 - [Nowledge Mem](https://mem.nowledge.co) running locally
-- `nmem` CLI on your PATH: if Mem is running on the same machine, install it from **Settings > Preferences > Developer Tools > Install CLI** in the app, or use `pip install nmem-cli` for a standalone setup
+- `nmem` CLI on your PATH: if Mem is running on the same machine, install it from **Settings > Preferences > Developer Tools > Install CLI** in the app, use `pip install nmem-cli` for a standalone setup, or on Arch Linux install the [`nmem-cli` AUR package](https://aur.archlinux.org/packages/nmem-cli) with `yay -S nmem-cli` or `paru -S nmem-cli`
 
 ```bash
 nmem status   # verify Nowledge Mem is running

--- a/nowledge-mem-bub-plugin/README.md
+++ b/nowledge-mem-bub-plugin/README.md
@@ -14,6 +14,7 @@ pip install nowledge-mem-bub
 
 ```bash
 pip install nmem-cli    # or: pipx install nmem-cli
+# Arch Linux: yay -S nmem-cli  # or: paru -S nmem-cli
 nmem status             # verify connection
 ```
 

--- a/nowledge-mem-claude-code-plugin/README.md
+++ b/nowledge-mem-claude-code-plugin/README.md
@@ -16,6 +16,7 @@ claude plugin install nowledge-mem@nowledge-community
 
 ```bash
 pip install nmem-cli    # or: pipx install nmem-cli
+# Arch Linux: yay -S nmem-cli  # or: paru -S nmem-cli
 nmem status             # verify connection
 ```
 

--- a/nowledge-mem-claude-code-plugin/skills/distill-memory/SKILL.md
+++ b/nowledge-mem-claude-code-plugin/skills/distill-memory/SKILL.md
@@ -76,7 +76,7 @@ nmem m add "Chose PostgreSQL over MongoDB for ACID compliance and complex querie
 
 ## Troubleshooting
 
-If `nmem` is not in PATH: `pip install nmem-cli`
+If `nmem` is not in PATH: `pip install nmem-cli`, or on Arch Linux `yay -S nmem-cli` / `paru -S nmem-cli`
 
 For remote servers: run `nmem config client set url https://...` and `nmem config client set api-key ...` once on this machine.
 

--- a/nowledge-mem-claude-code-plugin/skills/read-working-memory/SKILL.md
+++ b/nowledge-mem-claude-code-plugin/skills/read-working-memory/SKILL.md
@@ -64,6 +64,6 @@ The Working Memory briefing contains:
 
 ## Troubleshooting
 
-If `nmem` is not in PATH: `pip install nmem-cli` or `pipx install nmem-cli`
+If `nmem` is not in PATH: `pip install nmem-cli`, `pipx install nmem-cli`, or on Arch Linux `yay -S nmem-cli` / `paru -S nmem-cli`
 
 If Nowledge Mem is on a remote server, run `nmem config client set url https://...` and `nmem config client set api-key ...` once on this machine, or use `NMEM_API_URL` / `NMEM_API_KEY` for a temporary override.

--- a/nowledge-mem-claude-code-plugin/skills/save-thread/SKILL.md
+++ b/nowledge-mem-claude-code-plugin/skills/save-thread/SKILL.md
@@ -57,7 +57,7 @@ Thread ID: claude-code-{session_id}
 
 ## Troubleshooting
 
-If `nmem` is not in PATH: `pip install nmem-cli`
+If `nmem` is not in PATH: `pip install nmem-cli`, or on Arch Linux `yay -S nmem-cli` / `paru -S nmem-cli`
 
 For remote servers: run `nmem config client set url https://...` and `nmem config client set api-key ...` once on this machine.
 

--- a/nowledge-mem-claude-code-plugin/skills/search-memory/SKILL.md
+++ b/nowledge-mem-claude-code-plugin/skills/search-memory/SKILL.md
@@ -93,7 +93,7 @@ None: State clearly, suggest distilling if current discussion valuable
 
 ## Troubleshooting
 
-If `nmem` is not in PATH: `pip install nmem-cli`
+If `nmem` is not in PATH: `pip install nmem-cli`, or on Arch Linux `yay -S nmem-cli` / `paru -S nmem-cli`
 
 For remote servers: run `nmem config client set url https://...` and `nmem config client set api-key ...` once on this machine.
 

--- a/nowledge-mem-codex-plugin/README.md
+++ b/nowledge-mem-codex-plugin/README.md
@@ -64,7 +64,14 @@ curl -LsSf https://astral.sh/uv/install.sh | sh
 uvx --from nmem-cli nmem --version
 ```
 
-Or `pip install nmem-cli`. Then verify with `nmem status`.
+Or `pip install nmem-cli`. On Arch Linux, use the AUR package:
+
+```bash
+yay -S nmem-cli
+# or: paru -S nmem-cli
+```
+
+Then verify with `nmem status`.
 
 ## Install
 

--- a/nowledge-mem-copilot-cli-plugin/README.md
+++ b/nowledge-mem-copilot-cli-plugin/README.md
@@ -16,6 +16,7 @@ copilot plugin install nowledge-mem@nowledge-community
 
 ```bash
 pip install nmem-cli    # or: pipx install nmem-cli
+# Arch Linux: yay -S nmem-cli  # or: paru -S nmem-cli
 nmem status             # verify connection
 ```
 

--- a/nowledge-mem-copilot-cli-plugin/skills/distill-memory/SKILL.md
+++ b/nowledge-mem-copilot-cli-plugin/skills/distill-memory/SKILL.md
@@ -76,7 +76,7 @@ nmem m add "Chose PostgreSQL over MongoDB for ACID compliance and complex querie
 
 ## Troubleshooting
 
-If `nmem` is not in PATH: `pip install nmem-cli`
+If `nmem` is not in PATH: `pip install nmem-cli`, or on Arch Linux `yay -S nmem-cli` / `paru -S nmem-cli`
 
 For remote servers: run `nmem config client set url https://...` and `nmem config client set api-key ...` once on this machine.
 

--- a/nowledge-mem-copilot-cli-plugin/skills/read-working-memory/SKILL.md
+++ b/nowledge-mem-copilot-cli-plugin/skills/read-working-memory/SKILL.md
@@ -64,6 +64,6 @@ The Working Memory briefing contains:
 
 ## Troubleshooting
 
-If `nmem` is not in PATH: `pip install nmem-cli` or `pipx install nmem-cli`
+If `nmem` is not in PATH: `pip install nmem-cli`, `pipx install nmem-cli`, or on Arch Linux `yay -S nmem-cli` / `paru -S nmem-cli`
 
 If Nowledge Mem is on a remote server, run `nmem config client set url https://...` and `nmem config client set api-key ...` once on this machine, or use `NMEM_API_URL` / `NMEM_API_KEY` for a temporary override.

--- a/nowledge-mem-copilot-cli-plugin/skills/save-thread/SKILL.md
+++ b/nowledge-mem-copilot-cli-plugin/skills/save-thread/SKILL.md
@@ -38,6 +38,6 @@ Thread ID: {thread_id from nmem output}
 
 ## Troubleshooting
 
-If `nmem` is not in PATH: `pip install nmem-cli`
+If `nmem` is not in PATH: `pip install nmem-cli`, or on Arch Linux `yay -S nmem-cli` / `paru -S nmem-cli`
 
 Run `nmem status` to check server connection.

--- a/nowledge-mem-copilot-cli-plugin/skills/search-memory/SKILL.md
+++ b/nowledge-mem-copilot-cli-plugin/skills/search-memory/SKILL.md
@@ -93,7 +93,7 @@ None: State clearly, suggest distilling if current discussion valuable
 
 ## Troubleshooting
 
-If `nmem` is not in PATH: `pip install nmem-cli`
+If `nmem` is not in PATH: `pip install nmem-cli`, or on Arch Linux `yay -S nmem-cli` / `paru -S nmem-cli`
 
 For remote servers: run `nmem config client set url https://...` and `nmem config client set api-key ...` once on this machine.
 

--- a/nowledge-mem-droid-plugin/README.md
+++ b/nowledge-mem-droid-plugin/README.md
@@ -53,6 +53,10 @@ pip install nmem-cli
 # Option 2: uvx
 curl -LsSf https://astral.sh/uv/install.sh | sh
 uvx --from nmem-cli nmem --version
+
+# Option 3: Arch Linux AUR
+yay -S nmem-cli
+# or: paru -S nmem-cli
 ```
 
 Verify the connection:

--- a/nowledge-mem-hermes/README.md
+++ b/nowledge-mem-hermes/README.md
@@ -56,7 +56,7 @@ This adds the MCP server to `config.yaml` and installs behavioral guidance in `~
 
 1. **Nowledge Mem desktop app** running (or the server accessible on port 14242)
 2. **Hermes Agent** installed and configured
-3. **`nmem` CLI** available on PATH. If the desktop app is on the same machine, `nmem` is already bundled. Otherwise: `pip install nmem-cli`
+3. **`nmem` CLI** available on PATH. If the desktop app is on the same machine, `nmem` is already bundled. Otherwise use `pip install nmem-cli`, or on Arch Linux use `yay -S nmem-cli` / `paru -S nmem-cli`.
 
 ## What the plugin does
 

--- a/nowledge-mem-npx-skills/README.md
+++ b/nowledge-mem-npx-skills/README.md
@@ -72,6 +72,16 @@ pip install nmem-cli
 nmem --version
 ```
 
+**Option 3: Arch Linux AUR**
+
+```bash
+yay -S nmem-cli
+# or: paru -S nmem-cli
+nmem --version
+```
+
+Package: https://aur.archlinux.org/packages/nmem-cli
+
 ### 2. Nowledge Mem Server
 
 Ensure the Nowledge Mem server is running at `http://localhost:14242`.

--- a/nowledge-mem-npx-skills/skills/status/SKILL.md
+++ b/nowledge-mem-npx-skills/skills/status/SKILL.md
@@ -31,7 +31,7 @@ This shows:
 
 If status fails:
 - Ensure the Nowledge Mem desktop app is running, or start the server manually
-- Check that `nmem` is installed: `pip install nmem-cli` or use `uvx --from nmem-cli nmem`
+- Check that `nmem` is installed: use the desktop app's **Install CLI**, `pip install nmem-cli`, `uvx --from nmem-cli nmem`, or on Arch Linux `yay -S nmem-cli` / `paru -S nmem-cli`
 - For remote mode, verify `~/.nowledge-mem/config.json` has correct `apiUrl` and `apiKey`
 
 ## Native Connector

--- a/nowledge-mem-openclaw-plugin/SKILL.md
+++ b/nowledge-mem-openclaw-plugin/SKILL.md
@@ -74,7 +74,7 @@ nmem --version
 If this fails:
 
 - For users with the desktop app, direct them to **Settings > Preferences > Developer Tools > Install CLI**
-- Otherwise suggest `pip install nmem-cli`
+- Otherwise suggest `pip install nmem-cli`, or on Arch Linux `yay -S nmem-cli` / `paru -S nmem-cli`
 
 ### Step 2 — Verify the Backend Before Plugin Setup
 

--- a/nowledge-mem-opencode-plugin/README.md
+++ b/nowledge-mem-opencode-plugin/README.md
@@ -14,7 +14,7 @@ Nowledge Mem gives OpenCode access to knowledge from all your other AI tools: in
 ## Prerequisites
 
 1. **Nowledge Mem desktop app** running (or the server accessible on port 14242)
-2. **`nmem` CLI** on your PATH. In Nowledge Mem go to **Settings > Developer Tools > Install CLI**, or `pip install nmem-cli`
+2. **`nmem` CLI** on your PATH. In Nowledge Mem go to **Settings > Developer Tools > Install CLI**, use `pip install nmem-cli`, or on Arch Linux use `yay -S nmem-cli` / `paru -S nmem-cli`
 3. **OpenCode** installed
 
 ```bash

--- a/nowledge-mem-opencode-plugin/README.md
+++ b/nowledge-mem-opencode-plugin/README.md
@@ -143,7 +143,7 @@ Shared spaces, default retrieval, and agent guidance still come from Mem's own s
 
 ## Troubleshooting
 
-- **nmem not found.** Install with `pip install nmem-cli`, then run `nmem status` to verify.
+- **nmem not found.** Install with `pip install nmem-cli`, or on Arch Linux `yay -S nmem-cli` / `paru -S nmem-cli`, then run `nmem status` to verify.
 - **Server not responding.** Start the Nowledge Mem desktop app, or check `nmem status` for diagnostics.
 - **Plugin not loading.** Confirm `"opencode-nowledge-mem"` appears in your `opencode.json` plugin array. Restart OpenCode after changes.
 

--- a/nowledge-mem-pi-package/README.md
+++ b/nowledge-mem-pi-package/README.md
@@ -21,6 +21,7 @@ Pi gains five skills that connect it to your Nowledge Mem knowledge base:
 
 ```bash
 pip install nmem-cli    # or: pipx install nmem-cli
+# Arch Linux: yay -S nmem-cli  # or: paru -S nmem-cli
 nmem status             # verify connection
 ```
 

--- a/nowledge-mem-pi-package/README.md
+++ b/nowledge-mem-pi-package/README.md
@@ -79,7 +79,7 @@ That keeps your custom behavior durable across package updates.
 
 ## Troubleshooting
 
-**nmem not found:** Install with `pip install nmem-cli` or `pipx install nmem-cli`.
+**nmem not found:** Install with `pip install nmem-cli`, `pipx install nmem-cli`, or on Arch Linux `yay -S nmem-cli` / `paru -S nmem-cli`.
 
 **Server not running:** Start the Nowledge Mem desktop app, or run `nmem serve` on your server.
 

--- a/nowledge-mem-pi-package/skills/status/SKILL.md
+++ b/nowledge-mem-pi-package/skills/status/SKILL.md
@@ -29,7 +29,7 @@ nmem --json status
 **If it fails:**
 
 1. Check that the Nowledge Mem desktop app is running, or that `nmem serve` is active on your server.
-2. Verify `nmem` is installed: `pip install nmem-cli` or `pipx install nmem-cli`.
+2. Verify `nmem` is installed: `pip install nmem-cli`, `pipx install nmem-cli`, or on Arch Linux `yay -S nmem-cli` / `paru -S nmem-cli`.
 3. For remote servers, ensure `~/.nowledge-mem/config.json` contains valid `apiUrl` and `apiKey` fields, or set `NMEM_API_URL` and `NMEM_API_KEY` environment variables.
 
 ## Links

--- a/nowledge-mem-proma-plugin/README.md
+++ b/nowledge-mem-proma-plugin/README.md
@@ -9,7 +9,7 @@ Integrates Nowledge Mem's personal knowledge graph into [Proma](https://github.c
 - [Proma](https://github.com/proma-ai/proma) desktop app
 - Nowledge Mem server running (desktop app or remote)
 - Python 3.9+ (for hook scripts)
-- `nmem` CLI in PATH (bundled with [Nowledge Mem desktop app](https://mem.nowledge.co/), or `pip install nmem-cli`)
+- `nmem` CLI in PATH (bundled with [Nowledge Mem desktop app](https://mem.nowledge.co/), `pip install nmem-cli`, or on Arch Linux `yay -S nmem-cli` / `paru -S nmem-cli`)
 
 ## Installation
 

--- a/nowledge-mem-proma-plugin/README.md
+++ b/nowledge-mem-proma-plugin/README.md
@@ -194,7 +194,7 @@ The hook scripts read credentials from standard nmem config (`~/.nowledge-mem/co
 - Ensure hook commands use correct absolute paths
 
 **"nmem CLI not found":**
-- Install via `pip install nmem-cli` or the Nowledge Mem desktop app
+- Install via the Nowledge Mem desktop app, `pip install nmem-cli`, or on Arch Linux `yay -S nmem-cli` / `paru -S nmem-cli`
 - Verify `nmem --version` works in your terminal
 
 **Session not saved:**


### PR DESCRIPTION
## Summary
- add Arch Linux AUR install guidance for `nmem-cli`
- update connector README prerequisites and shared skill fallback guidance
- credit @czyt for publishing the AUR package and reporting the Arch install issue

Closes #268

## Validation
- `git diff --check`
- `node nowledge-mem-codex-plugin/scripts/validate-plugin.mjs`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Expanded installation instructions across the project to offer additional ways to install the nmem CLI (including Arch AUR options alongside existing pip and in-app install guidance).
  * Clarified and broadened troubleshooting guidance where nmem is not on the system PATH, adding platform-specific install suggestions to help users get the CLI working.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Markdown-only documentation updates with no runtime, auth, or integration logic changes.
> 
> **Overview**
> Documentation-only change: **Arch Linux** users can install `nmem-cli` via the AUR (`yay` / `paru`) alongside existing desktop-app and `pip` paths.
> 
> The root **README** Requirements section and integration **README** prerequisites (Bub, Claude Code, Copilot CLI, Codex, Droid, Hermes, npx-skills, OpenCode, Pi, Proma, etc.) now mention AUR install where relevant. **Troubleshooting** blocks in shared **SKILL** files (Claude/Copilot skills, npx `status`, OpenClaw setup guide, Pi `status`) were updated so agents suggest AUR when `nmem` is missing from PATH. Codex and npx-skills add a dedicated AUR option section with link to https://aur.archlinux.org/packages/nmem-cli.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8a45452f62c35a94853e517c54a27779f5612e9a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->