### PR TITLE
docker: bump default image tag to 0.9.17

### DIFF
--- a/docker/compose.yaml
+++ b/docker/compose.yaml
@@ -32,7 +32,7 @@ services:
     # optional `./nmemctl auto-update` sidecar can flip versions by
     # writing `NMEM_IMAGE_TAG=<ver>` to `.env` (mode 0600, gitignored)
     # without rewriting this file. Fresh installs use the default.
-    image: docker.io/nowledgelabs/mem:${NMEM_IMAGE_TAG:-0.9.16}
+    image: docker.io/nowledgelabs/mem:${NMEM_IMAGE_TAG:-0.9.17}
     container_name: nowledge-mem
     restart: unless-stopped
     labels:


### PR DESCRIPTION
Track the release so fresh / NAS-app installs pull this version (the preflight guard enforces it). Example commands stay on :latest.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the default container image version to 0.9.17, with support for custom version overrides.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->