### PR TITLE
fix: use HTTPS Claude marketplace source

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -22,7 +22,7 @@
       "tags": ["ai-powered", "knowledge-management", "context-management", "memory-management"],
       "source": {
         "source": "git-subdir",
-        "url": "nowledge-co/community",
+        "url": "https://github.com/nowledge-co/community",
         "path": "nowledge-mem-claude-code-plugin"
       }
     }

--- a/tests/plugin_e2e/test_key_plugins_e2e.py
+++ b/tests/plugin_e2e/test_key_plugins_e2e.py
@@ -267,6 +267,25 @@ def test_key_plugin_static_contracts_are_declared():
     assert historical_commands["pi"] == "nmem t sync --from pi"
     assert historical_commands["hermes"] == "nmem t sync --from hermes"
 
+    marketplace_files = [
+        COMMUNITY_ROOT / ".agents" / "plugins" / "marketplace.json",
+        COMMUNITY_ROOT / ".claude-plugin" / "marketplace.json",
+        COMMUNITY_ROOT / ".cursor-plugin" / "marketplace.json",
+        COMMUNITY_ROOT / ".factory-plugin" / "marketplace.json",
+        COMMUNITY_ROOT / ".github" / "plugin" / "marketplace.json",
+    ]
+    for marketplace_file in marketplace_files:
+        marketplace_text = marketplace_file.read_text(encoding="utf-8")
+        assert "git@github.com" not in marketplace_text
+        assert "ssh://git@github.com" not in marketplace_text
+        assert "github.com:" not in marketplace_text
+
+    claude_marketplace = _read_json(COMMUNITY_ROOT / ".claude-plugin" / "marketplace.json")
+    for plugin in claude_marketplace["plugins"]:
+        source = plugin.get("source", {})
+        if source.get("source") == "git-subdir":
+            assert source["url"].startswith("https://github.com/")
+
     claude_manifest = _read_json(CLAUDE_PLUGIN / ".claude-plugin" / "plugin.json")
     claude_hooks = _read_json(CLAUDE_PLUGIN / "hooks" / "hooks.json")["hooks"]
     assert claude_manifest["name"] == "nowledge-mem"


### PR DESCRIPTION
## Summary
- Use a full HTTPS GitHub URL in `.claude-plugin/marketplace.json` so Claude Code marketplace updates do not trigger SSH agent / password manager prompts.
- Add a plugin E2E static guard to keep marketplace descriptors free of SSH GitHub URLs.

## Verification
- `uv run --with pytest pytest tests/plugin_e2e -q`
- `node nowledge-mem-codex-plugin/scripts/validate-plugin.mjs`
- JSON marketplace files parse
- `git ls-remote https://github.com/nowledge-co/community main`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected plugin source URL to standard HTTPS format.

* **Tests**
  * Added validation to ensure marketplace plugins use HTTPS GitHub URLs instead of SSH-style formats.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->