### PR TITLE
docs(cursor): expose transcript import path

### DIFF
--- a/integrations.json
+++ b/integrations.json
@@ -446,7 +446,7 @@
         "bootstrap": "automatic",
         "recall": "guided",
         "distill": "guided",
-        "threads": "external-import",
+        "threads": "import-only",
         "bestResultRequires": [
           "Copy the local Cursor plugin and reload Cursor",
           "Keep nmem available for session-start bootstrap, handoff, and Cursor Agent transcript import",

--- a/integrations.json
+++ b/integrations.json
@@ -438,17 +438,18 @@
         "status": false
       },
       "threadSave": {
-        "method": "none",
-        "note": "Cursor lacks a native transcript importer; save-handoff used instead"
+        "method": "external",
+        "historicalCommand": "nmem t sync --from cursor --all-projects",
+        "note": "The Cursor plugin exposes save-handoff. Mem desktop and nmem can import real Cursor Agent transcripts from ~/.cursor/projects."
       },
       "autonomy": {
         "bootstrap": "automatic",
         "recall": "guided",
         "distill": "guided",
-        "threads": "handoff-only",
+        "threads": "external-import",
         "bestResultRequires": [
           "Copy the local Cursor plugin and reload Cursor",
-          "Keep nmem available for session-start bootstrap and handoff",
+          "Keep nmem available for session-start bootstrap, handoff, and Cursor Agent transcript import",
           "If Mem is remote, configure both Cursor MCP and the local nmem client"
         ]
       },


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Cursor integration now supports external transcript handling and import of historical sessions.
  * Conversation threads can be stored externally for backup and continuity.
  * Session bootstrap now preserves memory availability for handoff and transcript import.
  * Requires reloading the local Cursor plugin for the updated import behavior to take effect.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->