### PR TITLE
feat(proma-plugin): add PROMA_ALLOWED_WORKSPACES filter to save-to-nmem hook

### DIFF
--- a/nowledge-mem-proma-plugin/CHANGELOG.md
+++ b/nowledge-mem-proma-plugin/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog — nowledge-mem-proma-plugin
 
+## 0.1.3 (unreleased)
+
+- Add `PROMA_ALLOWED_WORKSPACES` env var to `save-to-nmem.py` so users can restrict thread sync to a subset of Proma workspaces. Defaults to `default`, preserving current behavior for single-workspace installs. Sessions whose cwd lives under a non-allowlisted workspace are skipped with a log entry.
+
 ## 0.1.2 (2026-06-13)
 
 - Align hooks with current Proma builds: install into `~/.proma/sdk-config/.claude/settings.json`, copy scripts to `~/.proma/scripts/`, and read transcripts from `~/.proma/sdk-config/projects/**/<session-id>.jsonl`.

--- a/nowledge-mem-proma-plugin/CHANGELOG.md
+++ b/nowledge-mem-proma-plugin/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 0.1.3 (unreleased)
 
-- Add `PROMA_ALLOWED_WORKSPACES` env var to `save-to-nmem.py` so users can restrict thread sync to a subset of Proma workspaces. Defaults to `default`, preserving current behavior for single-workspace installs. Sessions whose cwd lives under a non-allowlisted workspace are skipped with a log entry.
+- Add optional `PROMA_ALLOWED_WORKSPACES` filtering to `save-to-nmem.py` for multi-workspace Proma users. Leaving it unset keeps the previous behavior and syncs every workspace; setting a comma-separated list such as `default,research` skips other workspaces with a log entry.
 
 ## 0.1.2 (2026-06-13)
 

--- a/nowledge-mem-proma-plugin/README.md
+++ b/nowledge-mem-proma-plugin/README.md
@@ -217,10 +217,18 @@ The MCP server gives Proma agent access to Nowledge Mem search, save, status, sk
 | `NMEM_API_KEY` | Nowledge Mem API key | `~/.nowledge-mem/config.json` |
 | `PROMA_HOME` | Proma home directory | `~/.proma` |
 | `PROMA_PROJECTS_DIR` | Proma transcript directory | `~/.proma/sdk-config/projects` |
-| `PROMA_ALLOWED_WORKSPACES` | Comma-separated workspace dir names whose sessions get synced to Nowledge Mem (others are skipped) | `default` |
+| `PROMA_ALLOWED_WORKSPACES` | Optional comma-separated workspace dir names whose sessions get synced to Nowledge Mem. Leave unset to sync every Proma workspace. Use `*` or `all` for an explicit allow-all value. | unset |
 | `PROMA_WORKSPACE_DIR` | Proma workspace directory for `CLAUDE.md` | `~/.proma/agent-workspaces/default` |
 | `PROMA_CLAUDE_MD` | Explicit `CLAUDE.md` output path | `<workspace>/CLAUDE.md` |
 | `PROMA_CLAUDE_TEMPLATE` | Explicit template path | `<workspace>/CLAUDE.md.template` |
+
+If you keep several Proma workspaces and only want Nowledge Mem to capture some of them, set:
+
+```bash
+export PROMA_ALLOWED_WORKSPACES="default,research"
+```
+
+The names are the directory names under `~/.proma/agent-workspaces/`.
 
 Logs are written to:
 

--- a/nowledge-mem-proma-plugin/README.md
+++ b/nowledge-mem-proma-plugin/README.md
@@ -217,6 +217,7 @@ The MCP server gives Proma agent access to Nowledge Mem search, save, status, sk
 | `NMEM_API_KEY` | Nowledge Mem API key | `~/.nowledge-mem/config.json` |
 | `PROMA_HOME` | Proma home directory | `~/.proma` |
 | `PROMA_PROJECTS_DIR` | Proma transcript directory | `~/.proma/sdk-config/projects` |
+| `PROMA_ALLOWED_WORKSPACES` | Comma-separated workspace dir names whose sessions get synced to Nowledge Mem (others are skipped) | `default` |
 | `PROMA_WORKSPACE_DIR` | Proma workspace directory for `CLAUDE.md` | `~/.proma/agent-workspaces/default` |
 | `PROMA_CLAUDE_MD` | Explicit `CLAUDE.md` output path | `<workspace>/CLAUDE.md` |
 | `PROMA_CLAUDE_TEMPLATE` | Explicit template path | `<workspace>/CLAUDE.md.template` |

--- a/nowledge-mem-proma-plugin/hooks/save-to-nmem.py
+++ b/nowledge-mem-proma-plugin/hooks/save-to-nmem.py
@@ -70,14 +70,23 @@ LEGACY_SESSIONS_DIR = PROMA_HOME / "agent-sessions"
 LOG_DIR = PROMA_HOME / "logs"
 LOG_FILE = LOG_DIR / "nm-hooks.log"
 
-# Only sync sessions whose cwd lives under one of these workspace dirs
-# (relative to PROMA_HOME/agent-workspaces). Override with
-# PROMA_ALLOWED_WORKSPACES="default,other" (comma-separated).
-_DEFAULT_ALLOWED = "default"
-_ALLOWED_RAW = os.environ.get("PROMA_ALLOWED_WORKSPACES", _DEFAULT_ALLOWED)
-ALLOWED_WORKSPACE_DIRS: set[str] = {
-    part.strip() for part in _ALLOWED_RAW.split(",") if part.strip()
-}
+# Optional filter for sessions whose cwd lives under one of these workspace dirs
+# (relative to PROMA_HOME/agent-workspaces). Unset or blank preserves the
+# historical behavior and syncs all Proma workspaces. Set
+# PROMA_ALLOWED_WORKSPACES="default,other" to restrict capture.
+_ALLOW_ALL_WORKSPACES = {"*", "all"}
+
+
+def _parse_allowed_workspaces(raw: str | None) -> set[str] | None:
+    if not raw or not raw.strip():
+        return None
+    names = {part.strip() for part in raw.split(",") if part.strip()}
+    if not names or any(name.lower() in _ALLOW_ALL_WORKSPACES for name in names):
+        return None
+    return names
+
+
+ALLOWED_WORKSPACE_DIRS = _parse_allowed_workspaces(os.environ.get("PROMA_ALLOWED_WORKSPACES"))
 
 HEADERS = {
     "Content-Type": "application/json",
@@ -191,6 +200,21 @@ def find_session_file(session_id: str | None = None) -> Path | None:
         return max(files, key=lambda p: p.stat().st_mtime)
     except Exception:
         return files[0] if files else None
+
+
+def workspace_dir_from_cwd(cwd: str | None) -> str | None:
+    if not cwd:
+        return None
+    try:
+        cwd_path = Path(cwd).expanduser().resolve()
+        workspaces_root = (PROMA_HOME / "agent-workspaces").resolve()
+        rel = cwd_path.relative_to(workspaces_root)
+    except ValueError:
+        return None
+    except (OSError, RuntimeError) as exc:
+        log(f"workspace resolution failed for cwd={cwd}: {exc}")
+        return None
+    return rel.parts[0] if rel.parts else None
 
 
 def extract_text_from_content(content: Any) -> str:
@@ -322,23 +346,14 @@ def main() -> int:
 
     log(f"start event={args.event} session={session_id or 'latest'} cwd={cwd or 'missing'}")
 
-    if cwd:
-        try:
-            cwd_path = Path(cwd).expanduser().resolve()
-            workspaces_root = (PROMA_HOME / "agent-workspaces").resolve()
-            rel = cwd_path.relative_to(workspaces_root)
-            workspace_dir = rel.parts[0] if rel.parts else ""
-        except Exception:
-            workspace_dir = ""
+    if ALLOWED_WORKSPACE_DIRS is not None:
+        workspace_dir = workspace_dir_from_cwd(cwd)
         if workspace_dir not in ALLOWED_WORKSPACE_DIRS:
             log(
-                f"skip: workspace '{workspace_dir}' not in allowed "
+                f"skip: workspace '{workspace_dir or 'unknown'}' not in allowed "
                 f"{sorted(ALLOWED_WORKSPACE_DIRS)}"
             )
             return 0
-    else:
-        log("skip: cwd missing, cannot determine workspace")
-        return 0
 
     session_file = find_session_file(session_id)
     if not session_file:

--- a/nowledge-mem-proma-plugin/hooks/save-to-nmem.py
+++ b/nowledge-mem-proma-plugin/hooks/save-to-nmem.py
@@ -70,6 +70,15 @@ LEGACY_SESSIONS_DIR = PROMA_HOME / "agent-sessions"
 LOG_DIR = PROMA_HOME / "logs"
 LOG_FILE = LOG_DIR / "nm-hooks.log"
 
+# Only sync sessions whose cwd lives under one of these workspace dirs
+# (relative to PROMA_HOME/agent-workspaces). Override with
+# PROMA_ALLOWED_WORKSPACES="default,other" (comma-separated).
+_DEFAULT_ALLOWED = "default"
+_ALLOWED_RAW = os.environ.get("PROMA_ALLOWED_WORKSPACES", _DEFAULT_ALLOWED)
+ALLOWED_WORKSPACE_DIRS: set[str] = {
+    part.strip() for part in _ALLOWED_RAW.split(",") if part.strip()
+}
+
 HEADERS = {
     "Content-Type": "application/json",
     "APP": "Proma",
@@ -312,6 +321,24 @@ def main() -> int:
     cwd = payload_value(payload, "cwd", "projectDir", "workspace", "workspacePath")
 
     log(f"start event={args.event} session={session_id or 'latest'} cwd={cwd or 'missing'}")
+
+    if cwd:
+        try:
+            cwd_path = Path(cwd).expanduser().resolve()
+            workspaces_root = (PROMA_HOME / "agent-workspaces").resolve()
+            rel = cwd_path.relative_to(workspaces_root)
+            workspace_dir = rel.parts[0] if rel.parts else ""
+        except Exception:
+            workspace_dir = ""
+        if workspace_dir not in ALLOWED_WORKSPACE_DIRS:
+            log(
+                f"skip: workspace '{workspace_dir}' not in allowed "
+                f"{sorted(ALLOWED_WORKSPACE_DIRS)}"
+            )
+            return 0
+    else:
+        log("skip: cwd missing, cannot determine workspace")
+        return 0
 
     session_file = find_session_file(session_id)
     if not session_file:

--- a/tests/plugin_e2e/test_proma_plugin.py
+++ b/tests/plugin_e2e/test_proma_plugin.py
@@ -9,10 +9,10 @@ Live smoke test (requires Proma + nmem):
 
 from __future__ import annotations
 
-import json
-import os
-import sys
 import importlib.util
+import io
+import json
+import sys
 from pathlib import Path
 
 import pytest
@@ -165,6 +165,120 @@ class TestHookScripts:
         assert '"deduplicate": True' in content
         assert '"idempotency_key": f"proma:{session_id}"' in content
         assert 'metadata["external_id"] = f"proma:{uuid}"' in content
+
+    def test_save_script_workspace_filter_defaults_to_allow_all(self, monkeypatch):
+        monkeypatch.delenv("PROMA_ALLOWED_WORKSPACES", raising=False)
+        module = _load_hook_module(
+            "proma_save_hook_workspace_filter_unset",
+            PLUGIN_DIR / "hooks" / "save-to-nmem.py",
+        )
+
+        assert module.ALLOWED_WORKSPACE_DIRS is None
+        assert module._parse_allowed_workspaces("") is None
+        assert module._parse_allowed_workspaces("   ") is None
+        assert module._parse_allowed_workspaces("*") is None
+        assert module._parse_allowed_workspaces("all") is None
+
+    def test_save_script_workspace_filter_parses_explicit_allowlist(self, monkeypatch):
+        monkeypatch.setenv("PROMA_ALLOWED_WORKSPACES", "default, research ,personal")
+        module = _load_hook_module(
+            "proma_save_hook_workspace_filter_allowlist",
+            PLUGIN_DIR / "hooks" / "save-to-nmem.py",
+        )
+
+        assert module.ALLOWED_WORKSPACE_DIRS == {"default", "research", "personal"}
+
+    def test_save_script_resolves_workspace_dir_from_cwd(self, tmp_path, monkeypatch):
+        proma_home = tmp_path / ".proma"
+        workspace = proma_home / "agent-workspaces" / "research" / "project"
+        workspace.mkdir(parents=True)
+        outside = tmp_path / "outside"
+        outside.mkdir()
+        monkeypatch.setenv("PROMA_HOME", str(proma_home))
+
+        module = _load_hook_module(
+            "proma_save_hook_workspace_filter_resolution",
+            PLUGIN_DIR / "hooks" / "save-to-nmem.py",
+        )
+
+        assert module.workspace_dir_from_cwd(str(workspace)) == "research"
+        assert module.workspace_dir_from_cwd(str(outside)) is None
+        assert module.workspace_dir_from_cwd(None) is None
+
+    def test_save_script_without_allowlist_accepts_missing_cwd(self, tmp_path, monkeypatch):
+        proma_home = tmp_path / ".proma"
+        monkeypatch.setenv("PROMA_HOME", str(proma_home))
+        monkeypatch.delenv("PROMA_ALLOWED_WORKSPACES", raising=False)
+        module = _load_hook_module(
+            "proma_save_hook_workspace_filter_missing_cwd_allowed",
+            PLUGIN_DIR / "hooks" / "save-to-nmem.py",
+        )
+
+        session_dir = proma_home / "sdk-config" / "projects" / "workspace-hash"
+        session_dir.mkdir(parents=True)
+        (session_dir / "session-123.jsonl").write_text(
+            json.dumps({
+                "type": "user",
+                "uuid": "u1",
+                "message": {"role": "user", "content": "sync without cwd"},
+            }),
+            encoding="utf-8",
+        )
+
+        uploads = []
+        monkeypatch.setattr(
+            module,
+            "upload_thread",
+            lambda session_id, messages, cwd: (
+                uploads.append((session_id, messages, cwd)) or True
+            ),
+        )
+        monkeypatch.setattr(sys, "argv", ["save-to-nmem.py"])
+        monkeypatch.setattr(
+            sys,
+            "stdin",
+            io.StringIO(json.dumps({"session_id": "session-123"})),
+        )
+
+        assert module.main() == 0
+        assert uploads == [
+            (
+                "session-123",
+                [
+                    {
+                        "role": "user",
+                        "content": "sync without cwd",
+                        "metadata": {"external_id": "proma:u1"},
+                    }
+                ],
+                None,
+            )
+        ]
+
+    def test_save_script_with_allowlist_skips_missing_cwd(self, tmp_path, monkeypatch):
+        proma_home = tmp_path / ".proma"
+        monkeypatch.setenv("PROMA_HOME", str(proma_home))
+        monkeypatch.setenv("PROMA_ALLOWED_WORKSPACES", "default")
+        module = _load_hook_module(
+            "proma_save_hook_workspace_filter_missing_cwd_skipped",
+            PLUGIN_DIR / "hooks" / "save-to-nmem.py",
+        )
+
+        uploads = []
+        monkeypatch.setattr(
+            module,
+            "upload_thread",
+            lambda *args: uploads.append(args) or True,
+        )
+        monkeypatch.setattr(sys, "argv", ["save-to-nmem.py"])
+        monkeypatch.setattr(
+            sys,
+            "stdin",
+            io.StringIO(json.dumps({"session_id": "session-123"})),
+        )
+
+        assert module.main() == 0
+        assert uploads == []
 
     def test_save_script_parses_current_proma_sdk_jsonl(self, tmp_path, monkeypatch):
         proma_home = tmp_path / ".proma"


### PR DESCRIPTION
## Summary

Adds an optional `PROMA_ALLOWED_WORKSPACES` filter for the Proma `save-to-nmem.py` hook. This lets multi-workspace Proma users capture only selected workspace directories, while preserving existing sync behavior by default.

## Design

- `PROMA_ALLOWED_WORKSPACES` is unset by default, which means all Proma workspaces continue to sync.
- Empty values, `*`, and `all` are treated as explicit allow-all values.
- A comma-separated list such as `default,research` restricts capture to those directory names under `~/.proma/agent-workspaces/`.
- When a restrictive allowlist is configured and the hook cannot identify an allowed workspace from `cwd`, it skips upload and writes an observable log entry.

## Validation

- `uv run --with pytest pytest tests/plugin_e2e/test_proma_plugin.py -q`
- `uv run --with pytest pytest tests/plugin_e2e -q`
- `uv run --with ruff ruff check nowledge-mem-proma-plugin/hooks/save-to-nmem.py tests/plugin_e2e/test_proma_plugin.py`
- `node nowledge-mem-codex-plugin/scripts/validate-plugin.mjs`
- `git diff --check`