### PR TITLE
fix(windows): hide plugin subprocess consoles

### DIFF
--- a/integrations.json
+++ b/integrations.json
@@ -21,7 +21,7 @@
       "name": "Claude Code",
       "category": "coding",
       "type": "plugin",
-      "version": "0.7.14",
+      "version": "0.7.15",
       "directory": "nowledge-mem-claude-code-plugin",
       "transport": "cli",
       "capabilities": {
@@ -73,7 +73,7 @@
       "name": "Grok Build",
       "category": "coding",
       "type": "plugin",
-      "version": "0.7.14",
+      "version": "0.7.15",
       "directory": "nowledge-mem-claude-code-plugin",
       "transport": "cli",
       "capabilities": {
@@ -126,7 +126,7 @@
       "name": "Copilot CLI",
       "category": "coding",
       "type": "plugin",
-      "version": "0.1.3",
+      "version": "0.1.4",
       "directory": "nowledge-mem-copilot-cli-plugin",
       "transport": "cli",
       "capabilities": {
@@ -229,7 +229,7 @@
       "name": "Codex",
       "category": "coding",
       "type": "plugin",
-      "version": "0.1.21",
+      "version": "0.1.22",
       "directory": "nowledge-mem-codex-plugin",
 
       "legacyDirectory": "nowledge-mem-codex-prompts",
@@ -687,7 +687,7 @@
       "name": "Alma",
       "category": "coding",
       "type": "plugin",
-      "version": "0.7.3",
+      "version": "0.7.4",
       "directory": "nowledge-mem-alma-plugin",
       "transport": "http",
       "capabilities": {
@@ -737,7 +737,7 @@
       "name": "Bub",
       "category": "coding",
       "type": "plugin",
-      "version": "0.7.2",
+      "version": "0.7.3",
       "directory": "nowledge-mem-bub-plugin",
       "transport": "cli",
       "capabilities": {
@@ -946,7 +946,7 @@
       "name": "Kimi Code",
       "category": "coding",
       "type": "plugin",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "directory": "nowledge-mem-kimi-code-plugin",
       "transport": "mcp+skills+hook",
       "capabilities": {
@@ -1208,7 +1208,7 @@
       "name": "Proma",
       "category": "coding",
       "type": "plugin",
-      "version": "0.1.3",
+      "version": "0.1.4",
       "directory": "nowledge-mem-proma-plugin",
       "transport": "mcp",
       "capabilities": {

--- a/nowledge-mem-alma-plugin/CHANGELOG.md
+++ b/nowledge-mem-alma-plugin/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 0.7.4
+
+### Fixed
+
+- Windows CLI preflight now hides the child console window while resolving `nmem`, avoiding visible console flashes from GUI-launched Alma sessions.
+
 ## 0.7.3
 
 ### Added

--- a/nowledge-mem-alma-plugin/CLAUDE.md
+++ b/nowledge-mem-alma-plugin/CLAUDE.md
@@ -9,7 +9,7 @@ This file is a practical continuation guide for future agent sessions working on
 - Runtime: plain ESM (`main.js`), no build step
 - Memory backend: direct HTTP to Nowledge Mem API (default `http://127.0.0.1:14242`). CLI (`nmem`) is only used for diagnostic in the status tool.
 
-## Current Status (as of v0.7.3)
+## Current Status (as of v0.7.4)
 
 - Plugin is installed/activated and registers 13 tools successfully in Alma logs.
 - Live thread sync works via three hooks: `willSend` (user msg + recall), `didReceive` (AI response + idle timer), `thread.activated` (flush on switch).

--- a/nowledge-mem-alma-plugin/main.js
+++ b/nowledge-mem-alma-plugin/main.js
@@ -213,6 +213,7 @@ export class NowledgeMemClient {
 			const result = spawnSync(candidate.cmd, [...candidate.prefix, "--version"], {
 				encoding: "utf-8",
 				timeout: 10_000,
+				windowsHide: true,
 			});
 			if (result.status === 0) {
 				this.command = candidate;

--- a/nowledge-mem-alma-plugin/manifest.json
+++ b/nowledge-mem-alma-plugin/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "nowledge-mem",
   "name": "Nowledge Mem",
-  "version": "0.7.3",
+  "version": "0.7.4",
   "description": "Local-first personal memory for Alma, powered by Nowledge Mem",
   "author": {
     "name": "Nowledge Labs",

--- a/nowledge-mem-alma-plugin/package.json
+++ b/nowledge-mem-alma-plugin/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@nowledge/alma-nowledge-mem",
-	"version": "0.7.3",
+	"version": "0.7.4",
 	"type": "module",
 	"description": "Nowledge Mem plugin for Alma, local-first personal knowledge base",
 	"author": {

--- a/nowledge-mem-bub-plugin/CHANGELOG.md
+++ b/nowledge-mem-bub-plugin/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.7.3 (2026-07-02)
+
+- Fixed: Windows CLI calls now hide the child console window when Bub invokes `nmem`, avoiding visible `cmd.exe` flashes during memory operations.
+
 ## 0.7.2 (2026-06-07)
 
 - Fixed: `mem.save` no longer defaults an omitted memory type to `fact`. When the agent is unsure, Nowledge Mem now classifies the memory type itself.

--- a/nowledge-mem-bub-plugin/pyproject.toml
+++ b/nowledge-mem-bub-plugin/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "nowledge-mem-bub"
-version = "0.7.2"
+version = "0.7.3"
 description = "Nowledge Mem plugin for Bub — cross-ai context for your agent."
 readme = "README.md"
 license = "Apache-2.0"

--- a/nowledge-mem-bub-plugin/src/nowledge_mem_bub/client.py
+++ b/nowledge-mem-bub-plugin/src/nowledge_mem_bub/client.py
@@ -12,9 +12,17 @@ import json
 import logging
 import os
 import shutil
+import subprocess
+import sys
 from pathlib import Path
 
 logger = logging.getLogger(__name__)
+
+
+def _windows_no_window_kwargs() -> dict[str, int]:
+    if sys.platform != "win32":
+        return {}
+    return {"creationflags": getattr(subprocess, "CREATE_NO_WINDOW", 0x08000000)}
 
 
 class NmemError(Exception):
@@ -106,6 +114,7 @@ class NmemClient:
                 stdout=asyncio.subprocess.PIPE,
                 stderr=asyncio.subprocess.PIPE,
                 env=self._build_env(),
+                **_windows_no_window_kwargs(),
             )
             stdout, stderr = await asyncio.wait_for(proc.communicate(), timeout=timeout)
         except asyncio.TimeoutError:

--- a/nowledge-mem-claude-code-plugin/.claude-plugin/plugin.json
+++ b/nowledge-mem-claude-code-plugin/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "nowledge-mem",
   "description": "Personal knowledge graph for Claude Code and Grok \u2014 remembers decisions, searches past work, captures sessions",
-  "version": "0.7.14",
+  "version": "0.7.15",
   "author": {
     "name": "Nowledge Labs",
     "email": "hello@nowledge-labs.ai",

--- a/nowledge-mem-claude-code-plugin/CHANGELOG.md
+++ b/nowledge-mem-claude-code-plugin/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to the Nowledge Mem Claude Code plugin will be documented in
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.7.15] - 2026-07-02
+
+### Fixed
+
+- Windows lifecycle hooks now hide the child console window when running `nmem`, so Claude Code and Grok Build session capture no longer flashes a `cmd.exe` window during Stop or PreCompact.
+
 ## [0.7.14] - 2026-07-01
 
 ### Fixed

--- a/nowledge-mem-claude-code-plugin/scripts/nmem-hook-save.py
+++ b/nowledge-mem-claude-code-plugin/scripts/nmem-hook-save.py
@@ -36,6 +36,12 @@ JSON_FLAG_UNSUPPORTED_MARKERS = (
 )
 
 
+def _windows_no_window_kwargs() -> dict[str, int]:
+    if sys.platform != "win32":
+        return {}
+    return {"creationflags": getattr(subprocess, "CREATE_NO_WINDOW", 0x08000000)}
+
+
 def _read_hook_input() -> dict[str, Any]:
     raw = sys.stdin.read()
     if not raw.strip():
@@ -216,6 +222,7 @@ def _run_command(command: list[str], timeout: float) -> subprocess.CompletedProc
         stderr=subprocess.PIPE,
         text=True,
         timeout=timeout,
+        **_windows_no_window_kwargs(),
     )
 
 

--- a/nowledge-mem-claude-code-plugin/tests/test_nmem_hook_save.py
+++ b/nowledge-mem-claude-code-plugin/tests/test_nmem_hook_save.py
@@ -208,6 +208,26 @@ def test_run_capture_retries_until_nmem_reports_saved_result():
     assert run.call_count == 2
 
 
+def test_run_command_hides_child_console_on_windows():
+    proc = CompletedProcess(["nmem"], 0, stdout='{"results":[]}', stderr="")
+
+    with patch.object(nmem_hook_save.sys, "platform", "win32"), \
+        patch.object(nmem_hook_save.subprocess, "run", return_value=proc) as run:
+        nmem_hook_save._run_command(["nmem.cmd", "--version"], 5)
+
+    assert run.call_args.kwargs["creationflags"] == 0x08000000
+
+
+def test_run_command_does_not_pass_windows_creationflags_on_posix():
+    proc = CompletedProcess(["nmem"], 0, stdout='{"results":[]}', stderr="")
+
+    with patch.object(nmem_hook_save.sys, "platform", "darwin"), \
+        patch.object(nmem_hook_save.subprocess, "run", return_value=proc) as run:
+        nmem_hook_save._run_command(["nmem", "--version"], 5)
+
+    assert "creationflags" not in run.call_args.kwargs
+
+
 def test_run_capture_reports_uncaptured_when_transcript_never_flushes():
     proc = CompletedProcess(["nmem"], 0, stdout='{"results":[]}', stderr="")
 

--- a/nowledge-mem-codex-plugin/.codex-plugin/plugin.json
+++ b/nowledge-mem-codex-plugin/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "nowledge-mem",
-  "version": "0.1.21",
+  "version": "0.1.22",
   "description": "Your Codex agent remembers past decisions, finds relevant context, and learns from every session, across all your AI tools.",
   "skills": "./skills/",
   "mcpServers": "./.mcp.json",

--- a/nowledge-mem-codex-plugin/CHANGELOG.md
+++ b/nowledge-mem-codex-plugin/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [0.1.22] - 2026-07-02
+
+### Fixed
+
+- Windows Stop hook capture now hides the child console window when running `nmem`, avoiding visible `cmd.exe` flashes while Codex saves the session.
+
 ## [0.1.21] - 2026-07-02
 
 ### Fixed

--- a/nowledge-mem-codex-plugin/hooks/nmem-stop-save.py
+++ b/nowledge-mem-codex-plugin/hooks/nmem-stop-save.py
@@ -33,6 +33,12 @@ JSON_FLAG_UNSUPPORTED_MARKERS = (
 CODEX_HOOK_SUCCESS_RESPONSE = {"continue": True, "suppressOutput": True}
 
 
+def _windows_no_window_kwargs() -> dict[str, int]:
+    if sys.platform != "win32":
+        return {}
+    return {"creationflags": getattr(subprocess, "CREATE_NO_WINDOW", 0x08000000)}
+
+
 def _write_hook_response() -> None:
     json.dump(CODEX_HOOK_SUCCESS_RESPONSE, sys.stdout)
     sys.stdout.write("\n")
@@ -316,6 +322,7 @@ def _run_save(
         text=True,
         timeout=ATTEMPT_TIMEOUT_SECONDS,
         check=False,
+        **_windows_no_window_kwargs(),
     )
 
 

--- a/nowledge-mem-codex-plugin/scripts/validate-plugin.mjs
+++ b/nowledge-mem-codex-plugin/scripts/validate-plugin.mjs
@@ -8,7 +8,7 @@ import { fileURLToPath } from "node:url";
 const scriptDir = path.dirname(fileURLToPath(import.meta.url));
 const pluginRoot = path.resolve(scriptDir, "..");
 const repoRoot = path.resolve(pluginRoot, "..");
-const expectedVersion = "0.1.21";
+const expectedVersion = "0.1.22";
 
 const fail = (message) => {
   console.error(`FAIL: ${message}`);

--- a/nowledge-mem-codex-plugin/tests/test_codex_plugin.py
+++ b/nowledge-mem-codex-plugin/tests/test_codex_plugin.py
@@ -132,6 +132,34 @@ class HookTests(unittest.TestCase):
         self.assertEqual(proc.stdout, '{"results":[{"action":"created"}]}')
         self.assertEqual(run.call_count, 2)
 
+    def test_run_save_hides_child_console_on_windows(self):
+        with mock.patch.object(self.module, "_build_save_command", return_value=["nmem.cmd", "--version"]), \
+             mock.patch.object(self.module, "_build_env", return_value={}), \
+             mock.patch.object(self.module.sys, "platform", "win32"), \
+             mock.patch.object(self.module.subprocess, "run") as run:
+            run.return_value = mock.Mock(returncode=0, stdout='{"results":[]}', stderr="")
+            self.module._run_save(
+                "nmem.cmd",
+                {},
+                include_session_id=True,
+            )
+
+        self.assertEqual(run.call_args.kwargs["creationflags"], 0x08000000)
+
+    def test_run_save_does_not_pass_windows_creationflags_on_posix(self):
+        with mock.patch.object(self.module, "_build_save_command", return_value=["nmem", "--version"]), \
+             mock.patch.object(self.module, "_build_env", return_value={}), \
+             mock.patch.object(self.module.sys, "platform", "linux"), \
+             mock.patch.object(self.module.subprocess, "run") as run:
+            run.return_value = mock.Mock(returncode=0, stdout='{"results":[]}', stderr="")
+            self.module._run_save(
+                "nmem",
+                {},
+                include_session_id=True,
+            )
+
+        self.assertNotIn("creationflags", run.call_args.kwargs)
+
     def test_run_save_falls_back_for_legacy_nmem_without_json_support(self):
         calls = [
             mock.Mock(returncode=2, stdout="", stderr="No such option: --json"),

--- a/nowledge-mem-copilot-cli-plugin/.claude-plugin/plugin.json
+++ b/nowledge-mem-copilot-cli-plugin/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "nowledge-mem",
   "description": "Personal knowledge graph for GitHub Copilot CLI — remembers decisions, searches past work, captures sessions",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "author": {
     "name": "Nowledge Labs",
     "email": "hello@nowledge-labs.ai",

--- a/nowledge-mem-copilot-cli-plugin/CHANGELOG.md
+++ b/nowledge-mem-copilot-cli-plugin/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to the Nowledge Mem Copilot CLI plugin will be documented in
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.1.4] - 2026-07-02
+
+### Fixed
+
+- Windows capture hooks now hide the child console window when running `nmem`, so Copilot CLI session saves do not flash `cmd.exe` windows.
+
 ## [0.1.3] - 2026-06-06
 
 ### Improved

--- a/nowledge-mem-copilot-cli-plugin/hooks/copilot-stop-save.py
+++ b/nowledge-mem-copilot-cli-plugin/hooks/copilot-stop-save.py
@@ -94,6 +94,12 @@ PLACEHOLDER_HINTS = (
 )
 
 
+def windows_no_window_kwargs() -> dict[str, int]:
+    if sys.platform != "win32":
+        return {}
+    return {"creationflags": getattr(subprocess, "CREATE_NO_WINDOW", 0x08000000)}
+
+
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
@@ -245,6 +251,7 @@ def run_json(args: list[str]) -> dict:
             capture_output=True,
             text=True,
             timeout=NMEM_TIMEOUT_SECS,
+            **windows_no_window_kwargs(),
         )
     except subprocess.TimeoutExpired as exc:
         def _decode_timeout_output(value: object) -> str:

--- a/nowledge-mem-copilot-cli-plugin/tests/test_copilot_plugin.py
+++ b/nowledge-mem-copilot-cli-plugin/tests/test_copilot_plugin.py
@@ -14,6 +14,7 @@ Tests cover:
 import json
 import io
 import os
+import subprocess
 import sys
 import tempfile
 from pathlib import Path
@@ -593,3 +594,31 @@ class TestBuildNmemCommand:
     def test_windows_cmd(self):
         cmd = copilot_stop_save.build_nmem_command("C:\\nmem.cmd", "--json", "wm", "read")
         assert cmd == ["cmd.exe", "/d", "/c", "call", "C:\\nmem.cmd", "--json", "wm", "read"]
+
+    def test_windows_run_hides_child_console(self, monkeypatch):
+        calls = []
+
+        def fake_run(args, **kwargs):
+            calls.append((args, kwargs))
+            return subprocess.CompletedProcess(args, 0, stdout="{}", stderr="")
+
+        monkeypatch.setattr(copilot_stop_save.sys, "platform", "win32")
+        monkeypatch.setattr(copilot_stop_save.subprocess, "run", fake_run)
+
+        copilot_stop_save.run_json(["nmem.cmd", "--json", "wm", "read"])
+
+        assert calls[0][1]["creationflags"] == 0x08000000
+
+    def test_posix_run_does_not_pass_windows_creationflags(self, monkeypatch):
+        calls = []
+
+        def fake_run(args, **kwargs):
+            calls.append((args, kwargs))
+            return subprocess.CompletedProcess(args, 0, stdout="{}", stderr="")
+
+        monkeypatch.setattr(copilot_stop_save.sys, "platform", "linux")
+        monkeypatch.setattr(copilot_stop_save.subprocess, "run", fake_run)
+
+        copilot_stop_save.run_json(["nmem", "--json", "wm", "read"])
+
+        assert "creationflags" not in calls[0][1]

--- a/nowledge-mem-kimi-code-plugin/CHANGELOG.md
+++ b/nowledge-mem-kimi-code-plugin/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.1.1
+
+- Hide the child console window when Kimi Code lifecycle hooks run `nmem` on Windows.
+
 ## 0.1.0
 
 - Add the first Kimi Code package with Kimi-native plugin metadata, a session-start skill, and a local Nowledge Mem MCP declaration.

--- a/nowledge-mem-kimi-code-plugin/kimi.plugin.json
+++ b/nowledge-mem-kimi-code-plugin/kimi.plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "nowledge-mem",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Cross-tool memory for Kimi Code. Recall past decisions, search prior threads, and keep Kimi Code sessions searchable in Nowledge Mem.",
   "keywords": ["memory", "mcp", "skills", "thread-sync"],
   "author": {

--- a/nowledge-mem-kimi-code-plugin/scripts/kimi-sync-hook.py
+++ b/nowledge-mem-kimi-code-plugin/scripts/kimi-sync-hook.py
@@ -22,6 +22,12 @@ DEFAULT_TIMEOUT_SECONDS = 35
 DEFAULT_RETRIES = 2
 
 
+def _windows_no_window_kwargs() -> dict[str, int]:
+    if sys.platform != "win32":
+        return {}
+    return {"creationflags": getattr(subprocess, "CREATE_NO_WINDOW", 0x08000000)}
+
+
 def _kimi_home() -> Path:
     raw = os.environ.get("KIMI_CODE_HOME")
     if raw and raw.strip():
@@ -81,6 +87,7 @@ def _run_sync(session_id: str) -> subprocess.CompletedProcess[str]:
         capture_output=True,
         timeout=_positive_int_env("NMEM_KIMI_SYNC_TIMEOUT", DEFAULT_TIMEOUT_SECONDS),
         check=False,
+        **_windows_no_window_kwargs(),
     )
 
 

--- a/nowledge-mem-proma-plugin/.claude-plugin/plugin.json
+++ b/nowledge-mem-proma-plugin/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "nowledge-mem",
   "description": "Personal knowledge graph for Proma — saves Proma conversations, writes startup context into CLAUDE.md, and keeps nmem tools available during work",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "author": {
     "name": "Nowledge Labs",
     "email": "hello@nowledge-labs.ai",

--- a/nowledge-mem-proma-plugin/CHANGELOG.md
+++ b/nowledge-mem-proma-plugin/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog — nowledge-mem-proma-plugin
 
+## 0.1.4 (2026-07-02)
+
+- Hide the child console window when the Proma startup/asyncRewake hook reads Nowledge Mem context through `nmem` on Windows.
+
 ## 0.1.3 (2026-06-22)
 
 - Add optional `PROMA_ALLOWED_WORKSPACES` filtering to `save-to-nmem.py` for multi-workspace Proma users. Leaving it unset keeps the previous behavior and syncs every workspace; setting a comma-separated list such as `default,research` skips other workspaces with a log entry.

--- a/nowledge-mem-proma-plugin/hooks/read-working-memory.py
+++ b/nowledge-mem-proma-plugin/hooks/read-working-memory.py
@@ -15,6 +15,7 @@ import json
 import os
 import shutil
 import subprocess
+import sys
 from datetime import datetime
 from pathlib import Path
 from typing import Any
@@ -36,6 +37,12 @@ CLAUDE_MD = _env_path("PROMA_CLAUDE_MD", PROMA_WORKSPACE_DIR / "CLAUDE.md")
 CLAUDE_TEMPLATE = _env_path("PROMA_CLAUDE_TEMPLATE", PROMA_WORKSPACE_DIR / "CLAUDE.md.template")
 LOG_DIR = PROMA_HOME / "logs"
 LOG_FILE = LOG_DIR / "nm-hooks.log"
+
+
+def _windows_no_window_kwargs() -> dict[str, int]:
+    if sys.platform != "win32":
+        return {}
+    return {"creationflags": getattr(subprocess, "CREATE_NO_WINDOW", 0x08000000)}
 
 
 def log(msg: str) -> None:
@@ -85,6 +92,7 @@ def _run_nmem_json(args: list[str], label: str, timeout: int = 15) -> dict[str, 
             text=True,
             timeout=timeout,
             check=False,
+            **_windows_no_window_kwargs(),
         )
         if proc.returncode != 0:
             log(f"{label} exit={proc.returncode} stderr={proc.stderr.strip()[:240]}")

--- a/tests/plugin_e2e/test_key_plugins_e2e.py
+++ b/tests/plugin_e2e/test_key_plugins_e2e.py
@@ -289,10 +289,13 @@ def test_key_plugin_static_contracts_are_declared():
 
     claude_manifest = _read_json(CLAUDE_PLUGIN / ".claude-plugin" / "plugin.json")
     claude_hooks = _read_json(CLAUDE_PLUGIN / "hooks" / "hooks.json")["hooks"]
+    claude_save_hook = (CLAUDE_PLUGIN / "scripts" / "nmem-hook-save.py").read_text(encoding="utf-8")
     assert claude_manifest["name"] == "nowledge-mem"
+    assert claude_manifest["version"] == "0.7.15"
     assert {"SessionStart", "UserPromptSubmit", "PreCompact", "Stop"} <= set(claude_hooks)
     assert "nmem-hook-read.sh" in json.dumps(claude_hooks)
     assert "nmem-hook-save.py" in json.dumps(claude_hooks)
+    assert "CREATE_NO_WINDOW" in claude_save_hook
     assert "wm read" not in json.dumps(claude_hooks)
     assert (CLAUDE_PLUGIN / "scripts" / "nmem-hook-read.sh").exists()
     assert (CLAUDE_PLUGIN / "skills" / "save-thread" / "SKILL.md").exists()
@@ -300,7 +303,9 @@ def test_key_plugin_static_contracts_are_declared():
     codex_manifest = _read_json(CODEX_PLUGIN / ".codex-plugin" / "plugin.json")
     codex_mcp = _read_json(CODEX_PLUGIN / ".mcp.json")
     codex_hooks = _read_json(CODEX_PLUGIN / "hooks" / "hooks.json")["hooks"]
+    codex_save_hook = (CODEX_PLUGIN / "hooks" / "nmem-stop-save.py").read_text(encoding="utf-8")
     assert codex_manifest["name"] == "nowledge-mem"
+    assert codex_manifest["version"] == "0.1.22"
     assert codex_manifest["skills"] == "./skills/"
     assert codex_manifest["mcpServers"] == "./.mcp.json"
     assert codex_manifest["hooks"] == "./hooks/hooks.json"
@@ -341,6 +346,7 @@ def test_key_plugin_static_contracts_are_declared():
     assert (CODEX_PLUGIN / "scripts" / "install_hooks.py").exists()
     assert (CODEX_PLUGIN / "skills" / "working-memory" / "SKILL.md").exists()
     assert (CODEX_PLUGIN / "skills" / "save-thread" / "SKILL.md").exists()
+    assert "CREATE_NO_WINDOW" in codex_save_hook
 
     openclaw_manifest = _read_json(OPENCLAW_PLUGIN / "openclaw.plugin.json")
     openclaw_pkg = _read_json(OPENCLAW_PLUGIN / "package.json")
@@ -409,12 +415,14 @@ def test_key_plugin_static_contracts_are_declared():
 
     copilot_manifest = _read_json(COPILOT_PLUGIN / ".claude-plugin" / "plugin.json")
     copilot_hooks = _read_json(COPILOT_PLUGIN / "hooks" / "hooks.json")
-    assert copilot_manifest["version"] == "0.1.3"
+    copilot_capture = (COPILOT_PLUGIN / "hooks" / "copilot-stop-save.py").read_text(encoding="utf-8")
+    assert copilot_manifest["version"] == "0.1.4"
     assert "--source-app copilot-cli" in json.dumps(copilot_hooks)
     assert "NMEM_AGENT_ID" in json.dumps(copilot_hooks)
     assert "NMEM_HOST_AGENT_ID" in json.dumps(copilot_hooks)
     assert "rendered_markdown" in json.dumps(copilot_hooks)
     assert "wm read" in json.dumps(copilot_hooks)
+    assert "CREATE_NO_WINDOW" in copilot_capture
 
     droid_manifest = _read_json(DROID_PLUGIN / ".factory-plugin" / "plugin.json")
     droid_hooks = _read_json(DROID_PLUGIN / "hooks" / "hooks.json")
@@ -438,7 +446,7 @@ def test_key_plugin_static_contracts_are_declared():
     proma_hook = (PROMA_PLUGIN / "hooks" / "read-working-memory.py").read_text(encoding="utf-8")
     proma_save_hook = (PROMA_PLUGIN / "hooks" / "save-to-nmem.py").read_text(encoding="utf-8")
     proma_hooks = _read_json(PROMA_PLUGIN / "hooks" / "hooks.json")
-    assert proma_manifest["version"] == "0.1.3"
+    assert proma_manifest["version"] == "0.1.4"
     assert proma_hooks["installPath"] == "~/.proma/sdk-config/.claude/settings.json"
     assert proma_hooks["scriptInstallPath"] == "~/.proma/scripts/"
     assert "UserPromptSubmit" in proma_hooks["hooks"]
@@ -449,6 +457,7 @@ def test_key_plugin_static_contracts_are_declared():
     assert "NMEM_AGENT_ID" in proma_hook
     assert "NMEM_HOST_AGENT_ID" in proma_hook
     assert '"wm", "read"' in proma_hook
+    assert "CREATE_NO_WINDOW" in proma_hook
     assert "nowledge-mem:start" in proma_hook
     assert "CLAUDE.md" in proma_hook
     assert "sdk-config" in proma_save_hook
@@ -524,7 +533,7 @@ def test_key_plugin_static_contracts_are_declared():
     kimi_installer = (KIMI_PLUGIN / "scripts" / "install_hooks.py").read_text(encoding="utf-8")
     kimi_hook = (KIMI_PLUGIN / "scripts" / "kimi-sync-hook.py").read_text(encoding="utf-8")
     assert kimi_manifest["name"] == "nowledge-mem"
-    assert kimi_manifest["version"] == "0.1.0"
+    assert kimi_manifest["version"] == "0.1.1"
     assert kimi_manifest["skills"] == "./skills/"
     assert kimi_manifest["sessionStart"]["skill"] == "nowledge-mem"
     assert kimi_manifest["mcpServers"]["nowledge-mem"]["url"] == "http://127.0.0.1:14242/mcp/"
@@ -541,6 +550,7 @@ def test_key_plugin_static_contracts_are_declared():
     assert "--session-id" in kimi_hook
     assert "--apply" in kimi_hook
     assert "NMEM_KIMI_SYNC_TIMEOUT" in kimi_hook
+    assert "CREATE_NO_WINDOW" in kimi_hook
 
     kimi_work_manifest = _read_json(KIMI_WORK_CONNECTOR / "kimi.plugin.json")
     kimi_work_skill = (
@@ -568,11 +578,12 @@ def test_key_plugin_static_contracts_are_declared():
     alma_pkg = _read_json(ALMA_PLUGIN / "package.json")
     alma_skill = ALMA_PLUGIN / "skills" / "nowledge-mem" / "SKILL.md"
     alma_source = (ALMA_PLUGIN / "main.js").read_text(encoding="utf-8")
-    assert alma_manifest["version"] == "0.7.3"
-    assert alma_pkg["version"] == "0.7.3"
+    assert alma_manifest["version"] == "0.7.4"
+    assert alma_pkg["version"] == "0.7.4"
     assert alma_skill.exists()
     assert "nowledge_mem_context_bundle" in alma_skill.read_text(encoding="utf-8")
     assert "nowledge_mem_context_bundle" in alma_source
+    assert "windowsHide: true" in alma_source
 
 
 def test_kimi_code_hook_installer_uses_isolated_kimi_home(tmp_path: Path):
@@ -995,17 +1006,17 @@ def test_registry_connect_contract_points_agent_prompts_to_universal_skill():
         assert "/docs/integrations/" not in guide["promptZh"], entry["id"]
 
     by_id = {entry["id"]: entry for entry in integrations}
-    assert by_id["copilot-cli"]["version"] == "0.1.3"
+    assert by_id["copilot-cli"]["version"] == "0.1.4"
     assert by_id["gemini-cli"]["version"] == "0.1.9"
     assert by_id["cursor"]["version"] == "0.1.6"
     assert by_id["droid"]["version"] == "0.1.1"
     assert by_id["openclaw"]["version"] == "0.8.27"
-    assert by_id["proma"]["version"] == "0.1.3"
+    assert by_id["proma"]["version"] == "0.1.4"
     assert by_id["opencode"]["version"] == "0.3.4"
     assert by_id["pi"]["version"] == "0.8.2"
     assert by_id["pi"]["capabilities"]["autoRecall"] is True
     assert by_id["pi"]["autonomy"]["recall"] == "startup-context-injection"
-    assert by_id["kimi-code"]["version"] == "0.1.0"
+    assert by_id["kimi-code"]["version"] == "0.1.1"
     assert by_id["kimi-code"]["directory"] == "nowledge-mem-kimi-code-plugin"
     assert by_id["kimi-code"]["transport"] == "mcp+skills+hook"
     assert by_id["kimi-code"]["capabilities"]["autoCapture"] is True
@@ -1039,9 +1050,10 @@ def test_registry_connect_contract_points_agent_prompts_to_universal_skill():
         )
     assert by_id["zcode"]["threadSave"]["method"] == "none"
     assert by_id["zcode"]["autonomy"]["threads"] == "handoff-only"
-    assert by_id["alma"]["version"] == "0.7.3"
+    assert by_id["alma"]["version"] == "0.7.4"
     assert by_id["alma"]["skills"] == ["nowledge-mem"]
     assert "nowledge_mem_context_bundle" in by_id["alma"]["toolNaming"]["tools"]
+    assert by_id["bub"]["version"] == "0.7.3"
     assert by_id["pi"]["threadSave"]["method"] == "plugin-capture"
     assert by_id["pi"]["capabilities"]["autoCapture"] is True
     assert by_id["pi"]["autonomy"]["threads"] == "automatic-capture"
@@ -1049,9 +1061,15 @@ def test_registry_connect_contract_points_agent_prompts_to_universal_skill():
 
 
 def test_save_surfaces_do_not_default_omitted_unit_type_to_fact():
+    bub_pyproject = (BUB_PLUGIN / "pyproject.toml").read_text(encoding="utf-8")
+    bub_client = (
+        BUB_PLUGIN / "src" / "nowledge_mem_bub" / "client.py"
+    ).read_text(encoding="utf-8")
     bub_tools = (
         BUB_PLUGIN / "src" / "nowledge_mem_bub" / "tools.py"
     ).read_text(encoding="utf-8")
+    assert 'version = "0.7.3"' in bub_pyproject
+    assert "CREATE_NO_WINDOW" in bub_client
     assert "unit_type: str | None = Field(" in bub_tools
     assert "unit_type: str = Field(" not in bub_tools
     assert "Omit when unsure so Nowledge Mem can" in bub_tools


### PR DESCRIPTION
## Summary

Follow-up to #356. The Hermes fix was the right pattern, but the same Windows console-flash risk existed in other lifecycle hooks or plugin runtimes that invoke nmem from a host process.

This PR hides child console windows for:

- Claude Code / Grok Build Stop and PreCompact capture
- Codex Stop capture
- Copilot CLI capture
- Kimi Code sync hook
- Proma startup / asyncRewake context hook
- Bub CLI client
- Alma CLI preflight

It also bumps the touched plugin versions and keeps integrations.json aligned.

## Verification

- `uv run --with pytest pytest nowledge-mem-claude-code-plugin/tests/test_nmem_hook_save.py nowledge-mem-codex-plugin/tests/test_codex_plugin.py nowledge-mem-copilot-cli-plugin/tests/test_copilot_plugin.py -q` -> 107 passed
- `uv run --with pytest pytest tests/plugin_e2e -q` -> 66 passed, 6 skipped
- `node nowledge-mem-codex-plugin/scripts/validate-plugin.mjs` -> passed
- `npm test` in `nowledge-mem-alma-plugin` -> 9 passed
- `py_compile` for touched Python hooks/clients -> passed
- `jq empty` for touched JSON manifests/registry -> passed
- `git diff --check` -> passed
- windows-book smoke: Python 3.13.14 accepted `CREATE_NO_WINDOW` for both `subprocess.run` and `asyncio.create_subprocess_exec`
