### PR TITLE
fix: add CREATE_NO_WINDOW to subprocess.run on Windows

### DIFF
--- a/integrations.json
+++ b/integrations.json
@@ -787,7 +787,7 @@
       "name": "Hermes Agent",
       "category": "coding",
       "type": "plugin",
-      "version": "0.5.18",
+      "version": "0.5.19",
       "directory": "nowledge-mem-hermes",
       "transport": "cli",
       "capabilities": {

--- a/nowledge-mem-hermes/CHANGELOG.md
+++ b/nowledge-mem-hermes/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [0.5.19] - 2026-07-02
+
+### Fixed
+
+- Windows Hermes runs no longer flash a console window for each `nmem` CLI call when Hermes is launched through `pythonw.exe`. The provider now hides the child console for Windows subprocesses while keeping macOS and Linux behavior unchanged.
+
 ## [0.5.18] - 2026-06-18
 
 ### Changed

--- a/nowledge-mem-hermes/README.md
+++ b/nowledge-mem-hermes/README.md
@@ -208,7 +208,7 @@ bash <(curl -sL https://raw.githubusercontent.com/nowledge-co/community/main/now
 After updating, the script prints the version and endpoint from the files it actually wrote:
 
 ```text
-Installed version: 0.5.18
+Installed version: 0.5.19
 Thread import endpoint: /threads/import
 ```
 

--- a/nowledge-mem-hermes/client.py
+++ b/nowledge-mem-hermes/client.py
@@ -20,6 +20,7 @@ import os
 import re
 import shutil
 import subprocess
+import sys
 from typing import Any, Dict, List, Optional
 from urllib import error as urlerror
 from urllib import parse as urlparse
@@ -175,14 +176,17 @@ def _run_nmem(
     unchanged.
     """
     command: Any = _build_cmd_command(argv) if _is_batch(argv[0]) else argv
-    return subprocess.run(
-        command,
-        capture_output=True,
-        text=True,
-        encoding="utf-8",
-        timeout=timeout,
-        env=env,
-    )
+    # Hide console window when spawned from pythonw.exe (gateway/desktop)
+    popen_kwargs: Dict[str, Any] = {
+        "capture_output": True,
+        "text": True,
+        "encoding": "utf-8",
+        "timeout": timeout,
+        "env": env,
+    }
+    if sys.platform == "win32":
+        popen_kwargs["creationflags"] = 0x08000000  # CREATE_NO_WINDOW
+    return subprocess.run(command, **popen_kwargs)
 
 
 class NowledgeMemClient:

--- a/nowledge-mem-hermes/plugin.yaml
+++ b/nowledge-mem-hermes/plugin.yaml
@@ -1,5 +1,5 @@
 name: nowledge-mem
-version: 0.5.18
+version: 0.5.19
 description: "Cross-tool personal knowledge graph with semantic search, Working Memory, and proactive recall."
 hooks:
   - prefetch

--- a/nowledge-mem-hermes/tests/test_windows_batch_args.py
+++ b/nowledge-mem-hermes/tests/test_windows_batch_args.py
@@ -387,5 +387,54 @@ class BuildCmdCommandStringTests(unittest.TestCase):
         self.assertEqual(command, expected)
 
 
+class RunNmemSubprocessKwargsTests(unittest.TestCase):
+    """OS-independent coverage for subprocess kwargs around the Windows launcher."""
+
+    def test_windows_run_uses_create_no_window(self):
+        original_run = client_module.subprocess.run
+        original_platform = client_module.sys.platform
+        calls = []
+
+        def _fake_run(command, **kwargs):
+            calls.append((command, kwargs))
+            return subprocess.CompletedProcess(command, 0, stdout="{}", stderr="")
+
+        try:
+            client_module.subprocess.run = _fake_run
+            client_module.sys.platform = "win32"
+            result = client_module._run_nmem(["nmem.exe", "--version"], timeout=5)
+        finally:
+            client_module.subprocess.run = original_run
+            client_module.sys.platform = original_platform
+
+        self.assertEqual(result.returncode, 0)
+        self.assertEqual(len(calls), 1)
+        self.assertEqual(calls[0][0], ["nmem.exe", "--version"])
+        self.assertEqual(calls[0][1].get("creationflags"), 0x08000000)
+        self.assertEqual(calls[0][1]["timeout"], 5)
+        self.assertTrue(calls[0][1]["capture_output"])
+
+    def test_posix_run_does_not_pass_windows_creationflags(self):
+        original_run = client_module.subprocess.run
+        original_platform = client_module.sys.platform
+        calls = []
+
+        def _fake_run(command, **kwargs):
+            calls.append((command, kwargs))
+            return subprocess.CompletedProcess(command, 0, stdout="{}", stderr="")
+
+        try:
+            client_module.subprocess.run = _fake_run
+            client_module.sys.platform = "darwin"
+            result = client_module._run_nmem(["nmem", "--version"], timeout=5)
+        finally:
+            client_module.subprocess.run = original_run
+            client_module.sys.platform = original_platform
+
+        self.assertEqual(result.returncode, 0)
+        self.assertEqual(len(calls), 1)
+        self.assertNotIn("creationflags", calls[0][1])
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Problem

When the Hermes gateway runs under `pythonw.exe` (GUI subsystem, no console), every `subprocess.run()` call in `nowledge-mem-hermes/client.py` that invokes a console-mode child — e.g. the `nmem.CMD` batch shim — allocates a visible `conhost.exe` window that flashes on the user's screen.

This is particularly noticeable when the gateway processes incoming Telegram/Discord messages: each `nmem_search` / `nmem_save` call spawns a `cmd.exe` window that pops up and persists (depending on the user's terminal configuration).

## Root Cause

`pythonw.exe` is a GUI-subsystem process with no console. When it spawns a console-mode child (like `cmd.exe` running a `.CMD` batch shim), the child must allocate its own console — which appears as a visible window.

## Fix

Add `creationflags=0x08000000` (`CREATE_NO_WINDOW`) to the `subprocess.run()` call in `_run_nmem()` on Windows. No-op on POSIX.

```python
if sys.platform == "win32":
    popen_kwargs["creationflags"] = 0x08000000  # CREATE_NO_WINDOW
```

## Testing

- Verified on Windows 10 with Hermes gateway running as `pythonw.exe`
- `nmem_search` / `nmem_save` calls no longer pop up `cmd.exe` windows
- POSIX behavior unchanged (flag is Windows-only)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved command execution on Windows to avoid opening an extra console window.
  * Made background process handling more consistent across platforms, with the same output capture and timeout behavior preserved.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->