### PR TITLE
feat(pi): inject Nowledge Mem context at startup

### DIFF
--- a/integrations.json
+++ b/integrations.json
@@ -735,14 +735,14 @@
       "name": "Pi",
       "category": "coding",
       "type": "plugin",
-      "version": "0.8.1",
+      "version": "0.8.2",
       "directory": "nowledge-mem-pi-package",
       "transport": "plugin+cli",
       "capabilities": {
         "workingMemory": true,
         "search": true,
         "distill": true,
-        "autoRecall": false,
+        "autoRecall": true,
         "autoCapture": true,
         "graphExploration": false,
         "status": true
@@ -750,17 +750,17 @@
       "threadSave": {
         "method": "plugin-capture",
         "historicalCommand": "nmem t sync --from pi",
-        "note": "The Pi extension syncs completed session branches as Mem threads; nmem t sync --from pi can backfill older Pi session files; nowledge-mem-pi-sync remains an older-CLI fallback; save-thread remains available for curated handoff summaries."
+        "note": "The Pi extension injects startup Context Bundle or Working Memory, syncs completed session branches as Mem threads, and nmem t sync --from pi can backfill older Pi session files. nowledge-mem-pi-sync remains an older-CLI fallback; save-thread remains available for curated handoff summaries."
       },
       "autonomy": {
         "bootstrap": "guided",
-        "recall": "guided",
+        "recall": "startup-context-injection",
         "distill": "guided",
         "threads": "automatic-capture",
         "bestResultRequires": [
           "Install the Pi package",
           "Keep nmem available on this machine",
-          "Restart Pi after install or update so the extension is loaded",
+          "Restart Pi after install or update so the extension loads startup Context Bundle injection and thread sync",
           "Run nmem t sync --from pi --apply only when you want to import older Pi sessions",
           "Use save-thread only when you want an extra curated handoff summary"
         ]
@@ -777,7 +777,7 @@
       },
       "toolNaming": {
         "convention": "cli-direct",
-        "note": "Skills teach agent to invoke nmem CLI directly; the extension handles automatic thread capture."
+        "note": "The extension injects startup Context Bundle or Working Memory and handles automatic thread capture. Skills teach Pi when to search, save, and inspect prior threads through nmem."
       },
       "skills": ["read-working-memory", "search-memory", "distill-memory", "save-thread", "status"],
       "slashCommands": []

--- a/nowledge-mem-pi-package/CHANGELOG.md
+++ b/nowledge-mem-pi-package/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes to the Nowledge Mem Pi package will be documented in this fi
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.8.2] - 2026-06-30
+
+### Added
+
+- Inject Context Bundle at Pi session startup through the native `before_agent_start` hook, with Working Memory fallback for older or unavailable clients.
+- Refresh startup context after Pi compaction so long sessions keep the latest AI Context without re-reading on every turn.
+
+### Changed
+
+- Keep the startup guidance compact and aligned with the shared Nowledge Mem guidance instead of duplicating full skill instructions inside the extension.
+- Restrict the legacy `~/ai-now/memory.md` fallback to default local mode so explicit spaces, AI Identities, and remote servers do not receive stale Default-space context.
+
 ## [0.8.1] - 2026-06-10
 
 ### Fixed

--- a/nowledge-mem-pi-package/README.md
+++ b/nowledge-mem-pi-package/README.md
@@ -7,7 +7,8 @@ Cross-tool memory for Pi. Your decisions, preferences, and procedures persist ac
 Pi gains a native extension plus five skills:
 
 - Completed Pi conversations sync into Nowledge Mem as searchable threads
-- Context Bundle / Working Memory, search, and distillation stay available through skills
+- Context Bundle or Working Memory is injected at Pi startup when available
+- Search, thread lookup, and distillation stay available through skills and the `nmem` CLI
 - Remote Mem works through `~/.nowledge-mem/config.json` or `NMEM_API_URL` / `NMEM_API_KEY`
 
 | Skill | What it does |
@@ -70,6 +71,8 @@ Then have a short Pi exchange and check recent threads:
 ```bash
 nmem t list --source pi -n 5
 ```
+
+To confirm startup context injection, start a new Pi session and ask what Nowledge Mem context was provided. Pi should reference the injected Context Bundle or Working Memory without needing to run the `read-working-memory` skill again.
 
 ## Import Older Pi Sessions
 

--- a/nowledge-mem-pi-package/extensions/nowledge-mem.ts
+++ b/nowledge-mem-pi-package/extensions/nowledge-mem.ts
@@ -5,7 +5,7 @@ import { basename, win32 as pathWin32 } from "node:path";
 import type { ExtensionAPI, ExtensionContext } from "@earendil-works/pi-coding-agent";
 
 const SOURCE_APP = "pi";
-const PLUGIN_VERSION = "0.8.1";
+const PLUGIN_VERSION = "0.8.2";
 const DEFAULT_API_URL = "http://127.0.0.1:14242";
 const CONFIG_PATH = `${homedir()}/.nowledge-mem/config.json`;
 const LOCAL_WORKING_MEMORY_PATH = `${homedir()}/ai-now/memory.md`;
@@ -13,20 +13,16 @@ const MAX_MESSAGE_CHARS = 20_000;
 const FLUSH_DELAY_MS = 750;
 const API_TIMEOUT_MS = 8_000;
 
-const BEHAVIORAL_GUIDANCE = `## Nowledge Mem
+const STARTUP_GUIDANCE = `## Nowledge Mem Guidance
 
-You have access to the user's cross-tool knowledge through the \`nmem\` CLI. Use it proactively when it helps.
+Nowledge Mem is available through the installed Pi skills and the \`nmem\` CLI. Use it when past context would make the work better.
 
-- Context Bundle and Working Memory may already be injected above. Do not re-read them unless the user asks or session context changes materially.
-- Search when the task connects to prior work, a past decision, or a recurring workflow: \`nmem --json m search "query"\`.
-- Don't search speculatively for every message. Search when past context would improve the response.
-- Use thread search for prior conversations: \`nmem --json t search "query" --limit 5\`.
-- Save durable decisions, preferences, plans, procedures, learnings, or important context. Do not wait to be asked.
-- Search first. If a related memory exists, update it with \`nmem --json m update <id> -c "updated content"\`.
-- If the insight is genuinely new, save it with \`nmem --json m add "content" -t "Title" --unit-type decision -i 0.8\`.
-- One strong memory is better than three weak ones.
-- When the user asks for a checkpoint or handoff, create a curated summary with \`nmem --json t create\`.
-- When this runtime has an ambient lane (profile- or provider-owned space), include \`--space "<space>"\` on agent-initiated \`m\`, \`t\`, \`wm\`, and \`context\` CLI commands so reads and writes land in the correct lane.
+- Context Bundle or Working Memory may already be injected above. Do not read it again unless the user asks or the session context changes.
+- Search memory when the task resumes prior work, mentions an earlier decision, or would benefit from the user's established preferences and procedures.
+- Search threads when the user asks about a previous conversation or when a memory points back to source conversation history.
+- Save or update durable decisions, preferences, plans, procedures, learnings, events, or important context. Search first; keep one strong memory rather than several weak duplicates.
+- Create an explicit handoff thread only when the user asks for a checkpoint. The Pi extension already syncs completed Pi conversation history automatically.
+- Keep provenance as \`source_app=pi\`. Use \`NMEM_AGENT_ID\` only when this Pi process is intentionally running as a named Nowledge AI Identity.
 `;
 
 type JsonObject = Record<string, unknown>;
@@ -66,7 +62,7 @@ type StartupContextEntry = {
 const syncStates = new Map<string, SyncState>();
 const startupContextCache = new Map<string, StartupContextEntry>();
 const startupContextWarnings = new Set<string>();
-const WINDOWS_CMD_ENV_EXPANSION_RE = /%[A-Za-z_][A-Za-z0-9_]*%/
+const WINDOWS_CMD_ENV_EXPANSION_RE = /%[A-Za-z_][A-Za-z0-9_]*%/;
 
 function readSharedConfig(): JsonObject {
 	try {
@@ -587,8 +583,8 @@ function spawnNmem(args: string[], timeoutMs = API_TIMEOUT_MS): Promise<NmemResu
 				const line = windowsCommandLine(["nmem.cmd", ...baseArgs]);
 				execFile(
 					windowsComspec(),
-					[`/d /s /c "${line}"`],
-					{ timeout: timeoutMs, windowsHide: true, windowsVerbatimArguments: true, encoding: "utf8" },
+					["/d", "/s", "/c", line],
+					{ timeout: timeoutMs, windowsHide: true, encoding: "utf8" },
 					handle,
 				);
 			} catch (error) {
@@ -614,7 +610,9 @@ function parseNmemObject(output: string): JsonObject | undefined {
 
 function parseContextBundleMarkdown(output: string): string | undefined {
 	const parsed = parseNmemObject(output);
-	return parsed ? stringValue(parsed.rendered_markdown) || stringValue(parsed.content) : undefined;
+	return parsed
+		? stringValue(parsed.rendered_markdown) || stringValue(parsed.markdown) || stringValue(parsed.content)
+		: undefined;
 }
 
 function parseWorkingMemoryMarkdown(output: string): string | undefined {
@@ -631,6 +629,11 @@ function readLocalWorkingMemory(): string | undefined {
 		warnStartupContextFailure("local-file", error instanceof Error ? error.message : String(error));
 		return undefined;
 	}
+}
+
+function shouldUseLocalWorkingMemoryFallback(config: ReturnType<typeof resolveConfig>): boolean {
+	if (config.space || config.agentId || config.hostAgentId) return false;
+	return config.apiUrl === DEFAULT_API_URL;
 }
 
 async function readStartupContext(): Promise<StartupContextEntry> {
@@ -663,9 +666,11 @@ async function readStartupContext(): Promise<StartupContextEntry> {
 		}
 	}
 
-	const local = readLocalWorkingMemory();
-	if (local) return { context: local };
-	warnStartupContextFailure("fallback", "no Context Bundle, Working Memory, or local memory file available; using guidance only");
+	if (shouldUseLocalWorkingMemoryFallback(config)) {
+		const local = readLocalWorkingMemory();
+		if (local) return { context: local };
+	}
+	warnStartupContextFailure("fallback", "no Context Bundle or Working Memory available; using guidance only");
 	if (timedOut) return { degradedReason: "startup context reads timed out" };
 	if (sawReadFailure) return { degradedReason: "startup context reads failed" };
 	return {};
@@ -698,14 +703,14 @@ async function appendMemoryContext(systemPrompt: string, ctx: ExtensionContext):
 	if (key && !startupContextCache.has(key)) {
 		await refreshStartupContext(ctx);
 	}
-	const entry = key ? startupContextCache.get(key) : undefined;
+	const entry = key ? startupContextCache.get(key) : await readStartupContext();
 	const sections: string[] = [];
 	if (entry?.context) {
 		sections.push(`## Nowledge Mem Context Bundle\n\n${entry.context}`);
 	} else if (entry?.degradedReason) {
 		sections.push(`## Nowledge Mem Context Bundle\n\n[Nowledge Mem startup context unavailable: ${entry.degradedReason}.]`);
 	}
-	sections.push(BEHAVIORAL_GUIDANCE);
+	sections.push(STARTUP_GUIDANCE);
 	return `${systemPrompt}\n\n${sections.join("\n\n")}`;
 }
 

--- a/nowledge-mem-pi-package/extensions/nowledge-mem.ts
+++ b/nowledge-mem-pi-package/extensions/nowledge-mem.ts
@@ -621,10 +621,17 @@ function parseWorkingMemoryMarkdown(output: string): string | undefined {
 	return stringValue(parsed.content);
 }
 
+function truncateStartupContext(text: string, stage: string): string {
+	if (text.length <= MAX_MESSAGE_CHARS) return text;
+	warnStartupContextFailure(stage, `context truncated to ${MAX_MESSAGE_CHARS} characters`);
+	return `${text.slice(0, MAX_MESSAGE_CHARS)}\n\n[Nowledge Mem startup context truncated by Pi plugin]`;
+}
+
 function readLocalWorkingMemory(): string | undefined {
 	try {
 		if (!existsSync(LOCAL_WORKING_MEMORY_PATH)) return undefined;
-		return readFileSync(LOCAL_WORKING_MEMORY_PATH, "utf8").trim() || undefined;
+		const content = readFileSync(LOCAL_WORKING_MEMORY_PATH, "utf8").trim();
+		return content ? truncateStartupContext(content, "local-file") : undefined;
 	} catch (error) {
 		warnStartupContextFailure("local-file", error instanceof Error ? error.message : String(error));
 		return undefined;
@@ -658,7 +665,8 @@ async function readStartupContext(): Promise<StartupContextEntry> {
 		const result = await spawnNmem(attempt.args, remainingStartupContextTimeout(deadline));
 		if (result.ok) {
 			const parsed = attempt.parse(result.stdout);
-			if (parsed) return { context: parsed };
+			if (parsed) return { context: truncateStartupContext(parsed, attempt.stage) };
+			sawReadFailure = true;
 			warnStartupContextFailure(attempt.stage, "empty or invalid output");
 		} else {
 			sawReadFailure = true;
@@ -682,7 +690,8 @@ function startupContextCacheKey(ctx: ExtensionContext): string | undefined {
 		getSessionFile?: () => string | undefined;
 	};
 	const id = manager.getSessionId?.();
-	if (id) return id;
+	const normalizedId = id?.trim();
+	if (normalizedId && normalizedId.toLowerCase() !== "unknown") return normalizedId;
 	const file = manager.getSessionFile?.();
 	return file ? basename(file).replace(/\.jsonl$/i, "") : undefined;
 }

--- a/nowledge-mem-pi-package/extensions/nowledge-mem.ts
+++ b/nowledge-mem-pi-package/extensions/nowledge-mem.ts
@@ -1,17 +1,39 @@
+import { execFile } from "node:child_process";
 import { existsSync, readFileSync } from "node:fs";
 import { homedir } from "node:os";
-import { basename } from "node:path";
+import { basename, win32 as pathWin32 } from "node:path";
 import type { ExtensionAPI, ExtensionContext } from "@earendil-works/pi-coding-agent";
 
 const SOURCE_APP = "pi";
 const PLUGIN_VERSION = "0.8.1";
 const DEFAULT_API_URL = "http://127.0.0.1:14242";
 const CONFIG_PATH = `${homedir()}/.nowledge-mem/config.json`;
+const LOCAL_WORKING_MEMORY_PATH = `${homedir()}/ai-now/memory.md`;
 const MAX_MESSAGE_CHARS = 20_000;
 const FLUSH_DELAY_MS = 750;
 const API_TIMEOUT_MS = 8_000;
 
+const BEHAVIORAL_GUIDANCE = `## Nowledge Mem
+
+You have access to the user's cross-tool knowledge through the \`nmem\` CLI. Use it proactively when it helps.
+
+- Context Bundle and Working Memory may already be injected above. Do not re-read them unless the user asks or session context changes materially.
+- Search when the task connects to prior work, a past decision, or a recurring workflow: \`nmem --json m search "query"\`.
+- Don't search speculatively for every message. Search when past context would improve the response.
+- Use thread search for prior conversations: \`nmem --json t search "query" --limit 5\`.
+- Save durable decisions, preferences, plans, procedures, learnings, or important context. Do not wait to be asked.
+- Search first. If a related memory exists, update it with \`nmem --json m update <id> -c "updated content"\`.
+- If the insight is genuinely new, save it with \`nmem --json m add "content" -t "Title" --unit-type decision -i 0.8\`.
+- One strong memory is better than three weak ones.
+- When the user asks for a checkpoint or handoff, create a curated summary with \`nmem --json t create\`.
+- When this runtime has an ambient lane (profile- or provider-owned space), include \`--space "<space>"\` on agent-initiated \`m\`, \`t\`, \`wm\`, and \`context\` CLI commands so reads and writes land in the correct lane.
+`;
+
 type JsonObject = Record<string, unknown>;
+
+type NmemResult =
+	| { ok: true; stdout: string }
+	| { ok: false; error: string };
 
 interface ThreadMessage {
 	role: "user" | "assistant" | "system";
@@ -36,7 +58,15 @@ interface SyncPayload {
 	body: JsonObject;
 }
 
+type StartupContextEntry = {
+	context?: string;
+	degradedReason?: string;
+};
+
 const syncStates = new Map<string, SyncState>();
+const startupContextCache = new Map<string, StartupContextEntry>();
+const startupContextWarnings = new Set<string>();
+const WINDOWS_CMD_ENV_EXPANSION_RE = /%[A-Za-z_][A-Za-z0-9_]*%/
 
 function readSharedConfig(): JsonObject {
 	try {
@@ -83,6 +113,36 @@ function resolveConfig() {
 		agentId: readConfigValue(config, "NMEM_AGENT_ID", "agentId", "agent_id"),
 		hostAgentId: readConfigValue(config, "NMEM_HOST_AGENT_ID", "hostAgentId", "host_agent_id"),
 	};
+}
+
+function withAmbientNmemArgs(args: string[], config = resolveConfig()): string[] {
+	let next = [...args];
+	if (config.space && !next.includes("--space")) {
+		const scopedCommands = new Set(["context", "ctx", "wm", "m", "memories", "t", "threads"]);
+		if (scopedCommands.has(next[0] || "")) {
+			next = [...next, "--space", config.space];
+		}
+	}
+	if (next[0] !== "context" && next[0] !== "ctx") return next;
+	if (config.agentId && !next.includes("--agent-id")) {
+		next = [...next, "--agent-id", config.agentId];
+	}
+	if (config.hostAgentId && !next.includes("--host-agent-id")) {
+		next = [...next, "--host-agent-id", config.hostAgentId];
+	}
+	return next;
+}
+
+function contextArgs(config = resolveConfig()): string[] {
+	return withAmbientNmemArgs(["context", "--source-app", SOURCE_APP], config);
+}
+
+function workingMemoryArgs(config = resolveConfig()): string[] {
+	return withAmbientNmemArgs(["wm", "read"], config);
+}
+
+function withoutAmbientSpace(config: ReturnType<typeof resolveConfig>): ReturnType<typeof resolveConfig> {
+	return { ...config, space: undefined };
 }
 
 function withSpace(body: JsonObject, space: string | undefined): JsonObject {
@@ -437,7 +497,227 @@ function scheduleFlush(ctx: ExtensionContext, reason: string): void {
 	}, FLUSH_DELAY_MS);
 }
 
+function warnStartupContextFailure(stage: string, detail: string): void {
+	const key = `${stage}:${detail}`;
+	if (startupContextWarnings.has(key)) return;
+	startupContextWarnings.add(key);
+	console.warn(`[nowledge-mem] startup context ${stage}: ${detail}`);
+}
+
+function quoteWindowsBatchArg(arg: string): string {
+	if (arg === "") return '""';
+	const out: string[] = ['"'];
+	let i = 0;
+	const n = arg.length;
+	while (i < n) {
+		let backslashes = 0;
+		while (i < n && arg[i] === "\\") {
+			i += 1;
+			backslashes += 1;
+		}
+		if (i === n) {
+			out.push("\\".repeat(backslashes * 2));
+			break;
+		}
+		if (arg[i] === '"') {
+			out.push("\\".repeat(backslashes * 2));
+			out.push('""');
+			i += 1;
+		} else {
+			out.push("\\".repeat(backslashes));
+			out.push(arg[i]);
+			i += 1;
+		}
+	}
+	out.push('"');
+	return out.join("");
+}
+
+function rejectWindowsCmdEnvExpansion(args: string[]): void {
+	for (let index = 1; index < args.length; index += 1) {
+		if (WINDOWS_CMD_ENV_EXPANSION_RE.test(args[index])) {
+			throw new Error(
+				"nmem Windows .cmd shim cannot safely receive %VAR%-style arguments; remove or escape the environment-variable token before retrying.",
+			);
+		}
+	}
+}
+
+function windowsComspec(): string {
+	const systemRoot = process.env.SystemRoot || "C:\\Windows";
+	const root = pathWin32.isAbsolute(systemRoot) ? systemRoot : "C:\\Windows";
+	const expected = pathWin32.join(root, "System32", "cmd.exe");
+	const comspec = process.env.ComSpec || "";
+	const samePath = (left: string, right: string) =>
+		pathWin32.normalize(left).toLowerCase() === pathWin32.normalize(right).toLowerCase();
+	if (
+		comspec &&
+		pathWin32.isAbsolute(comspec) &&
+		pathWin32.basename(comspec).toLowerCase() === "cmd.exe" &&
+		samePath(comspec, expected) &&
+		existsSync(comspec)
+	) {
+		return comspec;
+	}
+	return existsSync(expected) ? expected : "C:\\Windows\\System32\\cmd.exe";
+}
+
+function windowsCommandLine(args: string[]): string {
+	rejectWindowsCmdEnvExpansion(args);
+	return args.map(quoteWindowsBatchArg).join(" ");
+}
+
+function remainingStartupContextTimeout(deadline: number): number {
+	return Math.max(1, deadline - Date.now());
+}
+
+function spawnNmem(args: string[], timeoutMs = API_TIMEOUT_MS): Promise<NmemResult> {
+	const baseArgs = ["--json", ...args];
+	return new Promise((resolve) => {
+		const handle = (error: Error | null, stdout: string, stderr: string) => {
+			const stderrText = stderr.trim();
+			if (error) {
+				resolve({ ok: false, error: stderrText || error.message });
+				return;
+			}
+			resolve({ ok: true, stdout: stdout.trim() });
+		};
+		if (process.platform === "win32") {
+			try {
+				const line = windowsCommandLine(["nmem.cmd", ...baseArgs]);
+				execFile(
+					windowsComspec(),
+					[`/d /s /c "${line}"`],
+					{ timeout: timeoutMs, windowsHide: true, windowsVerbatimArguments: true, encoding: "utf8" },
+					handle,
+				);
+			} catch (error) {
+				resolve({ ok: false, error: error instanceof Error ? error.message : String(error) });
+			}
+		} else {
+			execFile("nmem", baseArgs, { timeout: timeoutMs, encoding: "utf8" }, handle);
+		}
+	});
+}
+
+function parseNmemObject(output: string): JsonObject | undefined {
+	try {
+		const parsed = JSON.parse(output) as JsonObject;
+		if (!parsed || typeof parsed !== "object" || Array.isArray(parsed) || "error" in parsed) {
+			return undefined;
+		}
+		return parsed;
+	} catch {
+		return undefined;
+	}
+}
+
+function parseContextBundleMarkdown(output: string): string | undefined {
+	const parsed = parseNmemObject(output);
+	return parsed ? stringValue(parsed.rendered_markdown) || stringValue(parsed.content) : undefined;
+}
+
+function parseWorkingMemoryMarkdown(output: string): string | undefined {
+	const parsed = parseNmemObject(output);
+	if (!parsed || parsed.exists === false) return undefined;
+	return stringValue(parsed.content);
+}
+
+function readLocalWorkingMemory(): string | undefined {
+	try {
+		if (!existsSync(LOCAL_WORKING_MEMORY_PATH)) return undefined;
+		return readFileSync(LOCAL_WORKING_MEMORY_PATH, "utf8").trim() || undefined;
+	} catch (error) {
+		warnStartupContextFailure("local-file", error instanceof Error ? error.message : String(error));
+		return undefined;
+	}
+}
+
+async function readStartupContext(): Promise<StartupContextEntry> {
+	const config = resolveConfig();
+	const unscopedConfig = config.space ? withoutAmbientSpace(config) : undefined;
+	const attempts: Array<{ stage: string; args: string[]; parse: (output: string) => string | undefined }> = [
+		{ stage: "context", args: contextArgs(config), parse: parseContextBundleMarkdown },
+		...(unscopedConfig ? [{ stage: "context-default", args: contextArgs(unscopedConfig), parse: parseContextBundleMarkdown }] : []),
+		{ stage: "working-memory", args: workingMemoryArgs(config), parse: parseWorkingMemoryMarkdown },
+		...(unscopedConfig ? [{ stage: "working-memory-default", args: workingMemoryArgs(unscopedConfig), parse: parseWorkingMemoryMarkdown }] : []),
+	];
+	const deadline = Date.now() + API_TIMEOUT_MS;
+	let timedOut = false;
+	let sawReadFailure = false;
+
+	for (const attempt of attempts) {
+		if (Date.now() >= deadline) {
+			timedOut = true;
+			warnStartupContextFailure(attempt.stage, "skipped because earlier reads consumed the startup timeout");
+			continue;
+		}
+		const result = await spawnNmem(attempt.args, remainingStartupContextTimeout(deadline));
+		if (result.ok) {
+			const parsed = attempt.parse(result.stdout);
+			if (parsed) return { context: parsed };
+			warnStartupContextFailure(attempt.stage, "empty or invalid output");
+		} else {
+			sawReadFailure = true;
+			warnStartupContextFailure(attempt.stage, result.error);
+		}
+	}
+
+	const local = readLocalWorkingMemory();
+	if (local) return { context: local };
+	warnStartupContextFailure("fallback", "no Context Bundle, Working Memory, or local memory file available; using guidance only");
+	if (timedOut) return { degradedReason: "startup context reads timed out" };
+	if (sawReadFailure) return { degradedReason: "startup context reads failed" };
+	return {};
+}
+
+function startupContextCacheKey(ctx: ExtensionContext): string | undefined {
+	const manager = ctx.sessionManager as unknown as {
+		getSessionId?: () => string;
+		getSessionFile?: () => string | undefined;
+	};
+	const id = manager.getSessionId?.();
+	if (id) return id;
+	const file = manager.getSessionFile?.();
+	return file ? basename(file).replace(/\.jsonl$/i, "") : undefined;
+}
+
+async function refreshStartupContext(ctx: ExtensionContext): Promise<void> {
+	const key = startupContextCacheKey(ctx);
+	if (!key) return;
+	startupContextCache.set(key, await readStartupContext());
+}
+
+function evictStartupContext(ctx: ExtensionContext): void {
+	const key = startupContextCacheKey(ctx);
+	if (key) startupContextCache.delete(key);
+}
+
+async function appendMemoryContext(systemPrompt: string, ctx: ExtensionContext): Promise<string> {
+	const key = startupContextCacheKey(ctx);
+	if (key && !startupContextCache.has(key)) {
+		await refreshStartupContext(ctx);
+	}
+	const entry = key ? startupContextCache.get(key) : undefined;
+	const sections: string[] = [];
+	if (entry?.context) {
+		sections.push(`## Nowledge Mem Context Bundle\n\n${entry.context}`);
+	} else if (entry?.degradedReason) {
+		sections.push(`## Nowledge Mem Context Bundle\n\n[Nowledge Mem startup context unavailable: ${entry.degradedReason}.]`);
+	}
+	sections.push(BEHAVIORAL_GUIDANCE);
+	return `${systemPrompt}\n\n${sections.join("\n\n")}`;
+}
+
 export default function nowledgeMemPi(pi: ExtensionAPI) {
+	pi.on("session_start", async (_event, ctx) => {
+		await refreshStartupContext(ctx);
+	});
+
+	pi.on("before_agent_start", async (event, ctx) => {
+		return { systemPrompt: await appendMemoryContext(event.systemPrompt, ctx) };
+	});
+
 	pi.on("agent_end", async (_event, ctx) => {
 		scheduleFlush(ctx, "agent_end");
 	});
@@ -446,11 +726,17 @@ export default function nowledgeMemPi(pi: ExtensionAPI) {
 		await flush(ctx, "session_before_compact");
 	});
 
+	pi.on("session_compact", async (_event, ctx) => {
+		await refreshStartupContext(ctx);
+	});
+
 	pi.on("session_before_switch", async (event, ctx) => {
 		await flush(ctx, event.reason === "new" ? "session_new" : "session_resume");
+		evictStartupContext(ctx);
 	});
 
 	pi.on("session_shutdown", async (event, ctx) => {
 		await flush(ctx, `session_shutdown:${event.reason}`);
+		evictStartupContext(ctx);
 	});
 }

--- a/nowledge-mem-pi-package/package.json
+++ b/nowledge-mem-pi-package/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nowledge-mem-pi",
-  "version": "0.8.1",
+  "version": "0.8.2",
   "description": "Cross-tool memory for Pi. Recall past decisions, search knowledge from every AI tool, and save what matters.",
   "keywords": ["pi-package"],
   "author": "Nowledge Labs",

--- a/tests/plugin_e2e/test_key_plugins_e2e.py
+++ b/tests/plugin_e2e/test_key_plugins_e2e.py
@@ -482,6 +482,27 @@ def test_key_plugin_static_contracts_are_declared():
     assert "NMEM_HOST_AGENT_ID" in pi_extension
     assert "custom_message" in pi_extension
     assert "custom" in pi_extension
+    assert 'import { execFile } from "node:child_process";' in pi_extension
+    assert "LOCAL_WORKING_MEMORY_PATH" in pi_extension
+    assert "BEHAVIORAL_GUIDANCE" in pi_extension
+    assert '["context", "--source-app", SOURCE_APP]' in pi_extension
+    assert '["wm", "read"]' in pi_extension
+    assert "rendered_markdown" in pi_extension
+    assert "readFileSync(LOCAL_WORKING_MEMORY_PATH" in pi_extension
+    assert "withAmbientNmemArgs" in pi_extension
+    assert 'pi.on("session_start"' in pi_extension
+    assert 'pi.on("before_agent_start"' in pi_extension
+    assert 'pi.on("session_compact"' in pi_extension
+    assert "await appendMemoryContext(event.systemPrompt, ctx)" in pi_extension
+    assert "startupContextCacheKey" in pi_extension
+    assert "evictStartupContext" in pi_extension
+    assert "degradedReason" in pi_extension
+    assert "quoteWindowsBatchArg" in pi_extension
+    assert "rejectWindowsCmdEnvExpansion" in pi_extension
+    assert '/d /s /c' in pi_extension
+    assert '--space "<space>"' in pi_extension
+    before_agent_start_block = pi_extension.split('pi.on("before_agent_start"', 1)[1].split('pi.on("agent_end"', 1)[0]
+    assert "message:" not in before_agent_start_block
     assert "PI_CODING_AGENT_SESSION_DIR" in pi_history_sync
     assert "--apply" in pi_history_sync
     assert "historical_import: true" in pi_history_sync
@@ -1094,6 +1115,51 @@ def test_pi_live_package_install_and_extension_smoke(tmp_path: Path):
     listing = _run(["pi", "list", "--no-approve"], env=env, timeout=30)
     assert str(PI_PLUGIN) in listing.stdout
 
+    # Fake `nmem` CLI so the runtime smoke exercises startup Context Bundle
+    # injection without depending on the real Nowledge Mem server. The fake
+    # records every argv it receives to a JSONL file and returns a Context
+    # Bundle payload for `context --source-app pi`.
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    record_path = tmp_path / "nmem-calls.jsonl"
+    python = sys.executable
+    fake_script = bin_dir / "nmem_fake.py"
+    fake_script.write_text(
+        dedent(
+            f'''
+            import json
+            import os
+            import sys
+
+            args = sys.argv[1:]
+            record_path = os.environ.get("NMEM_FAKE_RECORD")
+            if record_path:
+                with open(record_path, "a", encoding="utf-8") as handle:
+                    handle.write(json.dumps(args) + "\\n")
+            if "context" in args:
+                payload = {{
+                    "rendered_markdown": "# Pi smoke Context Bundle\\n\\nInjected by fake nmem.",
+                    "content": "# Pi smoke Context Bundle fallback",
+                }}
+            elif "wm" in args:
+                payload = {{"exists": True, "content": "# Working Memory fallback"}}
+            else:
+                payload = {{}}
+            sys.stdout.write(json.dumps(payload))
+            '''
+        ),
+        encoding="utf-8",
+    )
+    (bin_dir / "nmem").write_text(
+        f'#!/bin/sh\nexec "{python}" "$(dirname "$0")/nmem_fake.py" "$@"\n',
+        encoding="utf-8",
+    )
+    (bin_dir / "nmem.cmd").write_text(
+        f'@echo off\r\n"{python}" "%~dp0nmem_fake.py" %*\r\n',
+        encoding="utf-8",
+    )
+    (bin_dir / "nmem").chmod(0o755)
+
     script = dedent(
         """
         import http from "node:http";
@@ -1156,6 +1222,33 @@ def test_pi_live_package_install_and_extension_smoke(tmp_path: Path):
             return manager;
           },
         };
+
+        // Startup context injection: session_start loads the Context Bundle via
+        // the fake nmem, then before_agent_start appends it to the system prompt.
+        await handlers.get("session_start")?.({ type: "session_start" }, ctx);
+        const injection = await handlers.get("before_agent_start")?.(
+          { systemPrompt: "Original pi smoke system prompt." },
+          ctx,
+        );
+        if (!injection || typeof injection !== "object") {
+          throw new Error("before_agent_start returned no value");
+        }
+        if (typeof injection.systemPrompt !== "string") {
+          throw new Error("before_agent_start missing systemPrompt");
+        }
+        if (!injection.systemPrompt.includes("Original pi smoke system prompt.")) {
+          throw new Error("original system prompt not preserved");
+        }
+        if (!injection.systemPrompt.includes("Pi smoke Context Bundle")) {
+          throw new Error("Context Bundle not injected into systemPrompt");
+        }
+        if (!injection.systemPrompt.includes("## Nowledge Mem")) {
+          throw new Error("behavioral guidance not injected");
+        }
+        if ("message" in injection) {
+          throw new Error("before_agent_start returned a message property");
+        }
+
         await handlers.get("agent_end")?.({ type: "agent_end" }, ctx);
         stale = true;
         await new Promise((resolve) => setTimeout(resolve, 1100));
@@ -1192,8 +1285,31 @@ def test_pi_live_package_install_and_extension_smoke(tmp_path: Path):
     )
     smoke_env = env.copy()
     smoke_env["PI_EXTENSION_URL"] = (PI_PLUGIN / "extensions" / "nowledge-mem.ts").resolve().as_uri()
+    smoke_env["PATH"] = str(bin_dir) + os.pathsep + smoke_env.get("PATH", "")
+    smoke_env["NMEM_FAKE_RECORD"] = str(record_path)
     result = _run(["bun", "--eval", script], env=smoke_env, timeout=30)
     assert '"ok":true' in result.stdout.replace(" ", "")
+
+    # The fake nmem recorded every argv it received. Confirm the startup
+    # context read used the Context Bundle command with the ambient flags.
+    recorded = []
+    if record_path.exists():
+        for line in record_path.read_text(encoding="utf-8").splitlines():
+            if line.strip():
+                recorded.append(json.loads(line))
+    context_calls = [c for c in recorded if "context" in c and "--source-app" in c]
+    assert context_calls, f"no context call recorded: {recorded}"
+    context_call = context_calls[0]
+    assert "pi" in context_call, f"context call missing --source-app pi: {context_call}"
+    if smoke_env.get("NMEM_SPACE"):
+        assert "--space" in context_call, f"context call missing --space: {context_call}"
+        assert "pi-smoke-space" in context_call, f"context call missing space value: {context_call}"
+    if smoke_env.get("NMEM_AGENT_ID"):
+        assert "--agent-id" in context_call, f"context call missing --agent-id: {context_call}"
+        assert "PiSmokeAgent" in context_call, f"context call missing agent id value: {context_call}"
+    if smoke_env.get("NMEM_HOST_AGENT_ID"):
+        assert "--host-agent-id" in context_call, f"context call missing --host-agent-id: {context_call}"
+        assert "slock:PiSmokeAgent" in context_call, f"context call missing host agent id value: {context_call}"
 
 
 @pytest.mark.skipif(_skip_live_host("claude"), reason="Claude live E2E not requested")

--- a/tests/plugin_e2e/test_key_plugins_e2e.py
+++ b/tests/plugin_e2e/test_key_plugins_e2e.py
@@ -466,7 +466,7 @@ def test_key_plugin_static_contracts_are_declared():
     pi_pkg = _read_json(PI_PLUGIN / "package.json")
     pi_extension = (PI_PLUGIN / "extensions" / "nowledge-mem.ts").read_text(encoding="utf-8")
     pi_history_sync = (PI_PLUGIN / "scripts" / "sync-history.mjs").read_text(encoding="utf-8")
-    assert pi_pkg["version"] == "0.8.1"
+    assert pi_pkg["version"] == "0.8.2"
     assert "./extensions/nowledge-mem.ts" in pi_pkg["pi"]["extensions"]
     assert "./skills" in pi_pkg["pi"]["skills"]
     assert pi_pkg["bin"]["nowledge-mem-pi-sync"] == "./scripts/sync-history.mjs"
@@ -484,10 +484,11 @@ def test_key_plugin_static_contracts_are_declared():
     assert "custom" in pi_extension
     assert 'import { execFile } from "node:child_process";' in pi_extension
     assert "LOCAL_WORKING_MEMORY_PATH" in pi_extension
-    assert "BEHAVIORAL_GUIDANCE" in pi_extension
+    assert "STARTUP_GUIDANCE" in pi_extension
     assert '["context", "--source-app", SOURCE_APP]' in pi_extension
     assert '["wm", "read"]' in pi_extension
     assert "rendered_markdown" in pi_extension
+    assert "shouldUseLocalWorkingMemoryFallback" in pi_extension
     assert "readFileSync(LOCAL_WORKING_MEMORY_PATH" in pi_extension
     assert "withAmbientNmemArgs" in pi_extension
     assert 'pi.on("session_start"' in pi_extension
@@ -499,8 +500,8 @@ def test_key_plugin_static_contracts_are_declared():
     assert "degradedReason" in pi_extension
     assert "quoteWindowsBatchArg" in pi_extension
     assert "rejectWindowsCmdEnvExpansion" in pi_extension
-    assert '/d /s /c' in pi_extension
-    assert '--space "<space>"' in pi_extension
+    assert '["/d", "/s", "/c", line]' in pi_extension
+    assert "source_app=pi" in pi_extension
     before_agent_start_block = pi_extension.split('pi.on("before_agent_start"', 1)[1].split('pi.on("agent_end"', 1)[0]
     assert "message:" not in before_agent_start_block
     assert "PI_CODING_AGENT_SESSION_DIR" in pi_history_sync
@@ -998,7 +999,9 @@ def test_registry_connect_contract_points_agent_prompts_to_universal_skill():
     assert by_id["openclaw"]["version"] == "0.8.27"
     assert by_id["proma"]["version"] == "0.1.3"
     assert by_id["opencode"]["version"] == "0.3.4"
-    assert by_id["pi"]["version"] == "0.8.1"
+    assert by_id["pi"]["version"] == "0.8.2"
+    assert by_id["pi"]["capabilities"]["autoRecall"] is True
+    assert by_id["pi"]["autonomy"]["recall"] == "startup-context-injection"
     assert by_id["kimi-code"]["version"] == "0.1.0"
     assert by_id["kimi-code"]["directory"] == "nowledge-mem-kimi-code-plugin"
     assert by_id["kimi-code"]["transport"] == "mcp+skills+hook"
@@ -1247,6 +1250,13 @@ def test_pi_live_package_install_and_extension_smoke(tmp_path: Path):
         }
         if ("message" in injection) {
           throw new Error("before_agent_start returned a message property");
+        }
+        const noKeyInjection = await handlers.get("before_agent_start")?.(
+          { systemPrompt: "No key pi smoke system prompt." },
+          { sessionManager: {} },
+        );
+        if (!noKeyInjection?.systemPrompt?.includes("Pi smoke Context Bundle")) {
+          throw new Error("Context Bundle not injected when session key is unavailable");
         }
 
         await handlers.get("agent_end")?.({ type: "agent_end" }, ctx);

--- a/tests/plugin_e2e/test_key_plugins_e2e.py
+++ b/tests/plugin_e2e/test_key_plugins_e2e.py
@@ -489,6 +489,9 @@ def test_key_plugin_static_contracts_are_declared():
     assert '["wm", "read"]' in pi_extension
     assert "rendered_markdown" in pi_extension
     assert "shouldUseLocalWorkingMemoryFallback" in pi_extension
+    assert "truncateStartupContext" in pi_extension
+    assert 'normalizedId.toLowerCase() !== "unknown"' in pi_extension
+    assert "sawReadFailure = true;" in pi_extension
     assert "readFileSync(LOCAL_WORKING_MEMORY_PATH" in pi_extension
     assert "withAmbientNmemArgs" in pi_extension
     assert 'pi.on("session_start"' in pi_extension
@@ -1129,7 +1132,7 @@ def test_pi_live_package_install_and_extension_smoke(tmp_path: Path):
     fake_script = bin_dir / "nmem_fake.py"
     fake_script.write_text(
         dedent(
-            f'''
+            '''
             import json
             import os
             import sys
@@ -1140,14 +1143,14 @@ def test_pi_live_package_install_and_extension_smoke(tmp_path: Path):
                 with open(record_path, "a", encoding="utf-8") as handle:
                     handle.write(json.dumps(args) + "\\n")
             if "context" in args:
-                payload = {{
+                payload = {
                     "rendered_markdown": "# Pi smoke Context Bundle\\n\\nInjected by fake nmem.",
                     "content": "# Pi smoke Context Bundle fallback",
-                }}
+                }
             elif "wm" in args:
-                payload = {{"exists": True, "content": "# Working Memory fallback"}}
+                payload = {"exists": True, "content": "# Working Memory fallback"}
             else:
-                payload = {{}}
+                payload = {}
             sys.stdout.write(json.dumps(payload))
             '''
         ),
@@ -1311,15 +1314,12 @@ def test_pi_live_package_install_and_extension_smoke(tmp_path: Path):
     assert context_calls, f"no context call recorded: {recorded}"
     context_call = context_calls[0]
     assert "pi" in context_call, f"context call missing --source-app pi: {context_call}"
-    if smoke_env.get("NMEM_SPACE"):
-        assert "--space" in context_call, f"context call missing --space: {context_call}"
-        assert "pi-smoke-space" in context_call, f"context call missing space value: {context_call}"
-    if smoke_env.get("NMEM_AGENT_ID"):
-        assert "--agent-id" in context_call, f"context call missing --agent-id: {context_call}"
-        assert "PiSmokeAgent" in context_call, f"context call missing agent id value: {context_call}"
-    if smoke_env.get("NMEM_HOST_AGENT_ID"):
-        assert "--host-agent-id" in context_call, f"context call missing --host-agent-id: {context_call}"
-        assert "slock:PiSmokeAgent" in context_call, f"context call missing host agent id value: {context_call}"
+    assert "--space" in context_call, f"context call missing --space: {context_call}"
+    assert "pi-smoke-space" in context_call, f"context call missing space value: {context_call}"
+    assert "--agent-id" in context_call, f"context call missing --agent-id: {context_call}"
+    assert "PiSmokeAgent" in context_call, f"context call missing agent id value: {context_call}"
+    assert "--host-agent-id" in context_call, f"context call missing --host-agent-id: {context_call}"
+    assert "slock:PiSmokeAgent" in context_call, f"context call missing host agent id value: {context_call}"
 
 
 @pytest.mark.skipif(_skip_live_host("claude"), reason="Claude live E2E not requested")


### PR DESCRIPTION
## Summary

Add deterministic Nowledge Mem startup context injection to the Pi extension.

The extension now reads the Nowledge Mem Context Bundle once per session start, caches it by Pi session, and appends it to `systemPrompt` on each `before_agent_start` turn. This gives Pi agents the current owner/agent/space/rules/Working Memory context without relying on the model to remember to call the `read-working-memory` skill.

## Changes

- Load startup context via `nmem --json context --source-app pi`
- Fall back through:
  1. scoped Context Bundle
  2. default-space Context Bundle
  3. scoped Working Memory
  4. default-space Working Memory
  5. `~/ai-now/memory.md`
  6. guidance-only
- Parse `rendered_markdown` before `content`
- Inject context through `systemPrompt`, not a transcript message
- Re-append on each `before_agent_start` because Pi resets prompt state between turns
- Refresh context after `session_compact`
- Reuse existing config resolution for `NMEM_SPACE`, `NMEM_AGENT_ID`, and `NMEM_HOST_AGENT_ID`
- Reuse the existing `API_TIMEOUT_MS` budget and fail open on read errors
- Avoid caching under the `"unknown"` session-id fallback
- Evict cached startup context on session switch/shutdown
- Keep existing thread sync behavior unchanged

## Hardening

- POSIX `nmem` execution uses array argv, no shell parsing
- Windows `.cmd` invocation uses explicit `cmd.exe /d /s /c` construction with argument quoting and `%VAR%` expansion rejection
- Cache miss in `before_agent_start` lazily populates context for resumed or unusual hook-ordering cases
- Timeout/read failure is distinguishable from genuinely empty memory in the injected prompt

Note: Windows command invocation is best-effort hardened and covered by static/runtime-adjacent checks, but has not been manually tested on Windows hardware.

## Testing

- `uv run --with pytest pytest tests/plugin_e2e/test_key_plugins_e2e.py -q`
- `uv run --with pytest pytest tests/plugin_e2e -q`
- `NMEM_PLUGIN_E2E=1 NMEM_PLUGIN_E2E_HOSTS=pi uv run --with pytest pytest tests/plugin_e2e/test_key_plugins_e2e.py -q -k pi_live_package_install_and_extension_smoke`
- Dogfooded locally in Pi via the working-tree extension; confirmed Context Bundle headings are visible without manually invoking `nmem`.

## Follow-ups

- Consider removing or repurposing the `read-working-memory` Pi skill now that startup context is injected deterministically.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Pi startup now injects an automatic “Context Bundle” (with Working Memory fallback when needed) into the system prompt.
  * Session-aware startup-context caching and refresh improve continuity across session start/compaction.

* **Bug Fixes**
  * Improved Windows-safe command execution and argument handling for `nmem` interactions.
  * Added more resilient startup-context loading with compact guidance and reduced warning duplication when reads fail.
  * Ensures cached startup context is refreshed/evicted appropriately across key session lifecycle moments.

* **Documentation**
  * Updated the Pi package README and changelog to describe the new startup injection verification step.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->