### PR TITLE
fix(proma): align hooks with current SDK layout

### DIFF
--- a/integrations.json
+++ b/integrations.json
@@ -838,7 +838,7 @@
       "name": "Proma",
       "category": "coding",
       "type": "plugin",
-      "version": "0.1.1",
+      "version": "0.1.2",
       "directory": "nowledge-mem-proma-plugin",
       "transport": "mcp",
       "capabilities": {
@@ -852,7 +852,7 @@
       },
       "threadSave": {
         "method": "plugin-capture",
-        "note": "Stop hook runs save-to-nmem.py which parses Proma session JSONL from ~/.proma/agent-sessions/ and appends messages to nmem via REST API. SessionStart hook injects Working Memory via read-working-memory.py."
+        "note": "UserPromptSubmit and Stop hooks run save-to-nmem.py, which parses Proma SDK JSONL from ~/.proma/sdk-config/projects/**/ and appends messages to nmem via REST API as source=proma. SessionStart writes Context Bundle into the workspace CLAUDE.md; Stop asyncRewake can push fresh Working Memory."
       },
       "autonomy": {
         "bootstrap": "automatic",
@@ -861,16 +861,16 @@
         "threads": "automatic-capture",
         "bestResultRequires": [
           "Add Nowledge Mem MCP server to ~/.proma/agent-workspaces/default/mcp.json (key: servers)",
-          "Copy hook scripts to ~/.proma/hooks/",
-          "Add Stop and SessionStart hooks to ~/.proma/settings.json",
+          "Copy hook scripts to ~/.proma/scripts/",
+          "Add SessionStart, UserPromptSubmit, and Stop hooks to ~/.proma/sdk-config/.claude/settings.json",
           "Copy the standard Nowledge Mem skill folders to ~/.proma/agent-workspaces/default/skills/",
-          "Add nmem usage guidance to CLAUDE.md for tool selection (nmem vs built-in MemOS)",
+          "Let the SessionStart hook maintain the marked Nowledge Mem block in ~/.proma/agent-workspaces/default/CLAUDE.md",
           "Restart Proma after configuration changes"
         ]
       },
       "install": {
         "command": "Manual setup — see plugin README for step-by-step instructions",
-        "updateCommand": "Replace hook scripts and skill files from latest plugin release",
+        "updateCommand": "Replace ~/.proma/scripts/save-to-nmem.py, ~/.proma/scripts/read-working-memory.py, Proma skill folders, and merge the latest hooks/hooks.json into ~/.proma/sdk-config/.claude/settings.json",
         "detectionHint": "~/.proma/agent-workspaces/default/mcp.json contains nowledge-mem server",
         "agentGuide": {
           "prompt": "Read https://mem.nowledge.co/SKILL.md and follow the instructions to install or update Nowledge Mem for Proma. Verify with nmem status and the Context Bundle or Working Memory check, then summarize what changed.",

--- a/nowledge-mem-proma-plugin/.claude-plugin/plugin.json
+++ b/nowledge-mem-proma-plugin/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "nowledge-mem",
-  "description": "Personal knowledge graph for Proma — remembers decisions, searches past work, captures sessions across Proma workspaces",
-  "version": "0.1.1",
+  "description": "Personal knowledge graph for Proma — saves Proma conversations, writes startup context into CLAUDE.md, and keeps nmem tools available during work",
+  "version": "0.1.2",
   "author": {
     "name": "Nowledge Labs",
     "email": "hello@nowledge-labs.ai",

--- a/nowledge-mem-proma-plugin/CHANGELOG.md
+++ b/nowledge-mem-proma-plugin/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog — nowledge-mem-proma-plugin
 
+## 0.1.2 (2026-06-13)
+
+- Align hooks with current Proma builds: install into `~/.proma/sdk-config/.claude/settings.json`, copy scripts to `~/.proma/scripts/`, and read transcripts from `~/.proma/sdk-config/projects/**/<session-id>.jsonl`.
+- Add `UserPromptSubmit` capture for near-real-time thread sync, with `Stop` remaining as the fallback save.
+- Replace stdout-only startup context with an idempotent Nowledge Mem block in Proma's workspace `CLAUDE.md`, preserving user-authored content and `CLAUDE.md.template`.
+- Add `Stop` asyncRewake Working Memory refresh for live context reminders after assistant turns.
+- Keep local/remote nmem config support and legacy `~/.proma/agent-sessions/` transcript fallback.
+
 ## 0.1.1 (2026-06-06)
 
 - SessionStart now loads Context Bundle when available, then falls back to Working Memory. Proma receives identity, active scope, active rules, and current priorities on newer Nowledge Mem installs without losing compatibility with older `nmem` clients.

--- a/nowledge-mem-proma-plugin/README.md
+++ b/nowledge-mem-proma-plugin/README.md
@@ -1,23 +1,40 @@
 # Nowledge Mem Plugin for Proma
 
-Integrates Nowledge Mem's personal knowledge graph into [Proma](https://github.com/proma-ai/proma), an extensible desktop AI agent built on the Claude Agent SDK. Provides persistent cross-session memory through MCP tools, lifecycle hooks, and companion skills.
+Connects [Proma](https://github.com/proma-ai/proma) to Nowledge Mem so Proma can:
 
-> **What is Proma?** Proma is a desktop AI agent application that combines a chat UI with an extensible plugin/skill system. It uses the Claude Agent SDK under the hood, giving it access to the same MCP and hook infrastructure as Claude Code, but with its own configuration surface (`mcp.json` with `"servers"` key, `settings.json` for hooks, workspace-level skills). Think of it as "Claude Code with a desktop GUI and plugin marketplace." [GitHub: proma-ai/proma](https://github.com/proma-ai/proma)
+- save Proma agent conversations into Nowledge Mem threads
+- load Nowledge Mem context when a Proma workspace starts
+- search and write memories through the Nowledge Mem MCP tools
+- use the standard Nowledge Mem skills as a manual fallback
+
+Proma is built on the Claude Agent SDK, but it keeps its own configuration under `~/.proma/`. Use the Proma paths below, not the Claude Code paths.
 
 ## Prerequisites
 
-- [Proma](https://github.com/proma-ai/proma) desktop app
-- Nowledge Mem server running (desktop app or remote)
-- Python 3.9+ (for hook scripts)
-- `nmem` CLI in PATH (bundled with [Nowledge Mem desktop app](https://mem.nowledge.co/), `pip install nmem-cli`, or on Arch Linux `yay -S nmem-cli` / `paru -S nmem-cli`)
+- Proma desktop app
+- Nowledge Mem desktop app or remote server
+- Python 3.9+
+- `nmem` CLI in PATH, or `uvx` available as fallback
 
-## Installation
+Check Nowledge Mem first:
 
-### 1. Configure MCP Server
+```bash
+nmem status
+```
 
-Add the Nowledge Mem MCP server to your Proma workspace `mcp.json`:
+## Install
 
-**Path:** `~/.proma/agent-workspaces/default/mcp.json`
+### 1. Configure MCP
+
+Add Nowledge Mem to your Proma workspace MCP config.
+
+Path:
+
+```text
+~/.proma/agent-workspaces/default/mcp.json
+```
+
+Local Nowledge Mem:
 
 ```json
 {
@@ -33,7 +50,7 @@ Add the Nowledge Mem MCP server to your Proma workspace `mcp.json`:
 }
 ```
 
-Local Nowledge Mem usually does not require an API key. For remote Mem setups, replace the URL with your remote server and add your key:
+Remote Nowledge Mem:
 
 ```json
 {
@@ -51,44 +68,72 @@ Local Nowledge Mem usually does not require an API key. For remote Mem setups, r
 }
 ```
 
-### 2. Install Hook Scripts
+### 2. Install hook scripts
 
-Copy the hook scripts to your Proma hooks directory:
+Copy the bundled hook scripts into Proma's script directory:
 
 ```bash
-mkdir -p ~/.proma/hooks/
-cp hooks/save-to-nmem.py ~/.proma/hooks/
-cp hooks/read-working-memory.py ~/.proma/hooks/
+mkdir -p ~/.proma/scripts
+cp hooks/save-to-nmem.py ~/.proma/scripts/
+cp hooks/read-working-memory.py ~/.proma/scripts/
+chmod +x ~/.proma/scripts/save-to-nmem.py ~/.proma/scripts/read-working-memory.py
 ```
 
-### 3. Enable Lifecycle Hooks
+### 3. Enable lifecycle hooks
 
-Merge the hooks configuration from `hooks/hooks.json` into `~/.proma/settings.json`:
+Merge `hooks/hooks.json` into Proma's Claude SDK hook config:
+
+```text
+~/.proma/sdk-config/.claude/settings.json
+```
+
+The important pieces are:
 
 ```json
 {
   "hooks": {
-    "Stop": [
-      {
-        "hooks": [
-          {
-            "type": "command",
-            "command": "python \"<proma-home>/hooks/save-to-nmem.py\"",
-            "timeout": 30,
-            "async": true
-          }
-        ]
-      }
-    ],
     "SessionStart": [
       {
         "matcher": "startup|resume",
         "hooks": [
           {
             "type": "command",
-            "command": "python \"<proma-home>/hooks/read-working-memory.py\"",
-            "timeout": 10,
-            "async": true
+            "command": "python \"$HOME/.proma/scripts/read-working-memory.py\"",
+            "timeout": 15000
+          }
+        ]
+      }
+    ],
+    "UserPromptSubmit": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python \"$HOME/.proma/scripts/save-to-nmem.py\" --event user-prompt-submit",
+            "timeout": 30000
+          }
+        ]
+      }
+    ],
+    "Stop": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python \"$HOME/.proma/scripts/save-to-nmem.py\" --event stop",
+            "timeout": 30000
+          }
+        ]
+      },
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python \"$HOME/.proma/scripts/read-working-memory.py\" --rewake",
+            "timeout": 15000,
+            "async": true,
+            "asyncRewake": true,
+            "rewakeMessage": "Nowledge Mem context refreshed"
           }
         ]
       }
@@ -97,106 +142,126 @@ Merge the hooks configuration from `hooks/hooks.json` into `~/.proma/settings.js
 }
 ```
 
-Replace `<proma-home>` with your actual Proma home path (usually `~/.proma` on macOS/Linux or `C:\Users\<user>\.proma` on Windows).
+If your Proma build expands environment variables, you can set `PROMA_HOME="$HOME/.proma"` and keep the `${PROMA_HOME}` commands from `hooks/hooks.json`. If not, use absolute paths in `settings.json`.
 
-If your Proma build expands environment variables in hook commands, you can instead set `PROMA_HOME` and keep the bundled `${PROMA_HOME}` paths from `hooks/hooks.json`:
+### 4. Install skills
 
-```bash
-export PROMA_HOME="$HOME/.proma"
-```
-
-The Python scripts also default to `~/.proma` when `PROMA_HOME` is not set, but the hook command itself still needs a path Proma can execute. The most portable setup is to use the literal path in `settings.json`.
-
-### 4. Install the Skills
-
-Copy the skill files to your Proma workspace:
+Copy the standard Nowledge Mem skills into the Proma workspace:
 
 ```bash
-cp -r skills/read-working-memory ~/.proma/agent-workspaces/default/skills/
-cp -r skills/search-memory ~/.proma/agent-workspaces/default/skills/
-cp -r skills/distill-memory ~/.proma/agent-workspaces/default/skills/
-cp -r skills/save-thread ~/.proma/agent-workspaces/default/skills/
-cp -r skills/status ~/.proma/agent-workspaces/default/skills/
+mkdir -p ~/.proma/agent-workspaces/default/skills
+cp -R skills/read-working-memory ~/.proma/agent-workspaces/default/skills/
+cp -R skills/search-memory ~/.proma/agent-workspaces/default/skills/
+cp -R skills/distill-memory ~/.proma/agent-workspaces/default/skills/
+cp -R skills/save-thread ~/.proma/agent-workspaces/default/skills/
+cp -R skills/status ~/.proma/agent-workspaces/default/skills/
 ```
 
-### 5. (Recommended) Add CLAUDE.md Guidance
+### 5. Restart Proma
 
-Add the following guidance to your CLAUDE.md so Proma knows when to use nmem vs built-in memory:
+Restart Proma after changing MCP, hooks, or skills.
+
+## What each part does
+
+### Thread sync
+
+`UserPromptSubmit` and `Stop` run `save-to-nmem.py`.
+
+The script reads Proma's current transcript from:
+
+```text
+~/.proma/sdk-config/projects/<workspace-hash>/<session-id>.jsonl
+```
+
+It saves the conversation as a Nowledge Mem thread with source `proma`, message-level deduplication, and stable IDs. Older Proma builds that still write `~/.proma/agent-sessions/*.jsonl` remain supported as a fallback.
+
+### Startup context
+
+`SessionStart` runs `read-working-memory.py`.
+
+Proma's current Claude Agent SDK does not reliably inject SessionStart stdout into the model context. To keep this path dependable, the script writes a marked Nowledge Mem block into:
+
+```text
+~/.proma/agent-workspaces/default/CLAUDE.md
+```
+
+If `CLAUDE.md.template` exists in the same workspace, the script uses it as the base and then adds or replaces only this block:
 
 ```markdown
-## Nowledge Mem (nmem) Usage
-
-When nmem MCP tools (`mcp__nowledge-mem__*`) are available:
-
-- **Cross-session persistence** -> nmem (`mcp__nowledge-mem__add_memory`)
-- **Within-session context** -> built-in `mcp__mem__*`
-- **Historical decisions, past discussions** -> `mcp__nowledge-mem__search_memories`
-- **Session archiving** -> `mcp__nowledge-mem__save_thread`
-
-**Proactive behaviors:**
-- Read Context Bundle at session start when available, with Working Memory fallback
-- Distill key decisions to nmem Memories
-- When user says "before", "last time": search nmem + built-in memory
+<!-- nowledge-mem:start -->
+...
+<!-- nowledge-mem:end -->
 ```
 
-### 6. Restart Proma
+Keep your own Proma instructions outside that marked block, or in `CLAUDE.md.template`.
 
-Restart Proma for the MCP server and hooks to take effect. Verify with `/nmem-status` in a new session.
+### Live Working Memory refresh
 
-## Architecture
+After each assistant turn, the asyncRewake Stop hook runs:
 
-```
-Proma Agent
-  |
-  |-- mcp.json  -->  nmem MCP server (tools: search, save, status)
-  |-- Stop Hook -->  save-to-nmem.py   (auto-capture sessions)
-  |-- SessionStart Hook --> read-working-memory.py (inject context)
-  |-- Skills -->  read-working-memory, search-memory, distill-memory,
-  |               save-thread, status
+```bash
+python "$HOME/.proma/scripts/read-working-memory.py" --rewake
 ```
 
-## How It Works
+When Nowledge Mem has useful Working Memory, the hook prints it and exits with code `2`, which lets Proma wake the agent with the latest reminder. Empty or unavailable context exits cleanly without interrupting the session.
 
-1. **MCP Tools** — `mcp__nowledge-mem__*` tools are available to the agent for on-demand memory operations: search past decisions, save new learnings, read Context Bundle or Working Memory.
-2. **Stop Hook** — After every agent response, `save-to-nmem.py` parses the current Proma session JSONL (`~/.proma/agent-sessions/<id>.jsonl`) and appends new messages to the matching nmem thread via REST API.
-3. **SessionStart Hook** — On new or resumed sessions, `read-working-memory.py` calls `nmem context --source-app proma` when available, then falls back to `nmem wm read` for context injection.
-4. **Skills** — Standard skills for read-working-memory, search-memory, distill-memory, save-thread, and status. Slash commands (`/nmem-save`, `/nmem-search`, `/nmem-status`) provide manual control as a fallback.
+### MCP tools
 
-### Session Format
-
-Proma stores sessions as JSONL files in `~/.proma/agent-sessions/`. Each line is a JSON object with:
-- `type`: `"user"` or `"assistant"`
-- `message.content`: array of content blocks (text, tool_use, tool_result, thinking)
-- `uuid`: unique message identifier
-
-The save script deduplicates by UUID, attaches message-level external IDs, and extracts human-readable text from content blocks.
+The MCP server gives Proma agent access to Nowledge Mem search, save, status, skills, and KFS tools. This is the intelligent retrieval path; lifecycle hooks are the automatic capture and startup-context path.
 
 ## Configuration
 
-| Environment Variable | Purpose | Default |
-|---------------------|---------|---------|
-| `NMEM_API_URL` | nmem server URL | From `~/.nowledge-mem/config.json` |
-| `NMEM_API_KEY` | nmem API key | From `~/.nowledge-mem/config.json` |
+| Environment variable | Purpose | Default |
+| --- | --- | --- |
+| `NMEM_API_URL` | Nowledge Mem server URL | `~/.nowledge-mem/config.json` or `http://127.0.0.1:14242` |
+| `NMEM_API_KEY` | Nowledge Mem API key | `~/.nowledge-mem/config.json` |
 | `PROMA_HOME` | Proma home directory | `~/.proma` |
+| `PROMA_SDK_CONFIG_DIR` | Proma Claude SDK config directory | `~/.proma/sdk-config/.claude` |
+| `PROMA_WORKSPACE_DIR` | Proma workspace directory for `CLAUDE.md` | `~/.proma/agent-workspaces/default` |
+| `PROMA_CLAUDE_MD` | Explicit `CLAUDE.md` output path | `<workspace>/CLAUDE.md` |
+| `PROMA_CLAUDE_TEMPLATE` | Explicit template path | `<workspace>/CLAUDE.md.template` |
 
-The hook scripts read credentials from standard nmem config (`~/.nowledge-mem/config.json`), so no duplicate configuration is needed if nmem is already set up on the machine.
+Logs are written to:
+
+```text
+~/.proma/logs/nm-hooks.log
+```
 
 ## Troubleshooting
 
-**MCP tools not showing up:**
-- Verify `mcp.json` uses `"servers"` (not `"mcpServers"`) as the top-level key
-- Check the API URL and key are correct
-- Restart Proma after changing `mcp.json`
+**MCP tools do not show up**
 
-**Hooks not firing:**
-- Check `~/.proma/log/nmem-hook.log` for errors
-- Verify Python 3.9+ is installed and in PATH
-- Ensure hook commands use correct absolute paths
+- Proma uses `"servers"` as the top-level key in `mcp.json`, not `"mcpServers"`.
+- Confirm the endpoint ends with `/mcp/`.
+- Restart Proma after changing `mcp.json`.
 
-**"nmem CLI not found":**
-- Install via the Nowledge Mem desktop app, `pip install nmem-cli`, or on Arch Linux `yay -S nmem-cli` / `paru -S nmem-cli`
-- Verify `nmem --version` works in your terminal
+**Hooks do not run**
 
-**Session not saved:**
-- Run the save script manually: `echo '{"session_id":"<id>"}' | python hooks/save-to-nmem.py`
-- Check the log at `~/.proma/log/nmem-hook.log`
+- Check `~/.proma/sdk-config/.claude/settings.json`, not `~/.proma/settings.json`.
+- Use absolute script paths if your Proma build does not expand environment variables.
+- Check `~/.proma/logs/nm-hooks.log`.
+
+**Proma starts but does not see Nowledge Mem context**
+
+- Open `~/.proma/agent-workspaces/default/CLAUDE.md`.
+- Confirm it contains a `<!-- nowledge-mem:start -->` block.
+- Run `python ~/.proma/scripts/read-working-memory.py` manually and check the log.
+
+**Threads are not saved**
+
+- Confirm Proma is writing JSONL files under `~/.proma/sdk-config/projects/`.
+- Run:
+
+```bash
+echo '{"session_id":"<session-id>"}' | python ~/.proma/scripts/save-to-nmem.py
+```
+
+- Then check Nowledge Mem for a thread with source `proma`.
+
+## Development
+
+Static tests:
+
+```bash
+uv run --with pytest pytest tests/plugin_e2e -q -k proma
+```

--- a/nowledge-mem-proma-plugin/README.md
+++ b/nowledge-mem-proma-plugin/README.md
@@ -185,7 +185,7 @@ Proma's current Claude Agent SDK does not reliably inject SessionStart stdout in
 ~/.proma/agent-workspaces/default/CLAUDE.md
 ```
 
-If `CLAUDE.md.template` exists in the same workspace, the script uses it as the base and then adds or replaces only this block:
+If `CLAUDE.md` does not exist yet and `CLAUDE.md.template` exists in the same workspace, the script uses the template as the first base. After that, it preserves the existing `CLAUDE.md` and only adds or replaces this block:
 
 ```markdown
 <!-- nowledge-mem:start -->

--- a/nowledge-mem-proma-plugin/README.md
+++ b/nowledge-mem-proma-plugin/README.md
@@ -216,7 +216,7 @@ The MCP server gives Proma agent access to Nowledge Mem search, save, status, sk
 | `NMEM_API_URL` | Nowledge Mem server URL | `~/.nowledge-mem/config.json` or `http://127.0.0.1:14242` |
 | `NMEM_API_KEY` | Nowledge Mem API key | `~/.nowledge-mem/config.json` |
 | `PROMA_HOME` | Proma home directory | `~/.proma` |
-| `PROMA_SDK_CONFIG_DIR` | Proma Claude SDK config directory | `~/.proma/sdk-config/.claude` |
+| `PROMA_PROJECTS_DIR` | Proma transcript directory | `~/.proma/sdk-config/projects` |
 | `PROMA_WORKSPACE_DIR` | Proma workspace directory for `CLAUDE.md` | `~/.proma/agent-workspaces/default` |
 | `PROMA_CLAUDE_MD` | Explicit `CLAUDE.md` output path | `<workspace>/CLAUDE.md` |
 | `PROMA_CLAUDE_TEMPLATE` | Explicit template path | `<workspace>/CLAUDE.md.template` |

--- a/nowledge-mem-proma-plugin/hooks/hooks.json
+++ b/nowledge-mem-proma-plugin/hooks/hooks.json
@@ -1,13 +1,37 @@
 {
+  "installPath": "~/.proma/sdk-config/.claude/settings.json",
+  "scriptInstallPath": "~/.proma/scripts/",
   "hooks": {
+    "UserPromptSubmit": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python \"${PROMA_HOME}/scripts/save-to-nmem.py\" --event user-prompt-submit",
+            "timeout": 30000
+          }
+        ]
+      }
+    ],
     "Stop": [
       {
         "hooks": [
           {
             "type": "command",
-            "command": "python \"${PROMA_HOME}/hooks/save-to-nmem.py\"",
-            "timeout": 30,
-            "async": true
+            "command": "python \"${PROMA_HOME}/scripts/save-to-nmem.py\" --event stop",
+            "timeout": 30000
+          }
+        ]
+      },
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python \"${PROMA_HOME}/scripts/read-working-memory.py\" --rewake",
+            "timeout": 15000,
+            "async": true,
+            "asyncRewake": true,
+            "rewakeMessage": "Nowledge Mem context refreshed"
           }
         ]
       }
@@ -18,9 +42,8 @@
         "hooks": [
           {
             "type": "command",
-            "command": "python \"${PROMA_HOME}/hooks/read-working-memory.py\"",
-            "timeout": 10,
-            "async": true
+            "command": "python \"${PROMA_HOME}/scripts/read-working-memory.py\"",
+            "timeout": 15000
           }
         ]
       }

--- a/nowledge-mem-proma-plugin/hooks/read-working-memory.py
+++ b/nowledge-mem-proma-plugin/hooks/read-working-memory.py
@@ -1,28 +1,37 @@
 #!/usr/bin/env python3
-"""Read Nowledge Mem startup context for Proma SessionStart hook.
+"""Read Nowledge Mem context for Proma startup and asyncRewake hooks.
 
-Calls `nmem --json context --source-app proma` when available, then falls
-back to `nmem --json wm read`. The result is emitted as JSON for the Proma
-Agent SDK to inject as session context.
-
-Falls back gracefully if nmem is not installed or the server is unreachable.
+Proma's current Claude Agent SDK does not reliably inject SessionStart stdout
+as additional context. For startup, this hook writes a marked Nowledge Mem block
+into Proma's workspace CLAUDE.md, which Proma loads naturally. For asyncRewake,
+it prints a compact Working Memory reminder and exits 2 only when there is
+context worth injecting.
 """
 
 from __future__ import annotations
 
+import argparse
 import json
 import os
 import shutil
 import subprocess
-import sys
-import os
 from datetime import datetime
 from pathlib import Path
 from typing import Any
 
-PROMA_HOME = Path(os.environ.get("PROMA_HOME", Path.home() / ".proma"))
-LOG_DIR = PROMA_HOME / "log"
-LOG_FILE = LOG_DIR / "nmem-hook.log"
+PROMA_HOME = Path(os.environ.get("PROMA_HOME", Path.home() / ".proma")).expanduser()
+PROMA_WORKSPACE_DIR = Path(
+    os.environ.get("PROMA_WORKSPACE_DIR", PROMA_HOME / "agent-workspaces" / "default")
+).expanduser()
+CLAUDE_MD = Path(os.environ.get("PROMA_CLAUDE_MD", PROMA_WORKSPACE_DIR / "CLAUDE.md")).expanduser()
+CLAUDE_TEMPLATE = Path(
+    os.environ.get("PROMA_CLAUDE_TEMPLATE", PROMA_WORKSPACE_DIR / "CLAUDE.md.template")
+).expanduser()
+LOG_DIR = PROMA_HOME / "logs"
+LOG_FILE = LOG_DIR / "nm-hooks.log"
+
+START_MARKER = "<!-- nowledge-mem:start -->"
+END_MARKER = "<!-- nowledge-mem:end -->"
 
 
 def log(msg: str) -> None:
@@ -30,40 +39,37 @@ def log(msg: str) -> None:
         LOG_DIR.mkdir(parents=True, exist_ok=True)
         ts = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
         with LOG_FILE.open("a", encoding="utf-8") as fh:
-            fh.write(f"[{ts}] {msg}\n")
+            fh.write(f"[{ts}] read-working-memory {msg}\n")
     except Exception:
         pass
 
 
 def _nmem_command_prefix() -> list[str] | None:
-    """Return the command prefix for invoking nmem."""
     found = shutil.which("nmem") or shutil.which("nmem.cmd")
     if found:
         return [found]
-    # Check common install paths on Windows
+
     candidates = [
         Path(os.environ.get("LOCALAPPDATA", "")) / "Nowledge Mem" / "cli" / "nmem.cmd",
         Path.home() / ".pixi" / "envs" / "python" / "Scripts" / "nmem.exe",
     ]
-    for p in candidates:
-        if p.exists():
-            return [str(p)]
-    # uvx fallback (per plugin development guide)
+    for path in candidates:
+        if path.exists():
+            return [str(path)]
+
     uvx = shutil.which("uvx")
     if uvx:
         return [uvx, "--from", "nmem-cli", "nmem"]
     return None
 
 
-def _run_nmem_json(args: list[str], label: str) -> dict[str, Any] | None:
+def _run_nmem_json(args: list[str], label: str, timeout: int = 15) -> dict[str, Any] | None:
     prefix = _nmem_command_prefix()
     if not prefix:
         log("nmem CLI not found")
         return None
 
     cmd = [*prefix, "--json", *args]
-    # Wrap Windows batch launchers through cmd.exe; keep argv split so quoted
-    # paths and following arguments are not flattened into one brittle string.
     if Path(prefix[0]).name.lower().endswith(".cmd"):
         cmd = ["cmd.exe", "/d", "/c", "call", *cmd]
 
@@ -73,16 +79,17 @@ def _run_nmem_json(args: list[str], label: str) -> dict[str, Any] | None:
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE,
             text=True,
-            timeout=15,
+            timeout=timeout,
             check=False,
         )
         if proc.returncode != 0:
-            log(f"{label} exit={proc.returncode} stderr={proc.stderr.strip()[:200]}")
+            log(f"{label} exit={proc.returncode} stderr={proc.stderr.strip()[:240]}")
             return None
         raw = proc.stdout.strip()
         if not raw:
             return None
-        return json.loads(raw)
+        loaded = json.loads(raw)
+        return loaded if isinstance(loaded, dict) else None
     except subprocess.TimeoutExpired:
         log(f"{label} timed out")
         return None
@@ -117,20 +124,116 @@ def _working_memory_args() -> list[str]:
     return args
 
 
-def main() -> int:
-    log("read-startup-context start")
+def _payload_text(payload: dict[str, Any] | None) -> str:
+    if not payload:
+        return ""
 
+    for key in ("rendered_markdown", "markdown", "content", "text"):
+        value = payload.get(key)
+        if isinstance(value, str) and value.strip():
+            return value.strip()
+
+    working_memory = payload.get("working_memory")
+    if isinstance(working_memory, dict):
+        value = working_memory.get("content")
+        if isinstance(value, str) and value.strip():
+            return value.strip()
+
+    context = payload.get("context")
+    if isinstance(context, str) and context.strip():
+        return context.strip()
+
+    return ""
+
+
+def _startup_context() -> dict[str, Any] | None:
     context = _run_nmem_json(_context_args(), "nmem context")
-    if context is None:
-        context = _run_nmem_json(_working_memory_args(), "nmem wm read")
+    if context is not None:
+        return context
+    return _run_nmem_json(_working_memory_args(), "nmem wm read")
 
-    if context is None:
-        log("read-startup-context: no data")
-        print(json.dumps({"context": None, "working_memory": None, "status": "empty"}))
+
+def _managed_block(context_markdown: str) -> str:
+    generated = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
+    return (
+        f"{START_MARKER}\n"
+        "## Nowledge Mem Context\n\n"
+        f"_Updated automatically by the Nowledge Mem Proma plugin at {generated}._\n\n"
+        "Use this context before planning, writing, or deciding. Search Nowledge Mem "
+        "with `mcp__nowledge-mem__*` tools when the task depends on past decisions, "
+        "brand rules, preferences, or earlier Proma conversations.\n\n"
+        f"{context_markdown.strip()}\n"
+        f"{END_MARKER}"
+    )
+
+
+def _base_claude_md() -> str:
+    if CLAUDE_TEMPLATE.exists():
+        return CLAUDE_TEMPLATE.read_text(encoding="utf-8")
+    if CLAUDE_MD.exists():
+        return CLAUDE_MD.read_text(encoding="utf-8")
+    return (
+        "# Proma Workspace Instructions\n\n"
+        "This file is loaded by Proma when a workspace session starts. "
+        "Add your stable project guidance above or below the Nowledge Mem block.\n"
+    )
+
+
+def render_claude_md(base: str, context_markdown: str) -> str:
+    block = _managed_block(context_markdown)
+    if START_MARKER in base and END_MARKER in base:
+        before, rest = base.split(START_MARKER, 1)
+        _, after = rest.split(END_MARKER, 1)
+        return f"{before.rstrip()}\n\n{block}\n{after.lstrip()}".rstrip() + "\n"
+    return f"{base.rstrip()}\n\n{block}\n"
+
+
+def update_claude_md(context_markdown: str) -> bool:
+    if not context_markdown.strip():
+        return False
+    try:
+        CLAUDE_MD.parent.mkdir(parents=True, exist_ok=True)
+        rendered = render_claude_md(_base_claude_md(), context_markdown)
+        CLAUDE_MD.write_text(rendered, encoding="utf-8")
+        log(f"updated CLAUDE.md path={CLAUDE_MD}")
+        return True
+    except Exception as exc:
+        log(f"failed to update CLAUDE.md: {exc}")
+        return False
+
+
+def _print_rewake() -> int:
+    payload = _run_nmem_json(_working_memory_args(), "nmem wm read", timeout=10)
+    text = _payload_text(payload)
+    if not text:
+        log("rewake: no working memory")
         return 0
 
-    log(f"read-startup-context: got data keys={list(context.keys())}")
-    print(json.dumps(context, ensure_ascii=False, indent=2))
+    print("## Nowledge Mem Working Memory")
+    print()
+    print(text)
+    log("rewake: emitted working memory")
+    return 2
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--rewake", action="store_true", help="Emit compact Working Memory for asyncRewake")
+    args = parser.parse_args()
+
+    if args.rewake:
+        return _print_rewake()
+
+    log("startup context refresh start")
+    payload = _startup_context()
+    text = _payload_text(payload)
+    if not text:
+        log("startup context refresh: no data")
+        print(json.dumps({"status": "empty"}))
+        return 0
+
+    ok = update_claude_md(text)
+    print(json.dumps({"status": "updated" if ok else "failed", "path": str(CLAUDE_MD)}))
     return 0
 
 

--- a/nowledge-mem-proma-plugin/hooks/read-working-memory.py
+++ b/nowledge-mem-proma-plugin/hooks/read-working-memory.py
@@ -19,19 +19,23 @@ from datetime import datetime
 from pathlib import Path
 from typing import Any
 
-PROMA_HOME = Path(os.environ.get("PROMA_HOME", Path.home() / ".proma")).expanduser()
-PROMA_WORKSPACE_DIR = Path(
-    os.environ.get("PROMA_WORKSPACE_DIR", PROMA_HOME / "agent-workspaces" / "default")
-).expanduser()
-CLAUDE_MD = Path(os.environ.get("PROMA_CLAUDE_MD", PROMA_WORKSPACE_DIR / "CLAUDE.md")).expanduser()
-CLAUDE_TEMPLATE = Path(
-    os.environ.get("PROMA_CLAUDE_TEMPLATE", PROMA_WORKSPACE_DIR / "CLAUDE.md.template")
-).expanduser()
-LOG_DIR = PROMA_HOME / "logs"
-LOG_FILE = LOG_DIR / "nm-hooks.log"
-
 START_MARKER = "<!-- nowledge-mem:start -->"
 END_MARKER = "<!-- nowledge-mem:end -->"
+
+
+def _env_path(name: str, default: Path) -> Path:
+    raw = os.environ.get(name)
+    if isinstance(raw, str) and raw.strip():
+        return Path(raw.strip()).expanduser()
+    return default.expanduser()
+
+
+PROMA_HOME = _env_path("PROMA_HOME", Path.home() / ".proma")
+PROMA_WORKSPACE_DIR = _env_path("PROMA_WORKSPACE_DIR", PROMA_HOME / "agent-workspaces" / "default")
+CLAUDE_MD = _env_path("PROMA_CLAUDE_MD", PROMA_WORKSPACE_DIR / "CLAUDE.md")
+CLAUDE_TEMPLATE = _env_path("PROMA_CLAUDE_TEMPLATE", PROMA_WORKSPACE_DIR / "CLAUDE.md.template")
+LOG_DIR = PROMA_HOME / "logs"
+LOG_FILE = LOG_DIR / "nm-hooks.log"
 
 
 def log(msg: str) -> None:
@@ -168,10 +172,10 @@ def _managed_block(context_markdown: str) -> str:
 
 
 def _base_claude_md() -> str:
-    if CLAUDE_TEMPLATE.exists():
-        return CLAUDE_TEMPLATE.read_text(encoding="utf-8")
     if CLAUDE_MD.exists():
         return CLAUDE_MD.read_text(encoding="utf-8")
+    if CLAUDE_TEMPLATE.exists():
+        return CLAUDE_TEMPLATE.read_text(encoding="utf-8")
     return (
         "# Proma Workspace Instructions\n\n"
         "This file is loaded by Proma when a workspace session starts. "
@@ -184,7 +188,8 @@ def render_claude_md(base: str, context_markdown: str) -> str:
     if START_MARKER in base and END_MARKER in base:
         before, rest = base.split(START_MARKER, 1)
         _, after = rest.split(END_MARKER, 1)
-        return f"{before.rstrip()}\n\n{block}\n{after.lstrip()}".rstrip() + "\n"
+        after = after.lstrip("\n\r")
+        return f"{before.rstrip()}\n\n{block}\n{after}".rstrip() + "\n"
     return f"{base.rstrip()}\n\n{block}\n"
 
 

--- a/nowledge-mem-proma-plugin/hooks/save-to-nmem.py
+++ b/nowledge-mem-proma-plugin/hooks/save-to-nmem.py
@@ -57,10 +57,15 @@ API_KEY = os.environ.get("NMEM_API_KEY") or _config_value("apiKey", "api_key") o
 REQUEST_TIMEOUT = 15
 SAVE_RETRY_DELAYS = (0.0, 0.5, 1.5, 3.0)
 
-PROMA_HOME = Path(os.environ.get("PROMA_HOME", Path.home() / ".proma")).expanduser()
-SDK_PROJECTS_DIR = Path(
-    os.environ.get("PROMA_PROJECTS_DIR", PROMA_HOME / "sdk-config" / "projects")
-).expanduser()
+def _env_path(name: str, default: Path) -> Path:
+    raw = os.environ.get(name)
+    if isinstance(raw, str) and raw.strip():
+        return Path(raw.strip()).expanduser()
+    return default.expanduser()
+
+
+PROMA_HOME = _env_path("PROMA_HOME", Path.home() / ".proma")
+SDK_PROJECTS_DIR = _env_path("PROMA_PROJECTS_DIR", PROMA_HOME / "sdk-config" / "projects")
 LEGACY_SESSIONS_DIR = PROMA_HOME / "agent-sessions"
 LOG_DIR = PROMA_HOME / "logs"
 LOG_FILE = LOG_DIR / "nm-hooks.log"
@@ -156,14 +161,22 @@ def _iter_session_files() -> list[Path]:
 
 
 def find_session_file(session_id: str | None = None) -> Path | None:
+    if session_id:
+        legacy_path = LEGACY_SESSIONS_DIR / f"{session_id}.jsonl"
+        if legacy_path.exists():
+            return legacy_path
+        if SDK_PROJECTS_DIR.exists():
+            try:
+                for path in SDK_PROJECTS_DIR.rglob(f"{session_id}.jsonl"):
+                    if path.is_file():
+                        return path
+            except Exception as exc:
+                log(f"targeted scan failed session={session_id}: {exc}")
+        return None
+
     files = _iter_session_files()
     if not files:
         return None
-
-    if session_id:
-        for path in files:
-            if path.stem == session_id:
-                return path
 
     try:
         return max(files, key=lambda p: p.stat().st_mtime)

--- a/nowledge-mem-proma-plugin/hooks/save-to-nmem.py
+++ b/nowledge-mem-proma-plugin/hooks/save-to-nmem.py
@@ -58,10 +58,9 @@ REQUEST_TIMEOUT = 15
 SAVE_RETRY_DELAYS = (0.0, 0.5, 1.5, 3.0)
 
 PROMA_HOME = Path(os.environ.get("PROMA_HOME", Path.home() / ".proma")).expanduser()
-PROMA_SDK_CONFIG_DIR = Path(
-    os.environ.get("PROMA_SDK_CONFIG_DIR", PROMA_HOME / "sdk-config" / ".claude")
+SDK_PROJECTS_DIR = Path(
+    os.environ.get("PROMA_PROJECTS_DIR", PROMA_HOME / "sdk-config" / "projects")
 ).expanduser()
-SDK_PROJECTS_DIR = PROMA_SDK_CONFIG_DIR / "projects"
 LEGACY_SESSIONS_DIR = PROMA_HOME / "agent-sessions"
 LOG_DIR = PROMA_HOME / "logs"
 LOG_FILE = LOG_DIR / "nm-hooks.log"

--- a/nowledge-mem-proma-plugin/hooks/save-to-nmem.py
+++ b/nowledge-mem-proma-plugin/hooks/save-to-nmem.py
@@ -1,13 +1,13 @@
 #!/usr/bin/env python3
-"""Proma session capture for Nowledge Mem Stop hooks.
+"""Proma session capture for Nowledge Mem lifecycle hooks.
 
-Reads the current Proma session JSONL, converts messages to nmem thread
-format, and uploads via the nmem REST API.
+Proma stores Claude Agent SDK transcripts under:
 
-Configuration is read from the standard nmem config file
-(~/.nowledge-mem/config.json) or NMEM_API_URL / NMEM_API_KEY env vars.
+    ~/.proma/sdk-config/projects/<workspace-hash>/<session-id>.jsonl
 
-Modeled on the Codex hook at nowledge-mem-codex-plugin/hooks/nowledge-mem-stop-save.py.
+Older builds used ~/.proma/agent-sessions/<session-id>.jsonl. This hook
+supports both, converts Proma JSONL into nmem thread messages, and uploads
+them through the nmem REST API as source="proma".
 """
 
 from __future__ import annotations
@@ -17,32 +17,32 @@ import json
 import os
 import sys
 import time
-import urllib.request
 import urllib.error
 import urllib.parse
+import urllib.request
 from datetime import datetime
 from pathlib import Path
 from typing import Any
 
-# ---------------------------------------------------------------------------
-# Configuration — resolved from env vars, then nmem config, then defaults
-# ---------------------------------------------------------------------------
 
 def _load_nmem_config() -> dict[str, str]:
     config_path = Path.home() / ".nowledge-mem" / "config.json"
     if config_path.exists():
         try:
             with config_path.open("r", encoding="utf-8") as fh:
-                return json.load(fh)
+                loaded = json.load(fh)
+            return loaded if isinstance(loaded, dict) else {}
         except Exception:
             pass
     return {}
 
-_nmem_cfg = _load_nmem_config()
+
+_NMEM_CFG = _load_nmem_config()
+
 
 def _config_value(*keys: str) -> str:
     for key in keys:
-        value = _nmem_cfg.get(key)
+        value = _NMEM_CFG.get(key)
         if isinstance(value, str) and value.strip():
             return value.strip()
     return ""
@@ -53,18 +53,18 @@ API_BASE = (
     or _config_value("apiUrl", "api_url")
     or "http://127.0.0.1:14242"
 ).rstrip("/")
-API_KEY = (
-    os.environ.get("NMEM_API_KEY")
-    or _config_value("apiKey", "api_key")
-    or ""
-)
+API_KEY = os.environ.get("NMEM_API_KEY") or _config_value("apiKey", "api_key") or ""
 REQUEST_TIMEOUT = 15
 SAVE_RETRY_DELAYS = (0.0, 0.5, 1.5, 3.0)
 
-PROMA_HOME = Path(os.environ.get("PROMA_HOME", Path.home() / ".proma"))
-SESSIONS_DIR = PROMA_HOME / "agent-sessions"
-LOG_DIR = PROMA_HOME / "log"
-LOG_FILE = LOG_DIR / "nmem-hook.log"
+PROMA_HOME = Path(os.environ.get("PROMA_HOME", Path.home() / ".proma")).expanduser()
+PROMA_SDK_CONFIG_DIR = Path(
+    os.environ.get("PROMA_SDK_CONFIG_DIR", PROMA_HOME / "sdk-config" / ".claude")
+).expanduser()
+SDK_PROJECTS_DIR = PROMA_SDK_CONFIG_DIR / "projects"
+LEGACY_SESSIONS_DIR = PROMA_HOME / "agent-sessions"
+LOG_DIR = PROMA_HOME / "logs"
+LOG_FILE = LOG_DIR / "nm-hooks.log"
 
 HEADERS = {
     "Content-Type": "application/json",
@@ -74,16 +74,13 @@ if API_KEY:
     HEADERS["Authorization"] = f"Bearer {API_KEY}"
     HEADERS["X-NMEM-API-Key"] = API_KEY
 
-# ---------------------------------------------------------------------------
-# Helpers
-# ---------------------------------------------------------------------------
 
 def log(msg: str) -> None:
     try:
         LOG_DIR.mkdir(parents=True, exist_ok=True)
         ts = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
         with LOG_FILE.open("a", encoding="utf-8") as fh:
-            fh.write(f"[{ts}] {msg}\n")
+            fh.write(f"[{ts}] save-to-nmem {msg}\n")
     except Exception:
         pass
 
@@ -93,29 +90,30 @@ def read_hook_input() -> dict[str, Any]:
     if not raw.strip():
         return {}
     try:
-        return json.loads(raw)
+        loaded = json.loads(raw)
+        return loaded if isinstance(loaded, dict) else {}
     except json.JSONDecodeError:
         return {}
 
 
 def payload_value(payload: dict[str, Any], *keys: str) -> str | None:
     containers: list[dict[str, Any]] = [payload]
-    for outer_key in ("input", "data", "payload"):
+    for outer_key in ("input", "data", "payload", "hookInput"):
         nested = payload.get(outer_key)
         if isinstance(nested, dict):
             containers.append(nested)
-            ni = nested.get("input")
-            if isinstance(ni, dict):
-                containers.append(ni)
-    for c in containers:
-        for k in keys:
-            v = c.get(k)
-            if isinstance(v, str) and v.strip():
-                return v.strip()
+            nested_input = nested.get("input")
+            if isinstance(nested_input, dict):
+                containers.append(nested_input)
+    for container in containers:
+        for key in keys:
+            value = container.get(key)
+            if isinstance(value, str) and value.strip():
+                return value.strip()
     return None
 
 
-def api_request(method: str, path: str, body: dict | None = None) -> dict[str, Any] | None:
+def api_request(method: str, path: str, body: dict[str, Any] | None = None) -> dict[str, Any] | None:
     url = f"{API_BASE}{path}"
     data = json.dumps(body).encode("utf-8") if body else None
     req = urllib.request.Request(url, data=data, headers=HEADERS, method=method)
@@ -140,44 +138,68 @@ def api_path_quote(value: str) -> str:
     return urllib.parse.quote(value, safe="")
 
 
-# ---------------------------------------------------------------------------
-# Session parsing
-# ---------------------------------------------------------------------------
+def _session_roots() -> list[Path]:
+    roots = [SDK_PROJECTS_DIR, LEGACY_SESSIONS_DIR]
+    return [root for root in roots if root.exists()]
 
-def find_session_file(session_id: str) -> Path | None:
-    path = SESSIONS_DIR / f"{session_id}.jsonl"
-    if path.exists():
-        return path
-    try:
-        candidates = sorted(
-            SESSIONS_DIR.glob("*.jsonl"),
-            key=lambda p: p.stat().st_mtime,
-            reverse=True,
-        )
-        return candidates[0] if candidates else None
-    except Exception:
+
+def _iter_session_files() -> list[Path]:
+    files: list[Path] = []
+    for root in _session_roots():
+        try:
+            if root == SDK_PROJECTS_DIR:
+                files.extend(root.rglob("*.jsonl"))
+            else:
+                files.extend(root.glob("*.jsonl"))
+        except Exception as exc:
+            log(f"scan failed root={root}: {exc}")
+    return files
+
+
+def find_session_file(session_id: str | None = None) -> Path | None:
+    files = _iter_session_files()
+    if not files:
         return None
 
+    if session_id:
+        for path in files:
+            if path.stem == session_id:
+                return path
 
-def extract_text_from_content(content_blocks: list[dict]) -> str:
+    try:
+        return max(files, key=lambda p: p.stat().st_mtime)
+    except Exception:
+        return files[0] if files else None
+
+
+def extract_text_from_content(content: Any) -> str:
+    if isinstance(content, str):
+        return content.strip()
+
+    if isinstance(content, dict):
+        content_type = content.get("type", "")
+        if content_type == "text":
+            text = content.get("text", "")
+            return text.strip() if isinstance(text, str) else ""
+        if content_type == "tool_use":
+            name = content.get("name", "unknown")
+            return f"[tool: {name}]"
+        if content_type == "tool_result":
+            result = content.get("content", "")
+            if isinstance(result, str) and result:
+                return f"[result: {result[:2000]}]"
+            if isinstance(result, list):
+                return "[result: ...]"
+        return ""
+
+    if not isinstance(content, list):
+        return ""
+
     parts: list[str] = []
-    for block in content_blocks:
-        t = block.get("type", "")
-        if t == "text":
-            text = block.get("text", "")
-            if isinstance(text, str) and text.strip():
-                parts.append(text.strip())
-        elif t == "tool_use":
-            name = block.get("name", "unknown")
-            parts.append(f"[tool: {name}]")
-        elif t == "tool_result":
-            content = block.get("content", "")
-            if isinstance(content, str) and content:
-                parts.append(f"[result: {content[:2000]}]")
-            elif isinstance(content, list):
-                parts.append("[result: ...]")
-        elif t == "thinking":
-            pass
+    for block in content:
+        text = extract_text_from_content(block)
+        if text:
+            parts.append(text)
     return "\n".join(parts)
 
 
@@ -206,44 +228,41 @@ def parse_session_messages(session_path: Path) -> list[dict[str, Any]]:
             if uuid:
                 seen_uuids.add(uuid)
 
+            timestamp = entry.get("timestamp")
             content = message.get("content", [])
-            if not isinstance(content, list):
-                content = []
 
             if msg_type == "user":
-                text = extract_text_from_content(content)
-                if text:
-                    message_body: dict[str, Any] = {"role": "user", "content": text}
-                    if uuid:
-                        message_body["metadata"] = {"external_id": f"proma:{uuid}"}
-                    messages.append(message_body)
+                role = "user"
             elif msg_type == "assistant":
                 role = message.get("role", "assistant")
-                # Proma can emit msg_type="assistant" rows that carry role="user"
-                # for reflected user content. Skip those before calling
-                # extract_text_from_content so messages does not duplicate turns.
                 if role == "user":
                     continue
-                text = extract_text_from_content(content)
-                if text:
-                    message_body = {"role": "assistant", "content": text}
-                    if uuid:
-                        message_body["metadata"] = {"external_id": f"proma:{uuid}"}
-                    messages.append(message_body)
+                role = "assistant"
+            else:
+                continue
+
+            text = extract_text_from_content(content)
+            if not text:
+                continue
+
+            message_body: dict[str, Any] = {"role": role, "content": text}
+            metadata: dict[str, Any] = {}
+            if uuid:
+                metadata["external_id"] = f"proma:{uuid}"
+            if isinstance(timestamp, str) and timestamp:
+                metadata["timestamp"] = timestamp
+            if metadata:
+                message_body["metadata"] = metadata
+            messages.append(message_body)
 
     return messages
 
 
-# ---------------------------------------------------------------------------
-# Upload
-# ---------------------------------------------------------------------------
-
-def upload_thread(session_id: str, messages: list[dict], cwd: str | None) -> bool:
+def upload_thread(session_id: str, messages: list[dict[str, Any]], cwd: str | None) -> bool:
     title = f"Proma session {session_id[:8]}"
     if cwd:
         try:
-            p = Path(cwd)
-            title = f"Proma - {p.name}"
+            title = f"Proma - {Path(cwd).name}"
         except Exception:
             pass
 
@@ -268,13 +287,8 @@ def upload_thread(session_id: str, messages: list[dict], cwd: str | None) -> boo
     if cwd:
         body["project"] = cwd
 
-    result = api_request("POST", "/threads", body)
-    return result is not None
+    return api_request("POST", "/threads", body) is not None
 
-
-# ---------------------------------------------------------------------------
-# Main
-# ---------------------------------------------------------------------------
 
 def main() -> int:
     parser = argparse.ArgumentParser()
@@ -282,33 +296,17 @@ def main() -> int:
     args, _ = parser.parse_known_args()
 
     payload = read_hook_input()
-    session_id = payload_value(payload, "session_id", "sessionId")
-    cwd = payload_value(payload, "cwd")
+    session_id = payload_value(payload, "session_id", "sessionId", "sessionID")
+    cwd = payload_value(payload, "cwd", "projectDir", "workspace", "workspacePath")
 
-    log(f"start event={args.event} session={session_id or 'missing'} cwd={cwd or 'missing'}")
-
-    if not session_id:
-        try:
-            candidates = sorted(
-                SESSIONS_DIR.glob("*.jsonl"),
-                key=lambda p: p.stat().st_mtime,
-                reverse=True,
-            )
-            if candidates:
-                session_id = candidates[0].stem
-                log(f"fallback session_id={session_id}")
-        except Exception:
-            pass
-
-    if not session_id:
-        log("skip: no session_id")
-        return 0
+    log(f"start event={args.event} session={session_id or 'latest'} cwd={cwd or 'missing'}")
 
     session_file = find_session_file(session_id)
     if not session_file:
-        log(f"skip: session file not found for {session_id}")
+        log(f"skip: session file not found for {session_id or 'latest'}")
         return 0
 
+    resolved_session_id = session_id or session_file.stem
     log(f"parsing: {session_file}")
     messages = parse_session_messages(session_file)
     log(f"parsed {len(messages)} messages")
@@ -321,7 +319,7 @@ def main() -> int:
         if delay:
             time.sleep(delay)
         log(f"upload attempt {attempt + 1}/{len(SAVE_RETRY_DELAYS)}")
-        if upload_thread(session_id, messages, cwd):
+        if upload_thread(resolved_session_id, messages, cwd):
             log("upload ok")
             return 0
         log(f"upload attempt {attempt + 1} failed")

--- a/nowledge-mem-proma-plugin/skills/read-working-memory/SKILL.md
+++ b/nowledge-mem-proma-plugin/skills/read-working-memory/SKILL.md
@@ -7,6 +7,8 @@ description: Load the Nowledge Mem Working Memory briefing at Proma session star
 
 Read Context Bundle for full Proma startup context when available: owner identity, AI Identity, active scope, active rules, and Working Memory. Read Working Memory alone when you only need current priorities.
 
+Proma's lifecycle hook also writes startup context into the workspace `CLAUDE.md` inside a `nowledge-mem:start` / `nowledge-mem:end` block. Treat that block as the automatic startup layer; call MCP or CLI when you need fresh or more specific retrieval during the session.
+
 ## When to Use
 
 **Session start**: beginning a new Proma conversation, returning after a break, or when recent context would help.

--- a/nowledge-mem-proma-plugin/skills/save-thread/SKILL.md
+++ b/nowledge-mem-proma-plugin/skills/save-thread/SKILL.md
@@ -15,7 +15,7 @@ Save the current Proma session to Nowledge Mem on explicit user request.
 - "Record this"
 - "Checkpoint this"
 
-The Stop hook in `~/.proma/settings.json` handles automatic capture after every response. This skill is for manual saves and for fallback when hooks are not configured.
+The `UserPromptSubmit` and `Stop` hooks in `~/.proma/sdk-config/.claude/settings.json` handle automatic capture. This skill is for manual saves and for fallback when hooks are not configured.
 
 ## Usage
 
@@ -28,17 +28,13 @@ mcp__nowledge-mem__save_thread
 
 **Manual script (if MCP unavailable)**:
 ```bash
-echo '{"session_id":"<id>","cwd":"<project dir>"}' | python ~/.proma/hooks/save-to-nmem.py
-```
-
-**CLI import (for Proma sessions already on disk)**:
-```bash
-nmem t save --from proma --project /path/to/project
+echo '{"session_id":"<id>","cwd":"<project dir>"}' | python ~/.proma/scripts/save-to-nmem.py
 ```
 
 ## Behavior
 
-- Proma sessions are stored as JSONL in `~/.proma/agent-sessions/<id>.jsonl`
+- Proma sessions are stored as JSONL in `~/.proma/sdk-config/projects/<workspace-hash>/<session-id>.jsonl`
+- Older Proma builds that write `~/.proma/agent-sessions/<id>.jsonl` are still supported by the script
 - The save script deduplicates by UUID and extracts text from content blocks
 - Thread ID format: `proma-{session_id}`
 - Re-running is idempotent — only new messages are appended
@@ -51,4 +47,4 @@ Both are useful — save a thread AND distill key learnings.
 
 ## Troubleshooting
 
-If thread save fails, check `~/.proma/log/nmem-hook.log` for errors. Verify the nmem server is running with `nmem status`.
+If thread save fails, check `~/.proma/logs/nm-hooks.log` for errors. Verify the nmem server is running with `nmem status`.

--- a/nowledge-mem-proma-plugin/skills/status/SKILL.md
+++ b/nowledge-mem-proma-plugin/skills/status/SKILL.md
@@ -31,9 +31,10 @@ nmem status
 1. **MCP tools available?** — Look for `mcp__nowledge-mem__*` in available tools
 2. **Server reachable?** — `nmem status` should show `status: ok`
 3. **API key configured?** — Check `~/.nowledge-mem/config.json` or `NMEM_API_KEY` env var
-4. **mcp.json correct?** — Top-level key must be `"servers"` (not `"mcpServers"`), type must be `"streamableHttp"`
-5. **Hooks configured?** — Check `~/.proma/settings.json` for Stop and SessionStart hooks
-6. **Hook scripts present?** — Verify `~/.proma/hooks/save-to-nmem.py` and `read-working-memory.py` exist
+4. **mcp.json correct?** — Check `~/.proma/agent-workspaces/default/mcp.json`; top-level key must be `"servers"` (not `"mcpServers"`), type must be `"streamableHttp"`
+5. **Hooks configured?** — Check `~/.proma/sdk-config/.claude/settings.json` for `SessionStart`, `UserPromptSubmit`, and `Stop` hooks
+6. **Hook scripts present?** — Verify `~/.proma/scripts/save-to-nmem.py` and `~/.proma/scripts/read-working-memory.py` exist
+7. **Startup context written?** — Check `~/.proma/agent-workspaces/default/CLAUDE.md` for the `nowledge-mem:start` block
 
 ## Troubleshooting
 
@@ -41,7 +42,8 @@ nmem status
 |---------|-------------|
 | No `mcp__nowledge-mem__*` tools | mcp.json not found or wrong key name; restart Proma |
 | MCP tools return errors | Server unreachable; check `nmem status` |
-| Hook scripts not firing | Python not in PATH; check `~/.proma/log/nmem-hook.log` |
+| Hook scripts not firing | Python not in PATH; check `~/.proma/logs/nm-hooks.log` |
+| Startup context missing | Run `python ~/.proma/scripts/read-working-memory.py`; check `CLAUDE.md` and the hook log |
 | "nmem CLI not found" | Install via `pip install nmem-cli` or desktop app |
 
 For remote Mem setups, verify `NMEM_API_URL` and `NMEM_API_KEY` are set, or check `~/.nowledge-mem/config.json`.

--- a/tests/plugin_e2e/test_key_plugins_e2e.py
+++ b/tests/plugin_e2e/test_key_plugins_e2e.py
@@ -378,11 +378,21 @@ def test_key_plugin_static_contracts_are_declared():
 
     proma_manifest = _read_json(PROMA_PLUGIN / ".claude-plugin" / "plugin.json")
     proma_hook = (PROMA_PLUGIN / "hooks" / "read-working-memory.py").read_text(encoding="utf-8")
-    assert proma_manifest["version"] == "0.1.1"
+    proma_save_hook = (PROMA_PLUGIN / "hooks" / "save-to-nmem.py").read_text(encoding="utf-8")
+    proma_hooks = _read_json(PROMA_PLUGIN / "hooks" / "hooks.json")
+    assert proma_manifest["version"] == "0.1.2"
+    assert proma_hooks["installPath"] == "~/.proma/sdk-config/.claude/settings.json"
+    assert proma_hooks["scriptInstallPath"] == "~/.proma/scripts/"
+    assert "UserPromptSubmit" in proma_hooks["hooks"]
+    assert "asyncRewake" in json.dumps(proma_hooks)
     assert '"context", "--source-app", "proma"' in proma_hook
     assert "NMEM_AGENT_ID" in proma_hook
     assert "NMEM_HOST_AGENT_ID" in proma_hook
     assert '"wm", "read"' in proma_hook
+    assert "nowledge-mem:start" in proma_hook
+    assert "CLAUDE.md" in proma_hook
+    assert "sdk-config" in proma_save_hook
+    assert "source\": \"proma\"" in proma_save_hook
 
     cursor_manifest = _read_json(CURSOR_PLUGIN / ".cursor-plugin" / "plugin.json")
     cursor_hook = (CURSOR_PLUGIN / "hooks" / "session-start.mjs").read_text(encoding="utf-8")
@@ -677,7 +687,7 @@ def test_registry_connect_contract_points_agent_prompts_to_universal_skill():
     assert by_id["cursor"]["version"] == "0.1.6"
     assert by_id["droid"]["version"] == "0.1.1"
     assert by_id["openclaw"]["version"] == "0.8.26"
-    assert by_id["proma"]["version"] == "0.1.1"
+    assert by_id["proma"]["version"] == "0.1.2"
     assert by_id["opencode"]["version"] == "0.3.4"
     assert by_id["pi"]["version"] == "0.8.1"
     assert by_id["alma"]["version"] == "0.7.3"

--- a/tests/plugin_e2e/test_proma_plugin.py
+++ b/tests/plugin_e2e/test_proma_plugin.py
@@ -171,7 +171,7 @@ class TestHookScripts:
         monkeypatch.setenv("PROMA_HOME", str(proma_home))
         module = _load_hook_module("proma_save_hook", PLUGIN_DIR / "hooks" / "save-to-nmem.py")
 
-        session_dir = proma_home / "sdk-config" / ".claude" / "projects" / "workspace-hash"
+        session_dir = proma_home / "sdk-config" / "projects" / "workspace-hash"
         session_dir.mkdir(parents=True)
         session_file = session_dir / "session-123.jsonl"
         session_file.write_text(

--- a/tests/plugin_e2e/test_proma_plugin.py
+++ b/tests/plugin_e2e/test_proma_plugin.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 import json
 import os
 import sys
+import importlib.util
 from pathlib import Path
 
 import pytest
@@ -50,7 +51,10 @@ class TestHooksConfig:
     def test_hooks_json_valid(self):
         hooks = PLUGIN_DIR / "hooks" / "hooks.json"
         data = json.loads(hooks.read_text(encoding="utf-8"))
+        assert data["installPath"] == "~/.proma/sdk-config/.claude/settings.json"
+        assert data["scriptInstallPath"] == "~/.proma/scripts/"
         assert "hooks" in data
+        assert "UserPromptSubmit" in data["hooks"], "Missing UserPromptSubmit hook"
         assert "Stop" in data["hooks"], "Missing Stop hook"
         assert "SessionStart" in data["hooks"], "Missing SessionStart hook"
 
@@ -65,6 +69,25 @@ class TestHooksConfig:
                     commands.append(h.get("command", ""))
         assert any("save-to-nmem.py" in c for c in commands), (
             f"Stop hook should reference save-to-nmem.py: {commands}"
+        )
+        assert any("--rewake" in c for c in commands), (
+            f"Stop hook should include asyncRewake Working Memory refresh: {commands}"
+        )
+        assert any(h.get("asyncRewake") is True for group in stop_hooks for h in group.get("hooks", [])), (
+            "Stop hook should enable asyncRewake for live Working Memory refresh"
+        )
+
+    def test_user_prompt_submit_has_save_script(self):
+        hooks = PLUGIN_DIR / "hooks" / "hooks.json"
+        data = json.loads(hooks.read_text(encoding="utf-8"))
+        commands = [
+            h.get("command", "")
+            for group in data["hooks"]["UserPromptSubmit"]
+            for h in group.get("hooks", [])
+            if h.get("type") == "command"
+        ]
+        assert any("save-to-nmem.py" in c for c in commands), (
+            f"UserPromptSubmit should reference save-to-nmem.py: {commands}"
         )
 
     def test_session_start_hook_has_wm_script(self):
@@ -130,6 +153,9 @@ class TestHookScripts:
         content = script.read_text(encoding="utf-8")
         assert '"apiUrl", "api_url"' in content
         assert '"apiKey", "api_key"' in content
+        assert "sdk-config" in content
+        assert "projects" in content
+        assert "agent-sessions" in content
 
     def test_save_script_appends_existing_threads(self):
         script = PLUGIN_DIR / "hooks" / "save-to-nmem.py"
@@ -138,7 +164,81 @@ class TestHookScripts:
         assert 'api_request("POST", f"/threads/{thread_path_id}/append", append_body)' in content
         assert '"deduplicate": True' in content
         assert '"idempotency_key": f"proma:{session_id}"' in content
-        assert '"external_id": f"proma:{uuid}"' in content
+        assert 'metadata["external_id"] = f"proma:{uuid}"' in content
+
+    def test_save_script_parses_current_proma_sdk_jsonl(self, tmp_path, monkeypatch):
+        proma_home = tmp_path / ".proma"
+        monkeypatch.setenv("PROMA_HOME", str(proma_home))
+        module = _load_hook_module("proma_save_hook", PLUGIN_DIR / "hooks" / "save-to-nmem.py")
+
+        session_dir = proma_home / "sdk-config" / ".claude" / "projects" / "workspace-hash"
+        session_dir.mkdir(parents=True)
+        session_file = session_dir / "session-123.jsonl"
+        session_file.write_text(
+            "\n".join(
+                [
+                    json.dumps({
+                        "type": "user",
+                        "uuid": "u1",
+                        "timestamp": "2026-06-13T01:00:00Z",
+                        "message": {"role": "user", "content": "hello proma"},
+                    }),
+                    json.dumps({
+                        "type": "assistant",
+                        "uuid": "a1",
+                        "timestamp": "2026-06-13T01:00:01Z",
+                        "message": {
+                            "role": "assistant",
+                            "content": [
+                                {"type": "thinking", "text": "hidden"},
+                                {"type": "text", "text": "saved"},
+                                {"type": "tool_use", "name": "Read"},
+                            ],
+                        },
+                    }),
+                    json.dumps({
+                        "type": "assistant",
+                        "uuid": "a1",
+                        "message": {"role": "assistant", "content": [{"type": "text", "text": "duplicate"}]},
+                    }),
+                ]
+            ),
+            encoding="utf-8",
+        )
+
+        assert module.find_session_file("session-123") == session_file
+        messages = module.parse_session_messages(session_file)
+        assert messages == [
+            {
+                "role": "user",
+                "content": "hello proma",
+                "metadata": {"external_id": "proma:u1", "timestamp": "2026-06-13T01:00:00Z"},
+            },
+            {
+                "role": "assistant",
+                "content": "saved\n[tool: Read]",
+                "metadata": {"external_id": "proma:a1", "timestamp": "2026-06-13T01:00:01Z"},
+            },
+        ]
+
+    def test_working_memory_script_replaces_managed_claude_block(self, tmp_path, monkeypatch):
+        proma_home = tmp_path / ".proma"
+        workspace = proma_home / "agent-workspaces" / "default"
+        workspace.mkdir(parents=True)
+        template = workspace / "CLAUDE.md.template"
+        template.write_text("# Project Rules\n\nKeep this line.\n", encoding="utf-8")
+        monkeypatch.setenv("PROMA_HOME", str(proma_home))
+
+        module = _load_hook_module("proma_wm_hook", PLUGIN_DIR / "hooks" / "read-working-memory.py")
+        assert module.update_claude_md("first context") is True
+        assert "first context" in (workspace / "CLAUDE.md").read_text(encoding="utf-8")
+
+        assert module.update_claude_md("second context") is True
+        rendered = (workspace / "CLAUDE.md").read_text(encoding="utf-8")
+        assert "Keep this line." in rendered
+        assert "second context" in rendered
+        assert "first context" not in rendered
+        assert rendered.count("nowledge-mem:start") == 1
 
 
 class TestSkills:
@@ -217,6 +317,8 @@ class TestIntegrationsJson:
         checklist = "\n".join(entry["autonomy"]["bestResultRequires"])
         assert "skills/nmem" not in checklist
         assert "standard Nowledge Mem skill folders" in checklist
+        assert "~/.proma/sdk-config/.claude/settings.json" in checklist
+        assert "~/.proma/scripts/" in checklist
 
     REQUIRED_SKILLS = TestSkills.REQUIRED_SKILLS
 
@@ -247,5 +349,14 @@ class TestChangelog:
     def test_changelog_has_version(self):
         cl = PLUGIN_DIR / "CHANGELOG.md"
         content = cl.read_text(encoding="utf-8")
+        assert "0.1.2" in content, "CHANGELOG should document version 0.1.2"
         assert "0.1.1" in content, "CHANGELOG should document version 0.1.1"
         assert "0.1.0" in content, "CHANGELOG should document version 0.1.0"
+
+
+def _load_hook_module(name: str, path: Path):
+    spec = importlib.util.spec_from_file_location(name, path)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module

--- a/tests/plugin_e2e/test_proma_plugin.py
+++ b/tests/plugin_e2e/test_proma_plugin.py
@@ -221,6 +221,28 @@ class TestHookScripts:
             },
         ]
 
+    def test_save_script_does_not_fallback_latest_when_session_id_missing(self, tmp_path, monkeypatch):
+        proma_home = tmp_path / ".proma"
+        monkeypatch.setenv("PROMA_HOME", str(proma_home))
+        module = _load_hook_module(
+            "proma_save_hook_missing_session",
+            PLUGIN_DIR / "hooks" / "save-to-nmem.py",
+        )
+
+        session_dir = proma_home / "sdk-config" / "projects" / "workspace-hash"
+        session_dir.mkdir(parents=True)
+        (session_dir / "other-session.jsonl").write_text(
+            json.dumps({
+                "type": "user",
+                "uuid": "u1",
+                "message": {"role": "user", "content": "wrong session"},
+            }),
+            encoding="utf-8",
+        )
+
+        assert module.find_session_file("missing-session") is None
+        assert module.find_session_file(None) == session_dir / "other-session.jsonl"
+
     def test_working_memory_script_replaces_managed_claude_block(self, tmp_path, monkeypatch):
         proma_home = tmp_path / ".proma"
         workspace = proma_home / "agent-workspaces" / "default"
@@ -239,6 +261,32 @@ class TestHookScripts:
         assert "second context" in rendered
         assert "first context" not in rendered
         assert rendered.count("nowledge-mem:start") == 1
+
+    def test_working_memory_script_preserves_user_claude_md_when_template_exists(self, tmp_path, monkeypatch):
+        proma_home = tmp_path / ".proma"
+        workspace = proma_home / "agent-workspaces" / "default"
+        workspace.mkdir(parents=True)
+        (workspace / "CLAUDE.md.template").write_text("# Template\n", encoding="utf-8")
+        claude_md = workspace / "CLAUDE.md"
+        claude_md.write_text(
+            "# User Rules\n\n"
+            "<!-- nowledge-mem:start -->\nold\n<!-- nowledge-mem:end -->\n"
+            "    indented user content\n",
+            encoding="utf-8",
+        )
+        monkeypatch.setenv("PROMA_HOME", str(proma_home))
+
+        module = _load_hook_module(
+            "proma_wm_hook_preserve_user_content",
+            PLUGIN_DIR / "hooks" / "read-working-memory.py",
+        )
+        assert module.update_claude_md("new context") is True
+        rendered = claude_md.read_text(encoding="utf-8")
+        assert "# User Rules" in rendered
+        assert "# Template" not in rendered
+        assert "new context" in rendered
+        assert "old" not in rendered
+        assert "    indented user content" in rendered
 
 
 class TestSkills:


### PR DESCRIPTION
## Summary
- update Proma plugin to v0.1.2 for current Proma SDK paths: hooks in ~/.proma/sdk-config/.claude/settings.json, scripts in ~/.proma/scripts, transcripts under ~/.proma/sdk-config/projects/**
- add UserPromptSubmit capture, keep Stop capture as fallback, and add asyncRewake Working Memory refresh
- replace stdout-only startup context with an idempotent Nowledge Mem block in workspace CLAUDE.md while preserving CLAUDE.md.template/user content
- refresh Proma README, skills, registry metadata, and plugin E2E coverage

## Verification
- uv run --with pytest pytest tests/plugin_e2e -q -k proma
- uv run --with pytest pytest tests/plugin_e2e -q
- python -m py_compile nowledge-mem-proma-plugin/hooks/save-to-nmem.py nowledge-mem-proma-plugin/hooks/read-working-memory.py
- jq empty integrations.json nowledge-mem-proma-plugin/hooks/hooks.json nowledge-mem-proma-plugin/.claude-plugin/plugin.json
- isolated temp-home hook smoke: saved a source=proma thread payload, wrote CLAUDE.md marked context block, and returned exit code 2 for asyncRewake
- node nowledge-mem-codex-plugin/scripts/validate-plugin.mjs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Real-time thread capture during user prompts plus continued session-end capture
  * Async working-memory refresh on session end to surface fresh context

* **Improvements**
  * Improved startup-context injection while preserving user-authored content
  * More reliable session discovery and transcript handling
  * Updated installation/configuration flow and plugin version bump

* **Documentation**
  * Rewritten setup and troubleshooting guidance to match new behavior and paths
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes automatic thread sync and startup context injection (including rewriting workspace CLAUDE.md), so misconfigured paths or aggressive rewake could affect user workspace files or session flow; scope is Proma integration only, not core auth or payment paths.
> 
> **Overview**
> Bumps the **Nowledge Mem Proma plugin to v0.1.2** so it matches current Proma / Claude Agent SDK layout instead of older `~/.proma/hooks` and `~/.proma/settings.json` paths.
> 
> **Configuration and capture:** Hooks install into `~/.proma/sdk-config/.claude/settings.json`; scripts live under `~/.proma/scripts/`. `save-to-nmem.py` reads transcripts from `~/.proma/sdk-config/projects/**/<session-id>.jsonl` (with legacy `agent-sessions` fallback), syncs on **`UserPromptSubmit`** as well as **`Stop`**, and posts threads as `source=proma` with dedupe and richer hook payload keys.
> 
> **Startup and live context:** `read-working-memory.py` no longer relies on SessionStart stdout; it **writes an idempotent `<!-- nowledge-mem:start -->` block** into workspace `CLAUDE.md` (respecting `CLAUDE.md.template`). A second **Stop** hook uses **`asyncRewake`** to print Working Memory and exit `2` when there is fresh context.
> 
> **Docs and tests:** `integrations.json`, README, skills, and CHANGELOG reflect the new paths and behaviors; plugin E2E/static tests assert hook contract, SDK JSONL parsing, and `CLAUDE.md` block replacement.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f24cb385a79f86d59bfe686cdb30fe78d98fe5ed. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->