### PR TITLE
docs(hermes): expose historical session sync

### DIFF
--- a/integrations.json
+++ b/integrations.json
@@ -744,7 +744,8 @@
       },
       "threadSave": {
         "method": "cli-native",
-        "note": "The native provider captures cleaned Hermes transcripts through the memory-provider lifecycle, with a post-LLM hook fallback for Hermes builds that route user plugins through the general hook loader. The first save imports the thread; later saves in the same live session append only the delta through the Mem API."
+        "historicalCommand": "nmem t sync --from hermes",
+        "note": "The native provider captures cleaned Hermes transcripts through the memory-provider lifecycle, with a post-LLM hook fallback for Hermes builds that route user plugins through the general hook loader. The first save imports the thread; later saves in the same live session append only the delta through the Mem API. Use nmem t sync --from hermes --apply to backfill older sessions from ~/.hermes/state.db, including remote Mem setups."
       },
       "autonomy": {
         "bootstrap": "automatic",
@@ -754,7 +755,8 @@
         "bestResultRequires": [
           "Install the native Hermes provider or configure the MCP fallback",
           "Point the local nmem client at Mem when using remote mode",
-          "Use the native provider and let Hermes end or reset the session cleanly so the session-boundary hook can flush the transcript"
+          "Use the native provider and let Hermes end or reset the session cleanly so the session-boundary hook can flush the transcript",
+          "Run nmem t sync --from hermes --apply when you want to import older Hermes sessions from state.db"
         ]
       },
       "install": {

--- a/nowledge-mem-hermes/README.md
+++ b/nowledge-mem-hermes/README.md
@@ -88,6 +88,15 @@ The plugin uses Hermes' memory provider lifecycle to replace manual Context Bund
 
 Durable knowledge saves still happen through the native `nmem_` tools. In addition, the provider captures cleaned Hermes transcript turns as Mem threads while the conversation runs, then performs a final delta flush at real session boundaries such as clean exit, `/new`, and `/reset`. The first write for each Hermes `session_id` imports a thread; later writes for that same session append only the delta. Transcript payloads use the Mem API directly so long sessions are not squeezed into shell arguments.
 
+For conversations that already existed before you installed the provider, run a historical import from the machine where Hermes is installed:
+
+```bash
+nmem t sync --from hermes          # preview only
+nmem t sync --from hermes --apply  # import ~/.hermes/state.db into Mem threads
+```
+
+This also works with remote Mem because the local `nmem` client reads Hermes' local SQLite database and uploads normalized threads to the configured Mem server. The command is safe to rerun: it uses the same Hermes `session_id` thread IDs as the live provider and appends with message deduplication.
+
 ## Tools
 
 Plugin mode exposes tools directly (no prefix):

--- a/tests/plugin_e2e/test_key_plugins_e2e.py
+++ b/tests/plugin_e2e/test_key_plugins_e2e.py
@@ -261,6 +261,7 @@ def test_key_plugin_static_contracts_are_declared():
     assert historical_commands["gemini-cli"] == "nmem t sync --from gemini-cli --all-projects"
     assert historical_commands["opencode"] == "nmem t sync --from opencode --all-projects"
     assert historical_commands["pi"] == "nmem t sync --from pi"
+    assert historical_commands["hermes"] == "nmem t sync --from hermes"
 
     claude_manifest = _read_json(CLAUDE_PLUGIN / ".claude-plugin" / "plugin.json")
     claude_hooks = _read_json(CLAUDE_PLUGIN / "hooks" / "hooks.json")["hooks"]


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Historical Hermes conversation import now available for syncing into Nowledge Mem
  * Remote Mem mode now supports thread uploads from local Hermes storage
  * Safe command rerunning with automatic message deduplication

* **Documentation**
  * Added guide for importing existing Hermes conversations into Nowledge Mem

<!-- end of auto-generated comment: release notes by coderabbit.ai -->