### PR TITLE
fix: sync marketplace.json nowledge-mem version to 0.7.15

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -12,7 +12,7 @@
     {
       "name": "nowledge-mem",
       "description": "Personal knowledge graph for Claude Code and Grok — remembers decisions, searches past work, captures sessions",
-      "version": "0.7.12",
+      "version": "0.7.15",
       "author": {
         "name": "Nowledge Labs",
         "url": "https://www.nowledge-labs.ai/",

--- a/.github/plugin/marketplace.json
+++ b/.github/plugin/marketplace.json
@@ -12,7 +12,7 @@
     {
       "name": "nowledge-mem",
       "description": "Personal knowledge graph for GitHub Copilot CLI — remembers decisions, searches past work, captures sessions",
-      "version": "0.1.1",
+      "version": "0.1.4",
       "source": "./nowledge-mem-copilot-cli-plugin"
     }
   ]


### PR DESCRIPTION
marketplace.json lists `nowledge-mem` at `0.7.12` while the plugin's own `.claude-plugin/plugin.json` is at `0.7.15`, so the marketplace listing shows a stale version. One-line sync.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the `nowledge-mem` plugin version in marketplace listings to the latest available release (both community and GitHub plugin entries).
  * No functional changes to the product behavior—this update is limited to keeping the displayed plugin version current.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->