### PR TITLE
fix(openclaw): avoid stale ClawHub update pins

### DIFF
--- a/integrations.json
+++ b/integrations.json
@@ -518,7 +518,7 @@
       "name": "OpenClaw",
       "category": "coding",
       "type": "plugin",
-      "version": "0.8.25",
+      "version": "0.8.26",
       "directory": "nowledge-mem-openclaw-plugin",
       "transport": "cli",
       "capabilities": {
@@ -543,13 +543,14 @@
         "threads": "automatic-capture",
         "bestResultRequires": [
           "Install the native OpenClaw plugin",
+          "Use OpenClaw 2026.5.3 or later for current ClawHub packages",
           "Keep nmem available on this machine",
           "Restart OpenClaw after install or config changes"
         ]
       },
       "install": {
         "command": "openclaw plugins install clawhub:@nowledge/openclaw-nowledge-mem",
-        "updateCommand": "openclaw plugins update openclaw-nowledge-mem",
+        "updateCommand": "openclaw plugins install clawhub:@nowledge/openclaw-nowledge-mem --force",
         "detectionHint": "Running as OpenClaw agent; ~/.openclaw/ exists",
         "agentGuide": {
           "prompt": "Read https://mem.nowledge.co/SKILL.md and follow the instructions to install or update Nowledge Mem for OpenClaw. Verify with nmem status and the Context Bundle or Working Memory check, then summarize what changed.",

--- a/nowledge-mem-openclaw-plugin/CHANGELOG.md
+++ b/nowledge-mem-openclaw-plugin/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to the Nowledge Mem OpenClaw plugin will be documented in th
 
 ## Unreleased
 
+## [0.8.26] - 2026-06-10
+
+### Fixed
+
+- OpenClaw update guidance now uses `openclaw plugins install clawhub:@nowledge/openclaw-nowledge-mem --force` so stale pinned install records cannot downgrade the plugin.
+- ClawHub package metadata now requires OpenClaw 2026.5.3 or later, matching current ClawHub npm-pack artifact support and avoiding confusing archive-integrity failures on older OpenClaw installers.
+
 ## [0.8.25] - 2026-06-06
 
 ### Improved

--- a/nowledge-mem-openclaw-plugin/README.md
+++ b/nowledge-mem-openclaw-plugin/README.md
@@ -9,7 +9,7 @@ This is not a flat note store. Nowledge Mem links related knowledge into a graph
 ## Requirements
 
 - [Nowledge Mem](https://mem.nowledge.co) desktop app **or** `nmem` CLI
-- [OpenClaw](https://openclaw.ai) >= 2026.4.5 (corpus supplement requires this version; core features work on >= 2026.3.7)
+- [OpenClaw](https://openclaw.ai) >= 2026.5.3 for ClawHub installs. Older 2026.4.x builds can reject current ClawHub packages with an archive integrity mismatch before the plugin is installed.
 
 ## Installation
 
@@ -18,6 +18,14 @@ openclaw plugins install clawhub:@nowledge/openclaw-nowledge-mem
 ```
 
 OpenClaw's installer writes the install record, enables the plugin, and switches the `memory` slot to `openclaw-nowledge-mem`. On current OpenClaw builds, that same install flow may also set `plugins.slots.contextEngine` to `openclaw-nowledge-mem`. Plugin `0.8.18+` accepts that automatically as a compatibility alias, so you do not need to hand-edit the file after install. If you manage config manually, keep using the canonical context engine id `nowledge-mem`.
+
+To update the plugin, re-run the ClawHub install with `--force`:
+
+```bash
+openclaw plugins install clawhub:@nowledge/openclaw-nowledge-mem --force
+```
+
+Use this instead of `openclaw plugins update openclaw-nowledge-mem` when an old install record is pinned to a specific version.
 
 Restart OpenClaw after install to load it.
 

--- a/nowledge-mem-openclaw-plugin/SKILL.md
+++ b/nowledge-mem-openclaw-plugin/SKILL.md
@@ -106,6 +106,15 @@ Default install:
 openclaw plugins install clawhub:@nowledge/openclaw-nowledge-mem
 ```
 
+If this fails with `archive integrity mismatch`, update OpenClaw first, then
+retry. Current ClawHub packages require OpenClaw 2026.5.3 or later.
+
+To update an existing install:
+
+```bash
+openclaw plugins install clawhub:@nowledge/openclaw-nowledge-mem --force
+```
+
 Alternatively, if the user is installing from OpenClaw's default registry rather than ClawHub, this also works:
 
 ```bash
@@ -240,6 +249,7 @@ What to expect:
 | `nmem --json status` fails in local mode | Start Nowledge Mem locally first |
 | Remote mode fails | Re-run `nmem --json --api-url ... status` with the exact URL and auth you plan to use |
 | `openclaw nowledge-mem status` fails after install | Restart OpenClaw and confirm the plugin was installed successfully |
+| ClawHub reports `archive integrity mismatch` | Update OpenClaw to 2026.5.3+ or latest, then reinstall with `openclaw plugins install clawhub:@nowledge/openclaw-nowledge-mem --force` |
 | `plugins.allow is empty` warning | Add `openclaw-nowledge-mem` to `plugins.allow` if the user wants explicit trust |
 | Remote config seems ignored | Check whether `~/.nowledge-mem/openclaw.json` is overriding plugin settings |
 | Local mode unexpectedly talks to a remote server | Check for stale `NMEM_API_URL` / `NMEM_API_KEY` in the environment or an overriding `~/.nowledge-mem/openclaw.json` |

--- a/nowledge-mem-openclaw-plugin/openclaw.plugin.json
+++ b/nowledge-mem-openclaw-plugin/openclaw.plugin.json
@@ -2,7 +2,7 @@
 	"id": "openclaw-nowledge-mem",
 	"name": "Nowledge Mem",
 	"description": "Cross-tool knowledge graph memory for OpenClaw with startup context, graph search, and session distillation.",
-	"version": "0.8.25",
+	"version": "0.8.26",
 	"kind": ["memory", "context-engine"],
 	"skills": [
 		"skills/memory-guide"

--- a/nowledge-mem-openclaw-plugin/package.json
+++ b/nowledge-mem-openclaw-plugin/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@nowledge/openclaw-nowledge-mem",
 	"displayName": "Nowledge Mem for OpenClaw",
-	"version": "0.8.25",
+	"version": "0.8.26",
 	"type": "module",
 	"description": "Nowledge Mem memory plugin for OpenClaw, local-first personal knowledge base",
 	"author": {
@@ -32,10 +32,10 @@
 			"npmSpec": "@nowledge/openclaw-nowledge-mem"
 		},
 		"compat": {
-			"pluginApi": ">=2026.4.5"
+			"pluginApi": ">=2026.5.3"
 		},
 		"build": {
-			"openclawVersion": "2026.4.5"
+			"openclawVersion": "2026.5.3"
 		},
 		"release": {
 			"publishToClawHub": true,

--- a/tests/plugin_e2e/README.md
+++ b/tests/plugin_e2e/README.md
@@ -93,8 +93,10 @@ as CLI arguments.
   just wrote so the package setup, parser, `nmem` path, API path, and dedupe
   guard are still covered.
 - OpenClaw: installs a package-shaped local plugin copy, enables session digest
-  plus the Nowledge Mem context engine slot, points the plugin at the test Mem
-  API through restored plugin config, and verifies an `openclaw` thread.
+  plus the Nowledge Mem context engine slot inside an isolated temporary
+  `OPENCLAW_HOME` / `OPENCLAW_STATE_DIR`, points the plugin at the test Mem API,
+  and verifies an `openclaw` thread without mutating the user's real
+  `~/.openclaw/extensions` or plugin install records.
 - Hermes: installs the local provider into an isolated `HERMES_HOME`, enables
   `memory.provider: nowledge-mem`, and verifies `on_session_end` saved a
   `hermes` thread.

--- a/tests/plugin_e2e/test_key_plugins_e2e.py
+++ b/tests/plugin_e2e/test_key_plugins_e2e.py
@@ -284,8 +284,8 @@ def test_key_plugin_static_contracts_are_declared():
     openclaw_spawn_env = (OPENCLAW_PLUGIN / "src" / "spawn-env.js").read_text(encoding="utf-8")
     openclaw_context_tool = (OPENCLAW_PLUGIN / "src" / "tools" / "context.js").read_text(encoding="utf-8")
     schema = openclaw_manifest["configSchema"]["properties"]
-    assert openclaw_manifest["version"] == "0.8.25"
-    assert openclaw_pkg["version"] == "0.8.25"
+    assert openclaw_manifest["version"] == "0.8.26"
+    assert openclaw_pkg["version"] == "0.8.26"
     assert openclaw_manifest["kind"] == ["memory", "context-engine"]
     assert "skills/memory-guide" in openclaw_manifest["skills"]
     assert schema["sessionDigest"]["default"] is True
@@ -406,7 +406,7 @@ def test_registry_connect_contract_points_agent_prompts_to_universal_skill():
     assert by_id["gemini-cli"]["version"] == "0.1.9"
     assert by_id["cursor"]["version"] == "0.1.6"
     assert by_id["droid"]["version"] == "0.1.1"
-    assert by_id["openclaw"]["version"] == "0.8.25"
+    assert by_id["openclaw"]["version"] == "0.8.26"
     assert by_id["proma"]["version"] == "0.1.1"
     assert by_id["opencode"]["version"] == "0.3.4"
     assert "nowledge_mem_context_bundle" in by_id["opencode"]["toolNaming"]["tools"]
@@ -711,9 +711,29 @@ def test_openclaw_live_hooks_and_context_engine_capture(e2e_context: E2EContext,
             "*.log",
         ),
     )
-    default_config = Path.home() / ".openclaw" / "openclaw.json"
-    default_config_backup = default_config.read_bytes() if not profile and default_config.exists() else None
-    default_config_existed = default_config_backup is not None
+    # OpenClaw profiles isolate config selection, but plugin installs and
+    # install records live under the OpenClaw state dir. Never let this live E2E
+    # rewrite the maintainer's real ~/.openclaw/extensions or plugins.installs.
+    real_state = Path(os.environ.get("NMEM_E2E_OPENCLAW_SOURCE_STATE", Path.home() / ".openclaw"))
+    isolated_home = tmp_path / "openclaw-home"
+    isolated_state = isolated_home / ".openclaw"
+    isolated_state.mkdir(parents=True)
+    real_config = real_state / "openclaw.json"
+    isolated_config = isolated_state / "openclaw.json"
+    if real_config.exists():
+        shutil.copy2(real_config, isolated_config)
+    else:
+        isolated_config.write_text("{}", encoding="utf-8")
+    for dirname in ("agents", "credentials", "identity"):
+        source = real_state / dirname
+        if source.exists():
+            shutil.copytree(source, isolated_state / dirname, dirs_exist_ok=True)
+    host_env = {
+        **e2e_context.env,
+        "OPENCLAW_HOME": str(isolated_home),
+        "OPENCLAW_STATE_DIR": str(isolated_state),
+        "OPENCLAW_CONFIG_PATH": str(isolated_config),
+    }
     config_ops: list[dict[str, Any]] = [
         {"path": "plugins.entries.openclaw-nowledge-mem.enabled", "value": True},
         {"path": "plugins.entries.openclaw-nowledge-mem.config.sessionDigest", "value": True},
@@ -739,41 +759,35 @@ def test_openclaw_live_hooks_and_context_engine_capture(e2e_context: E2EContext,
         config_ops.append({"path": "agents.defaults.model.primary", "value": os.environ["NMEM_E2E_OPENCLAW_MODEL"]})
     batch_file = tmp_path / "openclaw-config.json"
     batch_file.write_text(json.dumps(config_ops), encoding="utf-8")
-    try:
-        # OpenClaw profiles isolate config, not the installed extension directory.
-        # Install a package-shaped copy with --force so the safety scanner sees what
-        # users receive from npm/ClawHub instead of checkout-only test fixtures.
-        _run([*base, "plugins", "install", str(plugin_copy), "--force"], env=e2e_context.env, timeout=120)
-        _run([*base, "config", "set", "--batch-file", str(batch_file)], env=e2e_context.env, timeout=60)
 
-        prompt = f"Reply with exactly: done {e2e_context.marker}"
-        _run(
-            [
-                *base,
-                "agent",
-                "--local",
-                "--session-id",
-                f"nmem-e2e-{e2e_context.run_id}",
-                "--message",
-                prompt,
-                "--json",
-                "--timeout",
-                os.environ.get("NMEM_E2E_OPENCLAW_TIMEOUT_SECONDS", "180"),
-            ],
-            env=e2e_context.env,
-            timeout=int(os.environ.get("NMEM_E2E_OPENCLAW_TIMEOUT_SECONDS", "180")) + 30,
-        )
-        _poll_thread(
-            marker=e2e_context.marker,
-            source="openclaw",
-            space=e2e_context.space,
-            env=e2e_context.env,
-        )
-    finally:
-        if default_config_backup is not None:
-            default_config.write_bytes(default_config_backup)
-        elif not profile and not default_config_existed and default_config.exists():
-            default_config.unlink()
+    # Install a package-shaped copy with --force so the safety scanner sees what
+    # users receive from npm/ClawHub instead of checkout-only test fixtures.
+    _run([*base, "plugins", "install", str(plugin_copy), "--force"], env=host_env, timeout=120)
+    _run([*base, "config", "set", "--batch-file", str(batch_file)], env=host_env, timeout=60)
+
+    prompt = f"Reply with exactly: done {e2e_context.marker}"
+    _run(
+        [
+            *base,
+            "agent",
+            "--local",
+            "--session-id",
+            f"nmem-e2e-{e2e_context.run_id}",
+            "--message",
+            prompt,
+            "--json",
+            "--timeout",
+            os.environ.get("NMEM_E2E_OPENCLAW_TIMEOUT_SECONDS", "180"),
+        ],
+        env=host_env,
+        timeout=int(os.environ.get("NMEM_E2E_OPENCLAW_TIMEOUT_SECONDS", "180")) + 30,
+    )
+    _poll_thread(
+        marker=e2e_context.marker,
+        source="openclaw",
+        space=e2e_context.space,
+        env=e2e_context.env,
+    )
 
 
 @pytest.mark.skipif(_skip_live_host("hermes"), reason="Hermes live E2E not requested")


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved archive integrity mismatch issues by supporting forced plugin reinstallation.

* **Documentation**
  * Updated minimum OpenClaw requirement to version 2026.5.3+.
  * Added installation guidance for updating plugins with the `--force` flag.
  * Enhanced troubleshooting section for archive integrity errors.

* **Chores**
  * Bumped plugin version to 0.8.26.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->