### PR TITLE
Dev 0908

### DIFF
--- a/integrations.json
+++ b/integrations.json
@@ -579,7 +579,7 @@
       "name": "Alma",
       "category": "coding",
       "type": "plugin",
-      "version": "0.7.2",
+      "version": "0.7.3",
       "directory": "nowledge-mem-alma-plugin",
       "transport": "http",
       "capabilities": {
@@ -602,6 +602,7 @@
         "threads": "automatic-capture",
         "bestResultRequires": [
           "Install the Alma marketplace plugin",
+          "Enable the bundled nowledge-mem Skill if you use Alma's Skills surface",
           "Leave autoCapture enabled unless you intentionally want manual thread handling"
         ]
       },
@@ -610,8 +611,8 @@
         "updateCommand": "In Alma: Settings > Plugins > Marketplace, find Nowledge Mem, click Update",
         "detectionHint": "Running inside Alma; ~/.config/alma/ exists",
         "agentGuide": {
-          "prompt": "Read https://mem.nowledge.co/SKILL.md and follow the instructions to install or update Nowledge Mem for Alma. Verify with nmem status and the Context Bundle or Working Memory check, then summarize what changed.",
-          "promptZh": "读取 https://mem.nowledge.co/SKILL.md，按其中说明为 Alma 安装或更新 Nowledge Mem。用 nmem status 和 Context Bundle 或 Working Memory 检查验证结果，并总结你改了什么。"
+          "prompt": "Read https://mem.nowledge.co/SKILL.md and follow the instructions to install or update Nowledge Mem for Alma. If you use Alma Skills, enable the bundled nowledge-mem Skill or copy it to ~/.config/alma/skills/nowledge-mem. Verify with nmem status and the Context Bundle or Working Memory check, then summarize what changed.",
+          "promptZh": "读取 https://mem.nowledge.co/SKILL.md，按其中说明为 Alma 安装或更新 Nowledge Mem。如果你使用 Alma Skills，请启用随插件附带的 nowledge-mem Skill，或复制到 ~/.config/alma/skills/nowledge-mem。用 nmem status 和 Context Bundle 或 Working Memory 检查验证结果，并总结你改了什么。"
         },
         "docsUrl": "/docs/integrations/alma"
       },
@@ -620,7 +621,7 @@
         "prefix": "nowledge_mem_",
         "tools": ["nowledge_mem_query", "nowledge_mem_search", "nowledge_mem_store", "nowledge_mem_show", "nowledge_mem_update", "nowledge_mem_delete", "nowledge_mem_context_bundle", "nowledge_mem_working_memory", "nowledge_mem_status", "nowledge_mem_thread_search", "nowledge_mem_thread_show", "nowledge_mem_thread_create", "nowledge_mem_thread_delete"]
       },
-      "skills": [],
+      "skills": ["nowledge-mem"],
       "slashCommands": []
     },
     {

--- a/nowledge-mem-alma-plugin/CHANGELOG.md
+++ b/nowledge-mem-alma-plugin/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 0.7.3
+
+### Added
+
+- Ships a native Alma Skill at `skills/nowledge-mem/SKILL.md`, so users who use Alma's Skills page can enable Nowledge Mem guidance without copying the legacy prompt by hand.
+
 ## 0.7.2
 
 ### Changed

--- a/nowledge-mem-alma-plugin/CLAUDE.md
+++ b/nowledge-mem-alma-plugin/CLAUDE.md
@@ -9,10 +9,11 @@ This file is a practical continuation guide for future agent sessions working on
 - Runtime: plain ESM (`main.js`), no build step
 - Memory backend: direct HTTP to Nowledge Mem API (default `http://127.0.0.1:14242`). CLI (`nmem`) is only used for diagnostic in the status tool.
 
-## Current Status (as of v0.6.15)
+## Current Status (as of v0.7.3)
 
-- Plugin is installed/activated and registers 12 tools successfully in Alma logs.
+- Plugin is installed/activated and registers 13 tools successfully in Alma logs.
 - Live thread sync works via three hooks: `willSend` (user msg + recall), `didReceive` (AI response + idle timer), `thread.activated` (flush on switch).
+- The plugin ships a native Alma Skill at `skills/nowledge-mem/SKILL.md`; it is supplementary guidance on top of tools/hooks.
 - Thread IDs are deterministic: `alma-{sha1(almaThreadId)[:12]}`. Survives plugin restarts, LRU eviction, and Alma relaunches. First flush tries append (thread may exist from prior session), falls back to create.
 - All message data from hook payloads, never `context.chat.getMessages()`.
 - Titles resolved at flush time via `context.chat.getThread()` with 4-strategy fallback.
@@ -33,7 +34,8 @@ This file is a practical continuation guide for future agent sessions working on
 - `main.js`: all logic (tool registration, hooks, nmem client, validation/error mapping)
 - `manifest.json`: plugin metadata + contributed tools + settings schema
 - `README.md`: user-facing behavior, response contract examples
-- `alma-skill-nowledge-mem.md`: optional skill policy for better tool-calling
+- `skills/nowledge-mem/SKILL.md`: native Alma Skill policy for better tool-calling
+- `alma-skill-nowledge-mem.md`: legacy copy/paste skill policy for older manual setups
 - `CHANGELOG.md`: versioned changes
 
 ## Tool Inventory
@@ -46,6 +48,7 @@ Registered IDs (plugin-qualified at runtime as `nowledge-mem.<id>`):
 - `nowledge_mem_show`
 - `nowledge_mem_update`
 - `nowledge_mem_delete`
+- `nowledge_mem_context_bundle`
 - `nowledge_mem_working_memory`
 - `nowledge_mem_status`
 - `nowledge_mem_thread_search`
@@ -95,7 +98,9 @@ curl -s 'http://127.0.0.1:14242/memories/search?q=alma&limit=3'   # Test search 
 ## Reinstall / Reload in Alma
 
 ```bash
+mkdir -p ~/.config/alma/plugins/nowledge-mem
 cp manifest.json main.js package.json README.md CHANGELOG.md alma-skill-nowledge-mem.md ~/.config/alma/plugins/nowledge-mem/
+cp -R skills ~/.config/alma/plugins/nowledge-mem/
 osascript -e 'tell application "Alma" to quit' || true
 node -e "const fs=require('fs');const p=process.env.HOME+'/Library/Application Support/alma/plugin-cache';if(fs.existsSync(p))for(const f of fs.readdirSync(p))if(f.endsWith('.mjs'))fs.unlinkSync(p+'/'+f)"
 open -a Alma
@@ -131,7 +136,7 @@ All three hooks used by live sync are confirmed working in Alma (verified v0.6.1
 
 ## Known Limitations
 
-1. **Skill file requires manual setup** — Alma has no `contributes.skills` or programmatic skill registration API. The `alma-skill-nowledge-mem.md` file must be manually loaded into Alma's settings by the user. The plugin injects core behavioral guidance via the `chat.message.willSend` hook, so the skill file is supplementary.
+1. **Skill file is supplementary** — Alma reads native `SKILL.md` folders, and the plugin now ships `skills/nowledge-mem/SKILL.md`. If Alma does not surface the bundled skill from the plugin package, users can copy it to `~/.config/alma/skills/nowledge-mem/SKILL.md` and refresh Skills. The plugin still injects core behavioral guidance via the `chat.message.willSend` hook, so memory tools and thread sync do not depend on the Skill.
 2. **`recallPolicy` live reload is incomplete** — `recallInjectionEnabled` and `recallFrequency` are `const` computed once at activation. If the user changes `recallPolicy` at runtime via `onDidChange`, the hook registration state doesn't change. Fix requires disposing and re-registering the hook.
 
 ## Recommended Next Improvements

--- a/nowledge-mem-alma-plugin/README.md
+++ b/nowledge-mem-alma-plugin/README.md
@@ -103,11 +103,11 @@ No modal input commands are used. The plugin is designed to stay inside normal c
 
 ## Native Alma Skill
 
-The plugin includes a native Alma Skill at `skills/nowledge-mem/SKILL.md`. Enable it from Alma's Skills surface when you want stronger guidance for when to read Context Bundle, search memory, inspect prior threads, or save durable decisions.
+The plugin includes a native Alma Skill at `skills/nowledge-mem/SKILL.md`. After installing the plugin, open Alma's Skills surface. If the bundled `nowledge-mem` Skill appears there, enable it when you want stronger guidance for when to read Context Bundle, search memory, inspect prior threads, or save durable decisions.
 
 The plugin works without the Skill: tools, auto-recall, and thread sync are registered by the plugin itself. The Skill is supplementary; it improves model intent, especially in chats where Alma exposes Skills prominently.
 
-If the Skill does not appear automatically after installation, copy it into Alma's personal skills folder and refresh Skills:
+If the bundled Skill does not appear after installation, copy it into Alma's personal skills folder and refresh Skills:
 
 ```bash
 mkdir -p ~/.config/alma/skills/nowledge-mem

--- a/nowledge-mem-alma-plugin/README.md
+++ b/nowledge-mem-alma-plugin/README.md
@@ -11,6 +11,7 @@ This plugin gives Alma chat-native persistent memory:
 - Dedup guard: prevents saving near-identical memories (>=90% similarity)
 - Inject Context Bundle + relevant recall context before first send, with Working Memory fallback for older servers
 - Behavioral guidance: proactive save nudge + thread awareness in every turn
+- Native Alma Skill bundle for stronger tool-selection guidance in Alma's Skills surface
 - Save thread snapshots back to Nowledge Mem on quit (optional)
 
 Data operations use the Nowledge Mem HTTP API, so local desktop and remote Access Anywhere setups share the same behavior. The status tool may still use `nmem` / `uvx --from nmem-cli nmem` for diagnostics.
@@ -51,6 +52,7 @@ cp -R . ~/.config/alma/plugins/nowledge-mem
 | `nowledge_mem_delete` | Delete memory |
 | `nowledge_mem_context_bundle` | Read startup context: owner identity, AI Identity, active scope, active rules, Working Memory, and KFS paths. |
 | `nowledge_mem_working_memory` | Read daily Working Memory. Use Context Bundle for full startup identity/scope/rules context. |
+| `nowledge_mem_status` | Check connection mode, server health, CLI availability, and current plugin settings. |
 | `nowledge_mem_thread_search` | Search conversation threads with optional `source` filter |
 | `nowledge_mem_thread_show` | Fetch thread messages with pagination (`offset`/`limit`). Returns `hasMore`. |
 | `nowledge_mem_thread_create` | Create thread from content/messages |
@@ -99,17 +101,27 @@ cp -R . ~/.config/alma/plugins/nowledge-mem
 
 No modal input commands are used. The plugin is designed to stay inside normal chat flow via tool calls and hooks.
 
-## Optional Skill Prompt
+## Native Alma Skill
 
-For deeper tool-usage guidance (execution order, query heuristics, write heuristics, CLI fallback), load `alma-skill-nowledge-mem.md` into an Alma skill and enable it for chats that should prioritize external memory operations.
+The plugin includes a native Alma Skill at `skills/nowledge-mem/SKILL.md`. Enable it from Alma's Skills surface when you want stronger guidance for when to read Context Bundle, search memory, inspect prior threads, or save durable decisions.
 
-Note: Alma does not have a programmatic skill registration API. The skill file must be loaded manually into Alma's settings. The plugin already injects core behavioral guidance via the `chat.message.willSend` hook, so the skill file is supplementary — it adds more detailed instructions for power users.
+The plugin works without the Skill: tools, auto-recall, and thread sync are registered by the plugin itself. The Skill is supplementary; it improves model intent, especially in chats where Alma exposes Skills prominently.
+
+If the Skill does not appear automatically after installation, copy it into Alma's personal skills folder and refresh Skills:
+
+```bash
+mkdir -p ~/.config/alma/skills/nowledge-mem
+cp ~/.config/alma/plugins/nowledge-mem/skills/nowledge-mem/SKILL.md \
+  ~/.config/alma/skills/nowledge-mem/SKILL.md
+```
+
+`alma-skill-nowledge-mem.md` remains as a legacy copy/paste prompt for older Alma builds or manual setups.
 
 ## Customize without editing the plugin
 
 Alma does not currently have a separate packaged override file in this integration.
 
-- Use Alma's own settings and manually loaded skill prompt for extra behavior guidance.
+- Use Alma's own settings and the bundled native Skill for extra behavior guidance.
 - Keep plugin-level behavior changes in Alma settings such as recall policy, capture policy, remote settings, and space selection.
 - Do not patch the installed plugin bundle under `~/.config/alma/plugins/nowledge-mem`.
 

--- a/nowledge-mem-alma-plugin/manifest.json
+++ b/nowledge-mem-alma-plugin/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "nowledge-mem",
   "name": "Nowledge Mem",
-  "version": "0.7.2",
+  "version": "0.7.3",
   "description": "Local-first personal memory for Alma, powered by Nowledge Mem",
   "author": {
     "name": "Nowledge Labs",

--- a/nowledge-mem-alma-plugin/package.json
+++ b/nowledge-mem-alma-plugin/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@nowledge/alma-nowledge-mem",
-	"version": "0.7.2",
+	"version": "0.7.3",
 	"type": "module",
 	"description": "Nowledge Mem plugin for Alma, local-first personal knowledge base",
 	"author": {

--- a/nowledge-mem-alma-plugin/skills/nowledge-mem/SKILL.md
+++ b/nowledge-mem-alma-plugin/skills/nowledge-mem/SKILL.md
@@ -1,0 +1,69 @@
+---
+name: nowledge-mem
+description: Use Nowledge Mem in Alma for external memory, prior-thread recall, Context Bundle startup context, durable memory saves, and thread history lookup.
+---
+
+# Nowledge Mem
+
+Use Nowledge Mem as Alma's external memory system.
+
+## First Move
+
+At the start of work that may depend on identity, active scope, Rules, recent priorities, or prior decisions, call `nowledge_mem_context_bundle`.
+
+Use `nowledge_mem_working_memory` only when you need the lighter daily briefing or when Context Bundle is unavailable.
+
+## Retrieval
+
+- Use `nowledge_mem_query` for broad recall across memories, with thread fallback.
+- Use `nowledge_mem_search` for focused memory retrieval.
+- Use `nowledge_mem_thread_search` when the user is asking about conversation history.
+- When a memory includes `sourceThreadId`, use `nowledge_mem_thread_show` to inspect the original conversation before making strong claims.
+
+Start with a narrow query. Fetch more pages only when the current result is not enough.
+
+## Saving
+
+Use `nowledge_mem_store` when the conversation produces durable knowledge:
+
+- decisions
+- user preferences
+- debugging conclusions
+- workflow agreements
+- plans that should survive the current chat
+- facts about the user's projects or work
+
+Choose `unit_type` deliberately: `decision`, `learning`, `preference`, `fact`, `plan`, `procedure`, `context`, or `event`.
+
+Do not save pleasantries or filler. If the user explicitly asks you to remember something, save it.
+
+## Corrections And Cleanup
+
+- Use `nowledge_mem_update` when a remembered item is wrong but should remain.
+- Use `nowledge_mem_delete` only when the user clearly wants a memory removed.
+- Use thread delete tools only on explicit user intent.
+
+## If Tools Are Hidden
+
+If Alma does not expose plugin tools in the current thread, use Bash with `nmem` when available:
+
+```bash
+nmem --json context read --source-app alma
+nmem --json m search "<query>" -n 5
+nmem --json t search "<query>" -n 5 --source alma
+nmem --json t show <thread_id> -n 30 --offset 0 --content-limit 1200
+nmem --json m add "<content>" -t "<title>" --unit-type decision
+```
+
+If neither plugin tools nor Bash are available, state the blocker and ask for one concrete enablement step.
+
+## Response Contract
+
+When memory affected the answer, include a short source line:
+
+- `Source: nowledge_mem_query`
+- `Source: nowledge_mem_search + nowledge_mem_show`
+- `Source: nowledge_mem_thread_search + nowledge_mem_thread_show`
+- `Source: nmem CLI`
+- `Source: injected recall context`
+

--- a/tests/plugin_e2e/test_key_plugins_e2e.py
+++ b/tests/plugin_e2e/test_key_plugins_e2e.py
@@ -30,6 +30,7 @@ CURSOR_PLUGIN = COMMUNITY_ROOT / "nowledge-mem-cursor-plugin"
 PI_PLUGIN = COMMUNITY_ROOT / "nowledge-mem-pi-package"
 BUB_PLUGIN = COMMUNITY_ROOT / "nowledge-mem-bub-plugin"
 BENCH_PACKAGE = COMMUNITY_ROOT / "nowledge-mem-bench"
+ALMA_PLUGIN = COMMUNITY_ROOT / "nowledge-mem-alma-plugin"
 KEY_HOSTS = {"claude", "codex", "openclaw", "hermes", "opencode", "pi"}
 
 
@@ -423,6 +424,16 @@ def test_key_plugin_static_contracts_are_declared():
     assert "stablePathSuffix" in pi_history_sync
     assert "custom_message" in pi_history_sync
 
+    alma_manifest = _read_json(ALMA_PLUGIN / "manifest.json")
+    alma_pkg = _read_json(ALMA_PLUGIN / "package.json")
+    alma_skill = ALMA_PLUGIN / "skills" / "nowledge-mem" / "SKILL.md"
+    alma_source = (ALMA_PLUGIN / "main.js").read_text(encoding="utf-8")
+    assert alma_manifest["version"] == "0.7.3"
+    assert alma_pkg["version"] == "0.7.3"
+    assert alma_skill.exists()
+    assert "nowledge_mem_context_bundle" in alma_skill.read_text(encoding="utf-8")
+    assert "nowledge_mem_context_bundle" in alma_source
+
 
 def test_pi_history_sync_script_previews_and_appends_idempotently(tmp_path: Path):
     if shutil.which("node") is None:
@@ -669,6 +680,9 @@ def test_registry_connect_contract_points_agent_prompts_to_universal_skill():
     assert by_id["proma"]["version"] == "0.1.1"
     assert by_id["opencode"]["version"] == "0.3.4"
     assert by_id["pi"]["version"] == "0.8.1"
+    assert by_id["alma"]["version"] == "0.7.3"
+    assert by_id["alma"]["skills"] == ["nowledge-mem"]
+    assert "nowledge_mem_context_bundle" in by_id["alma"]["toolNaming"]["tools"]
     assert by_id["pi"]["threadSave"]["method"] == "plugin-capture"
     assert by_id["pi"]["capabilities"]["autoCapture"] is True
     assert by_id["pi"]["autonomy"]["threads"] == "automatic-capture"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Native Alma Skill now bundled with the plugin, eliminating need for manual prompt copying during setup.
  * Added new tool for memory context initialization.

* **Documentation**
  * Updated installation and usage guides with skill activation instructions.

* **Chores**
  * Bumped version to 0.7.3.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation, packaging, and registry metadata only; no changes to Alma plugin runtime (`main.js`) or memory API behavior.
> 
> **Overview**
> **Alma Nowledge Mem 0.7.3** ships a bundled native Skill at `skills/nowledge-mem/SKILL.md` so users can enable memory/tool guidance from Alma’s Skills UI instead of copying `alma-skill-nowledge-mem.md` by hand. The Skill covers Context Bundle first moves, retrieval/save heuristics, `nmem` CLI fallback, and source attribution; plugin hooks and tools are unchanged and still work without it.
> 
> **Registry and docs** bump Alma to `0.7.3`, set `skills` to `["nowledge-mem"]`, extend install/agent prompts (EN/ZH) with Skill enable/copy steps, and add enabling the bundled Skill to `bestResultRequires`. Maintainer docs and README describe the native Skill path, manual copy fallback to `~/.config/alma/skills/`, and reinstall steps that copy the `skills/` tree.
> 
> **Tests** add static checks that the Alma package version, bundled Skill file, and `nowledge_mem_context_bundle` references stay aligned with `integrations.json`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f5adfaf771545c37335f1f5ea0647ab6e901665c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->