### PR TITLE
fix(codex): support Windows hook capture

### DIFF
--- a/integrations.json
+++ b/integrations.json
@@ -175,7 +175,7 @@
       "name": "Codex",
       "category": "coding",
       "type": "plugin",
-      "version": "0.1.13",
+      "version": "0.1.14",
       "directory": "nowledge-mem-codex-plugin",
 
       "legacyDirectory": "nowledge-mem-codex-prompts",

--- a/nowledge-mem-codex-plugin/.codex-plugin/plugin.json
+++ b/nowledge-mem-codex-plugin/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "nowledge-mem",
-  "version": "0.1.13",
+  "version": "0.1.14",
   "description": "Your Codex agent remembers past decisions, finds relevant context, and learns from every session, across all your AI tools.",
   "skills": "./skills/",
   "mcpServers": "./.mcp.json",

--- a/nowledge-mem-codex-plugin/CHANGELOG.md
+++ b/nowledge-mem-codex-plugin/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [0.1.14] - 2026-06-14
+
+### Fixed
+
+- Codex Stop hooks now use a Windows-specific `python` launcher instead of assuming `python3` exists on Windows.
+- Codex Stop hook capture now invokes `nmem.CMD` directly on native Windows, avoiding `cmd.exe /s /c` quoting that could make paths with spaces fail.
+
 ## [0.1.13] - 2026-05-15
 
 ### Fixed

--- a/nowledge-mem-codex-plugin/CHANGELOG.md
+++ b/nowledge-mem-codex-plugin/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Fixed
 
-- Codex Stop hooks now use a Windows-specific `python` launcher instead of assuming `python3` exists on Windows.
+- Codex Stop hooks now use a Windows-specific launcher chain (`python`, then `py -3`, then `python3`) instead of assuming `python3` exists on Windows.
 - Codex Stop hook capture now invokes `nmem.CMD` directly on native Windows, avoiding `cmd.exe /s /c` quoting that could make paths with spaces fail.
 
 ## [0.1.13] - 2026-05-15

--- a/nowledge-mem-codex-plugin/hooks/hooks.json
+++ b/nowledge-mem-codex-plugin/hooks/hooks.json
@@ -8,7 +8,7 @@
           {
             "type": "command",
             "command": "python3 \"${PLUGIN_ROOT}/hooks/nmem-stop-save.py\"",
-            "commandWindows": "python \"${PLUGIN_ROOT}/hooks/nmem-stop-save.py\"",
+            "commandWindows": "python \"${PLUGIN_ROOT}/hooks/nmem-stop-save.py\" || py -3 \"${PLUGIN_ROOT}/hooks/nmem-stop-save.py\" || python3 \"${PLUGIN_ROOT}/hooks/nmem-stop-save.py\"",
             "timeout": 40,
             "statusMessage": "Saving Codex thread to Nowledge Mem..."
           }

--- a/nowledge-mem-codex-plugin/hooks/hooks.json
+++ b/nowledge-mem-codex-plugin/hooks/hooks.json
@@ -8,6 +8,7 @@
           {
             "type": "command",
             "command": "python3 \"${PLUGIN_ROOT}/hooks/nmem-stop-save.py\"",
+            "commandWindows": "python \"${PLUGIN_ROOT}/hooks/nmem-stop-save.py\"",
             "timeout": 40,
             "statusMessage": "Saving Codex thread to Nowledge Mem..."
           }

--- a/nowledge-mem-codex-plugin/hooks/nmem-stop-save.py
+++ b/nowledge-mem-codex-plugin/hooks/nmem-stop-save.py
@@ -219,9 +219,10 @@ def _cmd_exe_path(path: str) -> str:
 
 def _build_nmem_command(nmem: str, *args: str) -> list[str]:
     if nmem.lower().endswith(".cmd"):
+        if os.name == "nt":
+            return [nmem, *args]
         return [
             "cmd.exe",
-            "/s",
             "/c",
             subprocess.list2cmdline([_cmd_exe_path(nmem), *args]),
         ]

--- a/nowledge-mem-codex-plugin/scripts/validate-plugin.mjs
+++ b/nowledge-mem-codex-plugin/scripts/validate-plugin.mjs
@@ -8,7 +8,7 @@ import { fileURLToPath } from "node:url";
 const scriptDir = path.dirname(fileURLToPath(import.meta.url));
 const pluginRoot = path.resolve(scriptDir, "..");
 const repoRoot = path.resolve(pluginRoot, "..");
-const expectedVersion = "0.1.13";
+const expectedVersion = "0.1.14";
 
 const fail = (message) => {
   console.error(`FAIL: ${message}`);
@@ -105,6 +105,7 @@ if (hooks) {
       }
       if (value && typeof value === "object") {
         if (typeof value.command === "string") commands.push(value.command);
+        if (typeof value.commandWindows === "string") commands.push(value.commandWindows);
         for (const item of Object.values(value)) collectCommands(item);
       }
     };
@@ -115,6 +116,9 @@ if (hooks) {
     if (!commands.some((command) => command.includes("\"${PLUGIN_ROOT}/hooks/nmem-stop-save.py\""))) {
       fail("Stop hook command must quote the ${PLUGIN_ROOT} script path");
     } else ok("Stop hook path quoting");
+    if (!commands.some((command) => command.includes("python \"${PLUGIN_ROOT}/hooks/nmem-stop-save.py\""))) {
+      fail("Stop hook must declare a Windows command using python");
+    } else ok("Stop hook Windows Python launcher");
   }
 }
 

--- a/nowledge-mem-codex-plugin/scripts/validate-plugin.mjs
+++ b/nowledge-mem-codex-plugin/scripts/validate-plugin.mjs
@@ -119,6 +119,9 @@ if (hooks) {
     if (!commands.some((command) => command.includes("python \"${PLUGIN_ROOT}/hooks/nmem-stop-save.py\""))) {
       fail("Stop hook must declare a Windows command using python");
     } else ok("Stop hook Windows Python launcher");
+    if (!commands.some((command) => command.includes("py -3 \"${PLUGIN_ROOT}/hooks/nmem-stop-save.py\""))) {
+      fail("Stop hook must declare a Windows py launcher fallback");
+    } else ok("Stop hook Windows py fallback");
   }
 }
 

--- a/nowledge-mem-codex-plugin/tests/test_codex_plugin.py
+++ b/nowledge-mem-codex-plugin/tests/test_codex_plugin.py
@@ -60,6 +60,31 @@ class HookTests(unittest.TestCase):
             ],
         )
 
+    def test_build_command_invokes_windows_cmd_directly_on_windows(self):
+        nmem = r"C:\Users\jockie\AppData\Local\Nowledge Mem\cli\nmem.CMD"
+        with mock.patch.object(self.module.os, "name", "nt"):
+            command = self.module._build_save_command(
+                nmem,
+                {"session_id": "019abc", "cwd": r"D:\server-prod-env-setting"},
+                include_session_id=True,
+            )
+
+        self.assertEqual(command[0], nmem)
+        self.assertNotIn("cmd.exe", command)
+        self.assertIn(r"D:\server-prod-env-setting", command)
+
+    def test_build_command_keeps_cmd_bridge_for_wsl(self):
+        nmem = "/mnt/c/Users/jockie/AppData/Local/Nowledge Mem/cli/nmem.CMD"
+        with mock.patch.object(self.module.os, "name", "posix"):
+            command = self.module._build_save_command(
+                nmem,
+                {"session_id": "019abc", "cwd": "/home/jockie/project"},
+                include_session_id=True,
+            )
+
+        self.assertEqual(command[:2], ["cmd.exe", "/c"])
+        self.assertIn("nmem.CMD", command[2])
+
     def test_retry_without_session_id_on_lookup_miss(self):
         calls = []
 

--- a/tests/plugin_e2e/test_key_plugins_e2e.py
+++ b/tests/plugin_e2e/test_key_plugins_e2e.py
@@ -292,6 +292,14 @@ def test_key_plugin_static_contracts_are_declared():
         if isinstance(hook, dict)
     ]
     assert any('"${PLUGIN_ROOT}/hooks/nmem-stop-save.py"' in command for command in codex_stop_commands)
+    codex_windows_commands = [
+        hook.get("commandWindows", "")
+        for entry in codex_hooks.get("Stop", [])
+        if isinstance(entry, dict)
+        for hook in entry.get("hooks", [])
+        if isinstance(hook, dict)
+    ]
+    assert any('python "${PLUGIN_ROOT}/hooks/nmem-stop-save.py"' in command for command in codex_windows_commands)
     assert (CODEX_PLUGIN / "scripts" / "install_hooks.py").exists()
     assert (CODEX_PLUGIN / "skills" / "working-memory" / "SKILL.md").exists()
     assert (CODEX_PLUGIN / "skills" / "save-thread" / "SKILL.md").exists()

--- a/tests/plugin_e2e/test_key_plugins_e2e.py
+++ b/tests/plugin_e2e/test_key_plugins_e2e.py
@@ -300,6 +300,7 @@ def test_key_plugin_static_contracts_are_declared():
         if isinstance(hook, dict)
     ]
     assert any('python "${PLUGIN_ROOT}/hooks/nmem-stop-save.py"' in command for command in codex_windows_commands)
+    assert any('py -3 "${PLUGIN_ROOT}/hooks/nmem-stop-save.py"' in command for command in codex_windows_commands)
     assert (CODEX_PLUGIN / "scripts" / "install_hooks.py").exists()
     assert (CODEX_PLUGIN / "skills" / "working-memory" / "SKILL.md").exists()
     assert (CODEX_PLUGIN / "skills" / "save-thread" / "SKILL.md").exists()


### PR DESCRIPTION
## Summary

Fixes #296.

- Add a Windows-specific Codex hook command that uses `python` instead of assuming `python3` exists on Windows.
- Invoke `nmem.CMD` directly on native Windows instead of wrapping it with `cmd.exe /s /c`, avoiding broken quoting for paths with spaces.
- Bump the Codex plugin to `0.1.14` and update the community registry/validation tests.

Related: #297 is a core `nmem t save --from claude-code` Windows path-encoding issue; the paired fix is in the main Mem repo because it lives in `nmem-cli`, not in this community plugin package.

## Verification

- `uv run --with pytest pytest tests/plugin_e2e -q`
- `node nowledge-mem-codex-plugin/scripts/validate-plugin.mjs`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Windows stop transcript capture to better handle paths with spaces and avoid command-quoting issues.
  * Added a Windows Python launcher fallback chain (`python` → `py -3` → `python3`) for the stop hook.
  * Updated command execution so Windows runs the `.cmd` target directly, while non-Windows uses a safer `cmd.exe /c` flow.

* **Tests**
  * Added unit and contract checks for the new Windows vs non-Windows stop-hook command behavior.

* **Chores**
  * Bumped versions to **0.1.14** and updated the changelog.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->