### PR TITLE
[codex] fix Codex Stop hook JSON output

### DIFF
--- a/nowledge-mem-codex-plugin/CHANGELOG.md
+++ b/nowledge-mem-codex-plugin/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Fixed
+
+- Codex Stop hook capture now emits a minimal JSON hook response after saving the transcript, preventing current Codex builds from treating successful captures as invalid Stop hook output.
+
 ## [0.1.19] - 2026-06-17
 
 ### Fixed

--- a/nowledge-mem-codex-plugin/hooks/nmem-stop-save.py
+++ b/nowledge-mem-codex-plugin/hooks/nmem-stop-save.py
@@ -30,6 +30,12 @@ JSON_FLAG_UNSUPPORTED_MARKERS = (
     "unknown option --json",
     "unexpected argument '--json'",
 )
+CODEX_HOOK_SUCCESS_RESPONSE = {"continue": True, "suppressOutput": True}
+
+
+def _write_hook_response() -> None:
+    json.dump(CODEX_HOOK_SUCCESS_RESPONSE, sys.stdout)
+    sys.stdout.write("\n")
 
 
 def _read_hook_input() -> dict[str, Any]:
@@ -432,4 +438,6 @@ def main() -> int:
 
 
 if __name__ == "__main__":
-    raise SystemExit(main())
+    exit_code = main()
+    _write_hook_response()
+    raise SystemExit(exit_code)

--- a/nowledge-mem-codex-plugin/hooks/nmem-stop-save.py
+++ b/nowledge-mem-codex-plugin/hooks/nmem-stop-save.py
@@ -38,6 +38,17 @@ def _write_hook_response() -> None:
     sys.stdout.write("\n")
 
 
+def _run_entrypoint() -> object:
+    exit_code: object = 0
+    try:
+        exit_code = main()
+    except SystemExit as exc:
+        exit_code = exc.code
+    finally:
+        _write_hook_response()
+    return exit_code
+
+
 def _read_hook_input() -> dict[str, Any]:
     raw = sys.stdin.read()
     if not raw.strip():
@@ -438,6 +449,4 @@ def main() -> int:
 
 
 if __name__ == "__main__":
-    exit_code = main()
-    _write_hook_response()
-    raise SystemExit(exit_code)
+    raise SystemExit(_run_entrypoint())

--- a/nowledge-mem-codex-plugin/scripts/validate-plugin.mjs
+++ b/nowledge-mem-codex-plugin/scripts/validate-plugin.mjs
@@ -165,6 +165,8 @@ const hookRuntime = readTextIfPresent(path.join(pluginRoot, "hooks/nmem-stop-sav
 if (hookRuntime !== null) {
   if (!hookRuntime.includes("def _claim_capture_event")) fail("Stop hook runtime must guard duplicate hook sources");
   else ok("Stop hook duplicate guard");
+  if (!hookRuntime.includes("def _write_hook_response")) fail("Stop hook runtime must emit a Codex JSON response");
+  else ok("Stop hook JSON response");
 }
 
 const hookLauncher = readTextIfPresent(path.join(pluginRoot, "hooks/nmem-stop-launch.py"), "hooks/nmem-stop-launch.py");

--- a/nowledge-mem-codex-plugin/tests/test_codex_plugin.py
+++ b/nowledge-mem-codex-plugin/tests/test_codex_plugin.py
@@ -224,6 +224,18 @@ class HookTests(unittest.TestCase):
             {"continue": True, "suppressOutput": True},
         )
 
+    def test_hook_entrypoint_emits_response_when_main_exits_early(self):
+        stdout = io.StringIO()
+
+        with mock.patch.object(self.module, "main", side_effect=SystemExit(7)), \
+             mock.patch.object(self.module.sys, "stdout", stdout):
+            self.assertEqual(self.module._run_entrypoint(), 7)
+
+        self.assertEqual(
+            json.loads(stdout.getvalue()),
+            {"continue": True, "suppressOutput": True},
+        )
+
 
 class PackagedHookConfigTests(unittest.TestCase):
     def test_packaged_hooks_json_uses_strict_codex_schema(self):

--- a/nowledge-mem-codex-plugin/tests/test_codex_plugin.py
+++ b/nowledge-mem-codex-plugin/tests/test_codex_plugin.py
@@ -293,6 +293,28 @@ class LauncherTests(unittest.TestCase):
 
         self.assertEqual(calls, [(packaged_hook, "__main__", [str(packaged_hook), "--event", "stop"])])
 
+    def test_launcher_entrypoint_emits_valid_stop_hook_json(self):
+        codex_home = self.temp_path / ".codex"
+        env = os.environ.copy()
+        env["CODEX_HOME"] = str(codex_home)
+        env["PATH"] = ""
+
+        proc = subprocess.run(
+            [sys.executable, str(LAUNCH_MODULE_PATH), "--event", "stop"],
+            input="{}",
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+            env=env,
+            check=False,
+        )
+
+        self.assertEqual(proc.returncode, 0, proc.stderr)
+        self.assertEqual(
+            json.loads(proc.stdout),
+            {"continue": True, "suppressOutput": True},
+        )
+
 
 class InstallHookTests(unittest.TestCase):
     def setUp(self):

--- a/nowledge-mem-codex-plugin/tests/test_codex_plugin.py
+++ b/nowledge-mem-codex-plugin/tests/test_codex_plugin.py
@@ -1,5 +1,9 @@
 import importlib.util
+import io
 import json
+import os
+import subprocess
+import sys
 import tempfile
 import unittest
 from pathlib import Path
@@ -186,6 +190,39 @@ class HookTests(unittest.TestCase):
         with mock.patch.object(self.module, "_nmem_command", return_value=None), \
              mock.patch.object(self.module.sys, "stdin", mock.Mock(read=lambda: "{}")):
             self.assertEqual(self.module.main(), 0)
+
+    def test_hook_response_is_valid_stop_hook_json(self):
+        stdout = io.StringIO()
+
+        with mock.patch.object(self.module.sys, "stdout", stdout):
+            self.module._write_hook_response()
+
+        self.assertEqual(
+            json.loads(stdout.getvalue()),
+            {"continue": True, "suppressOutput": True},
+        )
+        self.assertTrue(stdout.getvalue().endswith("\n"))
+
+    def test_hook_entrypoint_emits_valid_stop_hook_json(self):
+        env = os.environ.copy()
+        env["CODEX_HOME"] = str(self.temp_path / ".codex")
+        env["PATH"] = ""
+
+        proc = subprocess.run(
+            [sys.executable, str(HOOK_MODULE_PATH), "--event", "stop"],
+            input="{}",
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+            env=env,
+            check=False,
+        )
+
+        self.assertEqual(proc.returncode, 0, proc.stderr)
+        self.assertEqual(
+            json.loads(proc.stdout),
+            {"continue": True, "suppressOutput": True},
+        )
 
 
 class PackagedHookConfigTests(unittest.TestCase):


### PR DESCRIPTION
## What changed

- Added an explicit Codex Stop hook JSON response after transcript capture completes.
- Added unit coverage for the response helper and the real hook entrypoint.
- Added plugin validation coverage so future changes keep the JSON response path.
- Documented the fix in the changelog.

## Why

Current Codex builds can report successful Stop hook runs as invalid when hook stdout is not valid Stop hook JSON. The transcript capture already writes diagnostics to its log file and does not need to emit user-facing text, so the hook now returns a minimal JSON response:

```json
{"continue":true,"suppressOutput":true}
```

The save behavior is unchanged. The hook still shells out to `nmem t save --from codex`, retries during the transcript flush window, and logs diagnostics to the existing log path.

## Validation

- `python3 -m unittest nowledge-mem-codex-plugin.tests.test_codex_plugin`
- `node nowledge-mem-codex-plugin/scripts/validate-plugin.mjs`
- Manual hook smoke test:

```bash
printf '{"cwd":"/private/tmp/nowledge-community-pr","session_id":"codex-hook-test","transcript_path":"/private/tmp/nowledge-community-pr/.codex/sessions/missing.jsonl"}' \
  | python3 nowledge-mem-codex-plugin/hooks/nmem-stop-save.py --event stop \
  | jq -e 'type == "object" and .continue == true and .suppressOutput == true'
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved stop-hook behavior: after a successful capture/transcript save, the hook now returns a structured JSON “success/continue” payload so Codex doesn’t treat it as invalid output.
* **Tests**
  * Expanded automated coverage for the hook and stop-hook entrypoints, including subprocess-based verification that the emitted JSON is correct.
* **Chores**
  * Updated plugin validation to confirm the required stop-hook response behavior is present.
* **Documentation**
  * Updated the changelog with an Unreleased entry describing the fix.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->