### PR TITLE
fix: align Proma connector with v0.13 setup

### DIFF
--- a/integrations.json
+++ b/integrations.json
@@ -1100,7 +1100,7 @@
       "name": "Proma",
       "category": "coding",
       "type": "plugin",
-      "version": "0.1.2",
+      "version": "0.1.3",
       "directory": "nowledge-mem-proma-plugin",
       "transport": "mcp",
       "capabilities": {
@@ -1114,7 +1114,7 @@
       },
       "threadSave": {
         "method": "plugin-capture",
-        "note": "UserPromptSubmit and Stop hooks run save-to-nmem.py, which parses Proma SDK JSONL from ~/.proma/sdk-config/projects/**/ and appends messages to nmem via REST API as source=proma. SessionStart writes Context Bundle into the workspace CLAUDE.md; Stop asyncRewake can push fresh Working Memory."
+        "note": "UserPromptSubmit and Stop hooks run save-to-nmem.py, which parses Proma SDK JSONL from ~/.proma/sdk-config/projects/**/ and appends messages to nmem via REST API as source=proma. SessionStart writes Context Bundle into the selected workspace CLAUDE.md; Stop asyncRewake can push fresh Working Memory."
       },
       "autonomy": {
         "bootstrap": "automatic",
@@ -1122,11 +1122,11 @@
         "distill": "guided",
         "threads": "automatic-capture",
         "bestResultRequires": [
-          "Add Nowledge Mem MCP server to ~/.proma/agent-workspaces/default/mcp.json (key: servers)",
+          "Choose the Proma workspace first, then add Nowledge Mem MCP server to that workspace's mcp.json (key: servers)",
           "Copy hook scripts to ~/.proma/scripts/",
           "Add SessionStart, UserPromptSubmit, and Stop hooks to ~/.proma/sdk-config/.claude/settings.json",
-          "Copy the standard Nowledge Mem skill folders to ~/.proma/agent-workspaces/default/skills/",
-          "Let the SessionStart hook maintain the marked Nowledge Mem block in ~/.proma/agent-workspaces/default/CLAUDE.md",
+          "Copy the standard Nowledge Mem skill folders to the selected workspace's skills/ directory",
+          "Let the SessionStart hook maintain the marked Nowledge Mem block in the selected workspace CLAUDE.md",
           "Restart Proma after configuration changes"
         ]
       },

--- a/nowledge-mem-proma-plugin/.claude-plugin/plugin.json
+++ b/nowledge-mem-proma-plugin/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "nowledge-mem",
   "description": "Personal knowledge graph for Proma — saves Proma conversations, writes startup context into CLAUDE.md, and keeps nmem tools available during work",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "author": {
     "name": "Nowledge Labs",
     "email": "hello@nowledge-labs.ai",

--- a/nowledge-mem-proma-plugin/CHANGELOG.md
+++ b/nowledge-mem-proma-plugin/CHANGELOG.md
@@ -1,8 +1,10 @@
 # Changelog — nowledge-mem-proma-plugin
 
-## 0.1.3 (unreleased)
+## 0.1.3 (2026-06-22)
 
 - Add optional `PROMA_ALLOWED_WORKSPACES` filtering to `save-to-nmem.py` for multi-workspace Proma users. Leaving it unset keeps the previous behavior and syncs every workspace; setting a comma-separated list such as `default,research` skips other workspaces with a log entry.
+- Use `$HOME/.proma` and `python3` in the packaged `hooks/hooks.json` commands instead of relying on a `PROMA_HOME` environment variable. Proma v0.13.0 does not set `PROMA_HOME` for SDK hook commands by default, so copied hook templates now work without extra shell environment setup.
+- Document Proma v0.13.0's built-in Nowledge Mem setup card as the easiest starting point, while keeping this package as the canonical hook/script source.
 
 ## 0.1.2 (2026-06-13)
 

--- a/nowledge-mem-proma-plugin/README.md
+++ b/nowledge-mem-proma-plugin/README.md
@@ -13,8 +13,13 @@ Proma is built on the Claude Agent SDK, but it keeps its own configuration under
 
 - Proma desktop app
 - Nowledge Mem desktop app or remote server
-- Python 3.9+
+- Python 3.9+ available as `python3`
 - `nmem` CLI in PATH, or `uvx` available as fallback
+
+Proma v0.13.0 and newer include a Nowledge Mem card in Proma's Memory settings. You can start from that card and let Proma copy the setup prompt into Agent mode. This package remains the source for the hook scripts, standard skills, and the exact `settings.json` contract.
+
+The examples below use Proma's `default` workspace. If you use another workspace, replace `default` with the directory name under `~/.proma/agent-workspaces/`.
+If your platform exposes Python only as `python`, replace `python3` with `python` in the hook commands below.
 
 Check Nowledge Mem first:
 
@@ -98,7 +103,7 @@ The important pieces are:
         "hooks": [
           {
             "type": "command",
-            "command": "python \"$HOME/.proma/scripts/read-working-memory.py\"",
+            "command": "python3 \"$HOME/.proma/scripts/read-working-memory.py\"",
             "timeout": 15000
           }
         ]
@@ -109,7 +114,7 @@ The important pieces are:
         "hooks": [
           {
             "type": "command",
-            "command": "python \"$HOME/.proma/scripts/save-to-nmem.py\" --event user-prompt-submit",
+            "command": "python3 \"$HOME/.proma/scripts/save-to-nmem.py\" --event user-prompt-submit",
             "timeout": 30000
           }
         ]
@@ -120,7 +125,7 @@ The important pieces are:
         "hooks": [
           {
             "type": "command",
-            "command": "python \"$HOME/.proma/scripts/save-to-nmem.py\" --event stop",
+            "command": "python3 \"$HOME/.proma/scripts/save-to-nmem.py\" --event stop",
             "timeout": 30000
           }
         ]
@@ -129,7 +134,7 @@ The important pieces are:
         "hooks": [
           {
             "type": "command",
-            "command": "python \"$HOME/.proma/scripts/read-working-memory.py\" --rewake",
+            "command": "python3 \"$HOME/.proma/scripts/read-working-memory.py\" --rewake",
             "timeout": 15000,
             "async": true,
             "asyncRewake": true,
@@ -142,7 +147,7 @@ The important pieces are:
 }
 ```
 
-If your Proma build expands environment variables, you can set `PROMA_HOME="$HOME/.proma"` and keep the `${PROMA_HOME}` commands from `hooks/hooks.json`. If not, use absolute paths in `settings.json`.
+The packaged `hooks/hooks.json` uses `$HOME/.proma` for the same reason. Proma sets `CLAUDE_CONFIG_DIR`, but it does not set `PROMA_HOME` for hook commands by default.
 
 ### 4. Install skills
 
@@ -200,7 +205,7 @@ Keep your own Proma instructions outside that marked block, or in `CLAUDE.md.tem
 After each assistant turn, the asyncRewake Stop hook runs:
 
 ```bash
-python "$HOME/.proma/scripts/read-working-memory.py" --rewake
+python3 "$HOME/.proma/scripts/read-working-memory.py" --rewake
 ```
 
 When Nowledge Mem has useful Working Memory, the hook prints it and exits with code `2`, which lets Proma wake the agent with the latest reminder. Empty or unavailable context exits cleanly without interrupting the session.
@@ -254,7 +259,7 @@ Logs are written to:
 
 - Open `~/.proma/agent-workspaces/default/CLAUDE.md`.
 - Confirm it contains a `<!-- nowledge-mem:start -->` block.
-- Run `python ~/.proma/scripts/read-working-memory.py` manually and check the log.
+- Run `python3 ~/.proma/scripts/read-working-memory.py` manually and check the log.
 
 **Threads are not saved**
 
@@ -262,7 +267,7 @@ Logs are written to:
 - Run:
 
 ```bash
-echo '{"session_id":"<session-id>"}' | python ~/.proma/scripts/save-to-nmem.py
+echo '{"session_id":"<session-id>"}' | python3 ~/.proma/scripts/save-to-nmem.py
 ```
 
 - Then check Nowledge Mem for a thread with source `proma`.

--- a/nowledge-mem-proma-plugin/hooks/hooks.json
+++ b/nowledge-mem-proma-plugin/hooks/hooks.json
@@ -7,7 +7,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "python \"${PROMA_HOME}/scripts/save-to-nmem.py\" --event user-prompt-submit",
+            "command": "python3 \"$HOME/.proma/scripts/save-to-nmem.py\" --event user-prompt-submit",
             "timeout": 30000
           }
         ]
@@ -18,7 +18,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "python \"${PROMA_HOME}/scripts/save-to-nmem.py\" --event stop",
+            "command": "python3 \"$HOME/.proma/scripts/save-to-nmem.py\" --event stop",
             "timeout": 30000
           }
         ]
@@ -27,7 +27,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "python \"${PROMA_HOME}/scripts/read-working-memory.py\" --rewake",
+            "command": "python3 \"$HOME/.proma/scripts/read-working-memory.py\" --rewake",
             "timeout": 15000,
             "async": true,
             "asyncRewake": true,
@@ -42,7 +42,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "python \"${PROMA_HOME}/scripts/read-working-memory.py\"",
+            "command": "python3 \"$HOME/.proma/scripts/read-working-memory.py\"",
             "timeout": 15000
           }
         ]

--- a/nowledge-mem-proma-plugin/skills/save-thread/SKILL.md
+++ b/nowledge-mem-proma-plugin/skills/save-thread/SKILL.md
@@ -28,7 +28,7 @@ mcp__nowledge-mem__save_thread
 
 **Manual script (if MCP unavailable)**:
 ```bash
-echo '{"session_id":"<id>","cwd":"<project dir>"}' | python ~/.proma/scripts/save-to-nmem.py
+echo '{"session_id":"<id>","cwd":"<project dir>"}' | python3 ~/.proma/scripts/save-to-nmem.py
 ```
 
 ## Behavior

--- a/nowledge-mem-proma-plugin/skills/status/SKILL.md
+++ b/nowledge-mem-proma-plugin/skills/status/SKILL.md
@@ -43,7 +43,7 @@ nmem status
 | No `mcp__nowledge-mem__*` tools | mcp.json not found or wrong key name; restart Proma |
 | MCP tools return errors | Server unreachable; check `nmem status` |
 | Hook scripts not firing | Python not in PATH; check `~/.proma/logs/nm-hooks.log` |
-| Startup context missing | Run `python ~/.proma/scripts/read-working-memory.py`; check `CLAUDE.md` and the hook log |
+| Startup context missing | Run `python3 ~/.proma/scripts/read-working-memory.py`; check `CLAUDE.md` and the hook log |
 | "nmem CLI not found" | Install via `pip install nmem-cli` or desktop app |
 
 For remote Mem setups, verify `NMEM_API_URL` and `NMEM_API_KEY` are set, or check `~/.nowledge-mem/config.json`.

--- a/tests/plugin_e2e/test_key_plugins_e2e.py
+++ b/tests/plugin_e2e/test_key_plugins_e2e.py
@@ -425,11 +425,13 @@ def test_key_plugin_static_contracts_are_declared():
     proma_hook = (PROMA_PLUGIN / "hooks" / "read-working-memory.py").read_text(encoding="utf-8")
     proma_save_hook = (PROMA_PLUGIN / "hooks" / "save-to-nmem.py").read_text(encoding="utf-8")
     proma_hooks = _read_json(PROMA_PLUGIN / "hooks" / "hooks.json")
-    assert proma_manifest["version"] == "0.1.2"
+    assert proma_manifest["version"] == "0.1.3"
     assert proma_hooks["installPath"] == "~/.proma/sdk-config/.claude/settings.json"
     assert proma_hooks["scriptInstallPath"] == "~/.proma/scripts/"
     assert "UserPromptSubmit" in proma_hooks["hooks"]
     assert "asyncRewake" in json.dumps(proma_hooks)
+    assert "${PROMA_HOME}" not in json.dumps(proma_hooks)
+    assert "$HOME/.proma/scripts/" in json.dumps(proma_hooks)
     assert '"context", "--source-app", "proma"' in proma_hook
     assert "NMEM_AGENT_ID" in proma_hook
     assert "NMEM_HOST_AGENT_ID" in proma_hook
@@ -892,7 +894,7 @@ def test_registry_connect_contract_points_agent_prompts_to_universal_skill():
     assert by_id["cursor"]["version"] == "0.1.6"
     assert by_id["droid"]["version"] == "0.1.1"
     assert by_id["openclaw"]["version"] == "0.8.26"
-    assert by_id["proma"]["version"] == "0.1.2"
+    assert by_id["proma"]["version"] == "0.1.3"
     assert by_id["opencode"]["version"] == "0.3.4"
     assert by_id["pi"]["version"] == "0.8.1"
     assert by_id["kimi-code"]["version"] == "0.1.0"

--- a/tests/plugin_e2e/test_proma_plugin.py
+++ b/tests/plugin_e2e/test_proma_plugin.py
@@ -511,6 +511,7 @@ class TestChangelog:
     def test_changelog_has_version(self):
         cl = PLUGIN_DIR / "CHANGELOG.md"
         content = cl.read_text(encoding="utf-8")
+        assert "0.1.3" in content, "CHANGELOG should document version 0.1.3"
         assert "0.1.2" in content, "CHANGELOG should document version 0.1.2"
         assert "0.1.1" in content, "CHANGELOG should document version 0.1.1"
         assert "0.1.0" in content, "CHANGELOG should document version 0.1.0"


### PR DESCRIPTION
## Summary
- Bump the Proma connector metadata to 0.1.3.
- Make the packaged Proma hook template self-contained by using `$HOME/.proma` instead of relying on Proma to export `PROMA_HOME`.
- Update README, skills, registry text, and static tests for Proma v0.13.0's built-in Nowledge Mem card and selected-workspace setup.

## Notes
- This does not require a Proma upstream change. The community package remains safe even if Proma keeps or later wires `PROMA_HOME` internally.

## Verification
- `uv run --with pytest pytest tests/plugin_e2e -q`
- `python -m json.tool integrations.json`
- `python -m json.tool nowledge-mem-proma-plugin/.claude-plugin/plugin.json`
- `python -m json.tool nowledge-mem-proma-plugin/hooks/hooks.json`
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added workspace-selection-aware setup configuration for improved flexibility.

* **Improvements**
  * Standardized Python 3.9+ as the explicit runtime requirement.
  * Streamlined path handling with direct `$HOME/.proma` references.

* **Documentation**
  * Updated installation instructions, examples, and troubleshooting guidance.

* **Version**
  * Released v0.1.3.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->