### PR TITLE
feat: add agent identity fingerprint to Codex and Claude Code plugins

### DIFF
--- a/nowledge-mem-claude-code-plugin/scripts/nmem-hook-save.py
+++ b/nowledge-mem-claude-code-plugin/scripts/nmem-hook-save.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import argparse
+import hashlib
 import json
 import os
 import shutil
@@ -108,6 +109,72 @@ def _cmd_exe_path(path: str) -> str:
     return "nmem.cmd" if Path(path).name.lower() == "nmem.cmd" else path
 
 
+_FINGERPRINT_SOURCES = (
+    "/etc/machine-id",
+    "/proc/1/mountinfo",
+)
+
+def _host_agent_fingerprint(runtime: str) -> str:
+    """Derive a stable agent-identity fingerprint from system sources.
+
+    Tries each source in ``_FINGERPRINT_SOURCES`` in order:
+
+    * ``/etc/machine-id`` — standard on systemd hosts.
+    * ``/proc/1/mountinfo`` — extracts the overlay upperdir layer hash
+      (Docker / LazyCat containers).
+
+    Returns ``"{runtime}-XXXXXXXX"`` (8 hex chars) or an empty string.
+    """
+    for source in _FINGERPRINT_SOURCES:
+        try:
+            raw = Path(source).read_text(encoding="utf-8").strip()
+        except (OSError, UnicodeDecodeError):
+            continue
+        if not raw:
+            continue
+
+        # For /proc/1/mountinfo, extract the overlay upperdir layer hash.
+        if source == "/proc/1/mountinfo":
+            extracted = _extract_overlay_id(raw)
+            if not extracted:
+                continue
+            raw = extracted
+
+        digest = hashlib.sha256(raw.encode("utf-8")).hexdigest()
+        return f"{runtime}-{digest[:8]}"
+
+    return ""
+
+
+def _extract_overlay_id(mountinfo: str) -> str:
+    """Pull the writable layer id from a Docker/LazyCat overlay mount.
+
+    Looks for a line containing ``upperdir=`` and returns the basename
+    of the upperdir path, e.g.
+    ``3f5a6e77235c373fdf96c583b0b4acafc14ca19825ed54bd009f5dca2d34a78d``.
+    """
+    for line in mountinfo.splitlines():
+        if "upperdir=" not in line:
+            continue
+        upper = line
+        # Extract upperdir=value (stop at comma or space)
+        marker = "upperdir="
+        idx = upper.find(marker)
+        if idx == -1:
+            continue
+        value = upper[idx + len(marker):]
+        # Stop at the first comma (overlay options separator) or whitespace
+        end = len(value)
+        for i, ch in enumerate(value):
+            if ch == "," or ch.isspace():
+                end = i
+                break
+        upperdir = value[:end]
+        # Return the basename (the layer hash)
+        return Path(upperdir).name
+
+    return ""
+
 def _build_nmem_command(nmem: str, *args: str) -> list[str]:
     if nmem.lower().endswith(".cmd"):
         return [
@@ -178,6 +245,10 @@ def _build_command(
         runtime,
         "--truncate",
     ]
+
+    host_agent_id = _host_agent_fingerprint(runtime)
+    if host_agent_id:
+        args.extend(["--host-agent-id", host_agent_id])
 
     session_id = _payload_value(payload, "session_id", "sessionId") or os.environ.get(
         "GROK_SESSION_ID", ""

--- a/nowledge-mem-codex-plugin/hooks/nmem-stop-save.py
+++ b/nowledge-mem-codex-plugin/hooks/nmem-stop-save.py
@@ -19,6 +19,13 @@ from typing import Any
 ATTEMPT_TIMEOUT_SECONDS = 8
 SAVE_RETRY_DELAYS_SECONDS = (0.0, 0.5, 1.5, 3.0)
 CAPTURE_LOCK_STALE_SECONDS = 90
+
+# Ordered by preference: /etc/machine-id (systemd/Linux standard),
+# then overlay root mountinfo (Docker/LazyCat containers).
+_FINGERPRINT_SOURCES = (
+    "/etc/machine-id",
+    "/proc/1/mountinfo",
+)
 SESSION_NOT_FOUND_MARKERS = (
     "No codex sessions found",
     "Codex sessions directory not found",
@@ -178,6 +185,68 @@ def _claim_capture_event(payload: dict[str, Any]) -> bool:
     return True
 
 
+def _host_agent_fingerprint() -> str:
+    """Derive a stable agent-identity fingerprint from system sources.
+
+    Tries each source in ``_FINGERPRINT_SOURCES`` in order:
+
+    * ``/etc/machine-id`` — standard on systemd hosts.
+    * ``/proc/1/mountinfo`` — extracts the overlay upperdir layer hash
+      (Docker / LazyCat containers).
+
+    Returns ``"codex-XXXXXXXX"`` (8 hex chars) or an empty string.
+    """
+    for source in _FINGERPRINT_SOURCES:
+        try:
+            raw = Path(source).read_text(encoding="utf-8").strip()
+        except (OSError, UnicodeDecodeError):
+            continue
+        if not raw:
+            continue
+
+        # For /proc/1/mountinfo, extract the overlay upperdir layer hash.
+        if source == "/proc/1/mountinfo":
+            extracted = _extract_overlay_id(raw)
+            if not extracted:
+                continue
+            raw = extracted
+
+        digest = hashlib.sha256(raw.encode("utf-8")).hexdigest()
+        return f"codex-{digest[:8]}"
+
+    return ""
+
+
+def _extract_overlay_id(mountinfo: str) -> str:
+    """Pull the writable layer id from a Docker/LazyCat overlay mount.
+
+    Looks for a line containing ``upperdir=`` and returns the basename
+    of the upperdir path, e.g.
+    ``3f5a6e77235c373fdf96c583b0b4acafc14ca19825ed54bd009f5dca2d34a78d``.
+    """
+    for line in mountinfo.splitlines():
+        if "upperdir=" not in line:
+            continue
+        upper = line
+        # Extract upperdir=value (stop at comma or space)
+        marker = "upperdir="
+        idx = upper.find(marker)
+        if idx == -1:
+            continue
+        value = upper[idx + len(marker):]
+        # Stop at the first comma (overlay options separator) or whitespace
+        end = len(value)
+        for i, ch in enumerate(value):
+            if ch == "," or ch.isspace():
+                end = i
+                break
+        upperdir = value[:end]
+        # Return the basename (the layer hash)
+        return Path(upperdir).name
+
+    return ""
+
+
 def _nmem_command() -> str | None:
     return shutil.which("nmem") or shutil.which("nmem.cmd")
 
@@ -263,6 +332,10 @@ def _build_save_command(
         "--truncate",
     ]
 
+    host_agent_id = _host_agent_fingerprint()
+    if host_agent_id:
+        args.extend(["--host-agent-id", host_agent_id])
+
     cwd = _payload_value(payload, "cwd")
     if cwd:
         project = str(Path(cwd).expanduser())
@@ -275,8 +348,6 @@ def _build_save_command(
         args.extend(["--session-id", session_id])
 
     return _build_nmem_command(nmem, *args)
-
-
 def _run_save(
     nmem: str,
     payload: dict[str, Any],


### PR DESCRIPTION
## 变更内容

为 Codex 和 Claude Code/Grok Build 插件的 hook 脚本添加自动 agent 身份指纹识别。

### 背景

Nowledge Mem 服务端支持 `--host-agent-id` 参数来区分不同客户端的 agent 身份，但三个前端插件（Hermes、Codex、Claude Code）之前都没有自动生成指纹的逻辑。

Hermes 端已在 PR #324 中实现。此 PR 为其余两个插件补齐。

### 指纹来源（按优先级）

1. `/etc/machine-id` — systemd / 标准 Linux 主机
2. `/proc/1/mountinfo` — Docker / LazyCat overlay upperdir 层 hash

### 格式

按运行时生成带前缀的指纹：
- Codex: `codex-df087996`
- Claude Code: `claude-code-df087996`  
- Grok Build: `grok-df087996`

### 特性

- **只读，不落盘** — 每次从系统源新鲜计算，不写配置文件
- **容器稳定** — 同一容器重启后指纹不变
- **容器区分** — 不同容器因 writable layer 不同，自动得到不同指纹
- **向后兼容** — 如果不传 `--host-agent-id`，nmem 行为不变

### 改动文件

- `nowledge-mem-codex-plugin/hooks/nmem-stop-save.py` — 新增 `_host_agent_fingerprint()`、`_extract_overlay_id()`，在 `_build_save_command()` 中传入 `--host-agent-id`
- `nowledge-mem-claude-code-plugin/scripts/nmem-hook-save.py` — 同上，prefix 根据运行时选择

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Sessions and transcripts now automatically include stable host identifiers. The system derives unique identifiers for each machine and attaches them to session data, supporting better organization and tracking across multiple physical machines, containers, and cloud environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->