### PR TITLE
fix(plugins): handle managed skill matches without explicit version

### DIFF
--- a/integrations.json
+++ b/integrations.json
@@ -21,7 +21,7 @@
       "name": "Claude Code",
       "category": "coding",
       "type": "plugin",
-      "version": "0.7.16",
+      "version": "0.7.17",
       "directory": "nowledge-mem-claude-code-plugin",
       "transport": "cli",
       "capabilities": {
@@ -73,7 +73,7 @@
       "name": "Grok Build",
       "category": "coding",
       "type": "plugin",
-      "version": "0.7.16",
+      "version": "0.7.17",
       "directory": "nowledge-mem-claude-code-plugin",
       "transport": "cli",
       "capabilities": {
@@ -229,7 +229,7 @@
       "name": "Codex",
       "category": "coding",
       "type": "plugin",
-      "version": "0.1.23",
+      "version": "0.1.24",
       "directory": "nowledge-mem-codex-plugin",
 
       "legacyDirectory": "nowledge-mem-codex-prompts",
@@ -840,7 +840,7 @@
       "name": "Hermes Agent",
       "category": "coding",
       "type": "plugin",
-      "version": "0.5.20",
+      "version": "0.5.21",
       "directory": "nowledge-mem-hermes",
       "transport": "cli",
       "capabilities": {

--- a/nowledge-mem-claude-code-plugin/.claude-plugin/plugin.json
+++ b/nowledge-mem-claude-code-plugin/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "nowledge-mem",
   "description": "Personal knowledge graph for Claude Code and Grok \u2014 remembers decisions, searches past work, captures sessions",
-  "version": "0.7.16",
+  "version": "0.7.17",
   "author": {
     "name": "Nowledge Labs",
     "email": "hello@nowledge-labs.ai",

--- a/nowledge-mem-claude-code-plugin/CHANGELOG.md
+++ b/nowledge-mem-claude-code-plugin/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to the Nowledge Mem Claude Code plugin will be documented in
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.7.17] - 2026-07-07
+
+### Fixed
+
+- Managed skill outcome extraction now handles `find_skills` matches that omit an explicit version by defaulting matching skill records to version `1`.
+- Claude Code managed-skills guidance now explicitly prioritizes `find_skills` before filesystem or memory searches when looking for skills.
+
 ## [0.7.16] - 2026-07-06
 
 ### Added

--- a/nowledge-mem-claude-code-plugin/scripts/skill_outcome.py
+++ b/nowledge-mem-claude-code-plugin/scripts/skill_outcome.py
@@ -217,9 +217,19 @@ def _skill_id(node: dict[str, Any]) -> str:
         if isinstance(value, str) and value.strip():
             return value.strip()
     value = node.get("id")
-    if isinstance(value, str) and value.strip() and _looks_like_skill_record(node):
+    if (
+        isinstance(value, str)
+        and value.strip()
+        and _looks_like_skill_id(value)
+        and _looks_like_skill_record(node)
+    ):
         return value.strip()
     return ""
+
+
+def _looks_like_skill_id(value: str) -> bool:
+    normalized = value.strip().lower()
+    return normalized.startswith("skill_") or normalized.startswith("skill-")
 
 
 def _skill_version(node: dict[str, Any]) -> str:
@@ -232,11 +242,13 @@ def _skill_version(node: dict[str, Any]) -> str:
         value = metadata.get("version")
         if isinstance(value, (str, int, float)) and str(value).strip():
             return str(value).strip()
+    if _looks_like_skill_record(node):
+        return "1"
     return ""
 
 
 def _looks_like_skill_record(node: dict[str, Any]) -> bool:
-    return "version" in node and any(
+    return any(
         key in node
         for key in (
             "name",

--- a/nowledge-mem-claude-code-plugin/scripts/skill_outcome.py
+++ b/nowledge-mem-claude-code-plugin/scripts/skill_outcome.py
@@ -1,9 +1,9 @@
 """Extract Nowledge Mem managed-skill use from host transcripts.
 
 The extractor is deliberately conservative: it only reports structured
-`find_skills` tool results that contain both a skill id and version. It does not
-regex free-form assistant text, so normal conversation cannot create false
-skill outcome records.
+`find_skills` tool results with skill-style ids. Missing versions default to
+version 1 for matching skill records. It does not regex free-form assistant
+text, so normal conversation cannot create false skill outcome records.
 """
 
 from __future__ import annotations
@@ -214,7 +214,7 @@ def _parse_json_text(value: str) -> Any | None:
 def _skill_id(node: dict[str, Any]) -> str:
     for key in ("skill_id", "skillId"):
         value = node.get(key)
-        if isinstance(value, str) and value.strip():
+        if isinstance(value, str) and value.strip() and _looks_like_skill_id(value):
             return value.strip()
     value = node.get("id")
     if (

--- a/nowledge-mem-claude-code-plugin/skills/read-working-memory/SKILL.md
+++ b/nowledge-mem-claude-code-plugin/skills/read-working-memory/SKILL.md
@@ -73,7 +73,7 @@ The Working Memory briefing contains:
 
 ## Managed Skills
 
-Nowledge Mem can hold managed skills: proven procedures for recurring, multi-step work. If the task is procedural and the Nowledge Mem MCP server exposes `find_skills`, check for a matching skill before starting. If one matches, read and follow its `SKILL.md`, then report the outcome with `report_skill_outcome` when the task is done.
+Nowledge Mem can hold managed skills: proven procedures for recurring, multi-step work. If the task is procedural and the Nowledge Mem MCP server exposes `find_skills`, check for a matching skill before starting. When looking for skills, always use `find_skills` first; do not search the filesystem or memory for skills. If one matches, read and follow its `SKILL.md`, then report the outcome with `report_skill_outcome` when the task is done.
 
 If MCP is unavailable but `nmem` is present, use:
 

--- a/nowledge-mem-claude-code-plugin/tests/test_nmem_hook_save.py
+++ b/nowledge-mem-claude-code-plugin/tests/test_nmem_hook_save.py
@@ -339,6 +339,35 @@ def test_extract_skill_outcomes_from_claude_tool_use_pair(tmp_path):
     ]
 
 
+def test_extract_skill_outcomes_defaults_missing_version_to_v1(tmp_path):
+    transcript = tmp_path / "claude-transcript-v1.jsonl"
+    transcript.write_text(
+        json_line(
+            {
+                "type": "mcp_tool_call_end",
+                "server": "nowledge-mem",
+                "tool": "find_skills",
+                "result": {
+                    "matches": [
+                        {
+                            "id": "skill-bravo",
+                            "name": "Bravo",
+                            "title": "Bravo Skill",
+                            "description": "A managed skill",
+                        }
+                    ]
+                },
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    assert nmem_hook_save.extract_skill_outcomes_from_file(str(transcript)) == [
+        ("skill-bravo", "1")
+    ]
+
+
 def test_report_skill_outcomes_runs_once_per_transcript_skill_version(tmp_path):
     transcript = tmp_path / "claude-transcript.jsonl"
     transcript.write_text(

--- a/nowledge-mem-claude-code-plugin/tests/test_nmem_hook_save.py
+++ b/nowledge-mem-claude-code-plugin/tests/test_nmem_hook_save.py
@@ -368,6 +368,32 @@ def test_extract_skill_outcomes_defaults_missing_version_to_v1(tmp_path):
     ]
 
 
+def test_extract_skill_outcomes_ignores_non_skill_style_ids(tmp_path):
+    transcript = tmp_path / "claude-transcript-non-skill-id.jsonl"
+    transcript.write_text(
+        json_line(
+            {
+                "type": "mcp_tool_call_end",
+                "server": "nowledge-mem",
+                "tool": "find_skills",
+                "result": {
+                    "matches": [
+                        {
+                            "skill_id": "bravo",
+                            "version": "7",
+                            "name": "Bravo",
+                        }
+                    ]
+                },
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    assert nmem_hook_save.extract_skill_outcomes_from_file(str(transcript)) == []
+
+
 def test_report_skill_outcomes_runs_once_per_transcript_skill_version(tmp_path):
     transcript = tmp_path / "claude-transcript.jsonl"
     transcript.write_text(

--- a/nowledge-mem-codex-plugin/.codex-plugin/plugin.json
+++ b/nowledge-mem-codex-plugin/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "nowledge-mem",
-  "version": "0.1.23",
+  "version": "0.1.24",
   "description": "Your Codex agent remembers past decisions, finds relevant context, and learns from every session, across all your AI tools.",
   "skills": "./skills/",
   "mcpServers": "./.mcp.json",

--- a/nowledge-mem-codex-plugin/AGENTS.md
+++ b/nowledge-mem-codex-plugin/AGENTS.md
@@ -106,7 +106,7 @@ nmem --json t show <thread_id> --limit 8 --offset 0 --content-limit 1200
 
 ## Skills
 
-Nowledge Mem can hold managed skills: proven procedures for the user's recurring, multi-step work. Once connected (`nmem skills connect --host codex`), they load as native Codex skills, so use them like any other skill when one fits. If MCP is available, `find_skills` finds a matching skill on demand for a recurring or procedural task; after using one, report how it went with `report_skill_outcome` (or `nmem skills outcome <id>`). Best-effort: don't force a skill onto a task it doesn't fit, and don't check for every question.
+Nowledge Mem can hold managed skills: proven procedures for the user's recurring, multi-step work. Once connected (`nmem skills connect --host codex`), they load as native Codex skills, so use them like any other skill when one fits. When looking for skills, always use `find_skills` first if MCP is available; do not search the filesystem or memory for skills. If MCP is unavailable, use `nmem skills match`. After using one, report how it went with `report_skill_outcome` (or `nmem skills outcome <id>`). Best-effort: don't force a skill onto a task it doesn't fit, and don't check for every question.
 
 ## Distill
 

--- a/nowledge-mem-codex-plugin/CHANGELOG.md
+++ b/nowledge-mem-codex-plugin/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [0.1.24] - 2026-07-07
+
+### Fixed
+
+- Managed skill outcome extraction now handles `find_skills` matches that omit an explicit version by defaulting matching skill records to version `1`.
+- Codex managed-skills guidance now explicitly prioritizes `find_skills` before filesystem or memory searches when looking for skills.
+
 ## [0.1.23] - 2026-07-06
 
 ### Added

--- a/nowledge-mem-codex-plugin/CHANGELOG.md
+++ b/nowledge-mem-codex-plugin/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - Managed skill outcome extraction now handles `find_skills` matches that omit an explicit version by defaulting matching skill records to version `1`.
 - Codex managed-skills guidance now explicitly prioritizes `find_skills` before filesystem or memory searches when looking for skills.
+- Codex hook installation now treats `skill_outcome.py` as a required runtime file, so broken installs fail loudly instead of silently disabling managed skill outcome reporting.
 
 ## [0.1.23] - 2026-07-06
 

--- a/nowledge-mem-codex-plugin/hooks/skill_outcome.py
+++ b/nowledge-mem-codex-plugin/hooks/skill_outcome.py
@@ -217,9 +217,19 @@ def _skill_id(node: dict[str, Any]) -> str:
         if isinstance(value, str) and value.strip():
             return value.strip()
     value = node.get("id")
-    if isinstance(value, str) and value.strip() and _looks_like_skill_record(node):
+    if (
+        isinstance(value, str)
+        and value.strip()
+        and _looks_like_skill_id(value)
+        and _looks_like_skill_record(node)
+    ):
         return value.strip()
     return ""
+
+
+def _looks_like_skill_id(value: str) -> bool:
+    normalized = value.strip().lower()
+    return normalized.startswith("skill_") or normalized.startswith("skill-")
 
 
 def _skill_version(node: dict[str, Any]) -> str:
@@ -232,11 +242,13 @@ def _skill_version(node: dict[str, Any]) -> str:
         value = metadata.get("version")
         if isinstance(value, (str, int, float)) and str(value).strip():
             return str(value).strip()
+    if _looks_like_skill_record(node):
+        return "1"
     return ""
 
 
 def _looks_like_skill_record(node: dict[str, Any]) -> bool:
-    return "version" in node and any(
+    return any(
         key in node
         for key in (
             "name",

--- a/nowledge-mem-codex-plugin/hooks/skill_outcome.py
+++ b/nowledge-mem-codex-plugin/hooks/skill_outcome.py
@@ -1,9 +1,9 @@
 """Extract Nowledge Mem managed-skill use from host transcripts.
 
 The extractor is deliberately conservative: it only reports structured
-`find_skills` tool results that contain both a skill id and version. It does not
-regex free-form assistant text, so normal conversation cannot create false
-skill outcome records.
+`find_skills` tool results with skill-style ids. Missing versions default to
+version 1 for matching skill records. It does not regex free-form assistant
+text, so normal conversation cannot create false skill outcome records.
 """
 
 from __future__ import annotations
@@ -214,7 +214,7 @@ def _parse_json_text(value: str) -> Any | None:
 def _skill_id(node: dict[str, Any]) -> str:
     for key in ("skill_id", "skillId"):
         value = node.get(key)
-        if isinstance(value, str) and value.strip():
+        if isinstance(value, str) and value.strip() and _looks_like_skill_id(value):
             return value.strip()
     value = node.get("id")
     if (

--- a/nowledge-mem-codex-plugin/scripts/install_hooks.py
+++ b/nowledge-mem-codex-plugin/scripts/install_hooks.py
@@ -21,6 +21,8 @@ GLOBAL_HOOKS_FILE = CODEX_DIR / "hooks.json"
 CONFIG_FILE = CODEX_DIR / "config.toml"
 SOURCE_HOOK = PLUGIN_ROOT / "hooks" / "nmem-stop-save.py"
 INSTALLED_HOOK = HOOKS_DIR / "nowledge-mem-stop-save.py"
+SOURCE_SKILL_OUTCOME = PLUGIN_ROOT / "hooks" / "skill_outcome.py"
+INSTALLED_SKILL_OUTCOME = HOOKS_DIR / "skill_outcome.py"
 CODEX_HOOKS_KEY_RE = re.compile(r"^\s*codex_hooks\s*=")
 CODEX_HOOKS_NEW_KEY_RE = re.compile(r"^\s*hooks\s*=")
 CODEX_PLUGIN_HOOKS_KEY_RE = re.compile(r"^\s*plugin_hooks\s*=")
@@ -108,6 +110,8 @@ def install_runtime_hook() -> None:
     shutil.copy2(SOURCE_HOOK, INSTALLED_HOOK)
     mode = INSTALLED_HOOK.stat().st_mode
     INSTALLED_HOOK.chmod(mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH)
+    if SOURCE_SKILL_OUTCOME.exists():
+        shutil.copy2(SOURCE_SKILL_OUTCOME, INSTALLED_SKILL_OUTCOME)
 
 
 def _quote_for_hook_command(path: Path) -> str:
@@ -507,6 +511,8 @@ def main() -> int:
 
     print("Installed Nowledge Mem Codex Stop hook")
     print(f"- runtime hook: {INSTALLED_HOOK}")
+    if INSTALLED_SKILL_OUTCOME.exists():
+        print(f"- skill outcome extractor: {INSTALLED_SKILL_OUTCOME}")
     print(f"- hooks config: {GLOBAL_HOOKS_FILE}")
     print(f"- hook feature flags ensured in: {CONFIG_FILE}")
     print(f"- plugin Stop hook enabled in: {CONFIG_FILE}")

--- a/nowledge-mem-codex-plugin/scripts/install_hooks.py
+++ b/nowledge-mem-codex-plugin/scripts/install_hooks.py
@@ -110,8 +110,9 @@ def install_runtime_hook() -> None:
     shutil.copy2(SOURCE_HOOK, INSTALLED_HOOK)
     mode = INSTALLED_HOOK.stat().st_mode
     INSTALLED_HOOK.chmod(mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH)
-    if SOURCE_SKILL_OUTCOME.exists():
-        shutil.copy2(SOURCE_SKILL_OUTCOME, INSTALLED_SKILL_OUTCOME)
+    if not SOURCE_SKILL_OUTCOME.exists():
+        raise SystemExit(f"missing skill outcome extractor: {SOURCE_SKILL_OUTCOME}")
+    shutil.copy2(SOURCE_SKILL_OUTCOME, INSTALLED_SKILL_OUTCOME)
 
 
 def _quote_for_hook_command(path: Path) -> str:
@@ -511,8 +512,7 @@ def main() -> int:
 
     print("Installed Nowledge Mem Codex Stop hook")
     print(f"- runtime hook: {INSTALLED_HOOK}")
-    if INSTALLED_SKILL_OUTCOME.exists():
-        print(f"- skill outcome extractor: {INSTALLED_SKILL_OUTCOME}")
+    print(f"- skill outcome extractor: {INSTALLED_SKILL_OUTCOME}")
     print(f"- hooks config: {GLOBAL_HOOKS_FILE}")
     print(f"- hook feature flags ensured in: {CONFIG_FILE}")
     print(f"- plugin Stop hook enabled in: {CONFIG_FILE}")

--- a/nowledge-mem-codex-plugin/scripts/validate-plugin.mjs
+++ b/nowledge-mem-codex-plugin/scripts/validate-plugin.mjs
@@ -67,6 +67,7 @@ for (const file of [
   "hooks/hooks.json",
   "hooks/nmem-stop-launch.py",
   "hooks/nmem-stop-save.py",
+  "hooks/skill_outcome.py",
   "scripts/install_hooks.py",
   "scripts/validate-plugin.mjs",
   "skills/working-memory/SKILL.md",

--- a/nowledge-mem-codex-plugin/scripts/validate-plugin.mjs
+++ b/nowledge-mem-codex-plugin/scripts/validate-plugin.mjs
@@ -8,7 +8,7 @@ import { fileURLToPath } from "node:url";
 const scriptDir = path.dirname(fileURLToPath(import.meta.url));
 const pluginRoot = path.resolve(scriptDir, "..");
 const repoRoot = path.resolve(pluginRoot, "..");
-const expectedVersion = "0.1.23";
+const expectedVersion = "0.1.24";
 
 const fail = (message) => {
   console.error(`FAIL: ${message}`);

--- a/nowledge-mem-codex-plugin/tests/test_codex_plugin.py
+++ b/nowledge-mem-codex-plugin/tests/test_codex_plugin.py
@@ -237,6 +237,34 @@ class HookTests(unittest.TestCase):
             [("skill-alpha", "1")],
         )
 
+    def test_extract_skill_outcomes_ignores_non_skill_style_ids(self):
+        transcript = self.temp_path / "codex-transcript-non-skill-id.jsonl"
+        transcript.write_text(
+            json.dumps(
+                {
+                    "type": "mcp_tool_call_end",
+                    "server": "nowledge-mem",
+                    "tool": "find_skills",
+                    "result": {
+                        "matches": [
+                            {
+                                "skill_id": "alpha",
+                                "version": "3",
+                                "name": "Alpha",
+                            }
+                        ]
+                    },
+                }
+            )
+            + "\n",
+            encoding="utf-8",
+        )
+
+        self.assertEqual(
+            self.module.extract_skill_outcomes_from_file(str(transcript)),
+            [],
+        )
+
     def test_report_skill_outcomes_runs_once_per_transcript_skill_version(self):
         transcript = self.temp_path / "codex-transcript.jsonl"
         transcript.write_text(
@@ -466,12 +494,13 @@ class InstallHookTests(unittest.TestCase):
     def setUp(self):
         self.module = load_module("install_hooks", INSTALL_MODULE_PATH)
         self.temp_dir = tempfile.TemporaryDirectory()
-        temp_path = Path(self.temp_dir.name)
-        self.module.CODEX_DIR = temp_path / ".codex"
+        self.temp_path = Path(self.temp_dir.name)
+        self.module.CODEX_DIR = self.temp_path / ".codex"
         self.module.HOOKS_DIR = self.module.CODEX_DIR / "hooks"
         self.module.GLOBAL_HOOKS_FILE = self.module.CODEX_DIR / "hooks.json"
         self.module.CONFIG_FILE = self.module.CODEX_DIR / "config.toml"
         self.module.INSTALLED_HOOK = self.module.HOOKS_DIR / "nowledge-mem-stop-save.py"
+        self.module.INSTALLED_SKILL_OUTCOME = self.module.HOOKS_DIR / "skill_outcome.py"
 
     def tearDown(self):
         self.temp_dir.cleanup()
@@ -641,6 +670,20 @@ class InstallHookTests(unittest.TestCase):
 
         self.assertTrue(self.module.INSTALLED_HOOK.exists())
         self.assertIn("Best-effort Codex transcript capture", self.module.INSTALLED_HOOK.read_text())
+        self.assertTrue(self.module.INSTALLED_SKILL_OUTCOME.exists())
+        self.assertIn(
+            "extract_skill_outcomes_from_file",
+            self.module.INSTALLED_SKILL_OUTCOME.read_text(),
+        )
+
+    def test_install_runtime_hook_fails_when_skill_outcome_extractor_missing(self):
+        self.module.SOURCE_SKILL_OUTCOME = self.temp_path / "missing-skill-outcome.py"
+
+        with self.assertRaises(SystemExit) as raised:
+            self.module.install_runtime_hook()
+
+        self.assertIn("missing skill outcome extractor", str(raised.exception))
+        self.assertFalse(self.module.INSTALLED_SKILL_OUTCOME.exists())
 
     def test_install_codex_mcp_config_writes_managed_authenticated_override(self):
         self.module.CONFIG_FILE.parent.mkdir(parents=True, exist_ok=True)

--- a/nowledge-mem-codex-plugin/tests/test_codex_plugin.py
+++ b/nowledge-mem-codex-plugin/tests/test_codex_plugin.py
@@ -208,6 +208,35 @@ class HookTests(unittest.TestCase):
             [("skill-alpha", "3")],
         )
 
+    def test_extract_skill_outcomes_defaults_missing_version_to_v1(self):
+        transcript = self.temp_path / "codex-transcript-v1.jsonl"
+        transcript.write_text(
+            json.dumps(
+                {
+                    "type": "mcp_tool_call_end",
+                    "server": "nowledge-mem",
+                    "tool": "find_skills",
+                    "result": {
+                        "matches": [
+                            {
+                                "id": "skill-alpha",
+                                "name": "Alpha",
+                                "title": "Alpha Skill",
+                                "description": "A managed skill",
+                            }
+                        ]
+                    },
+                }
+            )
+            + "\n",
+            encoding="utf-8",
+        )
+
+        self.assertEqual(
+            self.module.extract_skill_outcomes_from_file(str(transcript)),
+            [("skill-alpha", "1")],
+        )
+
     def test_report_skill_outcomes_runs_once_per_transcript_skill_version(self):
         transcript = self.temp_path / "codex-transcript.jsonl"
         transcript.write_text(

--- a/nowledge-mem-hermes/CHANGELOG.md
+++ b/nowledge-mem-hermes/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [0.5.21] - 2026-07-07
+
+### Fixed
+
+- Managed skill outcome extraction now handles `find_skills` matches that omit an explicit version by defaulting matching skill records to version `1`.
+- Managed-skills guidance now explicitly tells agents to call `find_skills` before filesystem or memory searches when looking for skills.
+
 ## [0.5.20] - 2026-07-06
 
 ### Added

--- a/nowledge-mem-hermes/README.md
+++ b/nowledge-mem-hermes/README.md
@@ -208,7 +208,7 @@ bash <(curl -sL https://raw.githubusercontent.com/nowledge-co/community/main/now
 After updating, the script prints the version and endpoint from the files it actually wrote:
 
 ```text
-Installed version: 0.5.20
+Installed version: 0.5.21
 Thread import endpoint: /threads/import
 ```
 

--- a/nowledge-mem-hermes/plugin.yaml
+++ b/nowledge-mem-hermes/plugin.yaml
@@ -1,5 +1,5 @@
 name: nowledge-mem
-version: 0.5.20
+version: 0.5.21
 description: "Cross-tool personal knowledge graph with semantic search, Working Memory, and proactive recall."
 hooks:
   - prefetch

--- a/nowledge-mem-hermes/provider.py
+++ b/nowledge-mem-hermes/provider.py
@@ -62,8 +62,9 @@ topic, use nmem_update rather than create a duplicate.
 **Managed skills:** Nowledge Mem can also hold proven procedures for the \
 user's recurring, multi-step work. When the Nowledge Mem MCP is connected, \
 check find_skills before a recurring or procedural task; if one matches, \
-follow its SKILL.md, then call report_skill_outcome afterward. Best-effort, \
-not for every question."""
+follow its SKILL.md, then call report_skill_outcome afterward. When looking \
+for skills, always use find_skills first; do not search the filesystem or \
+memory for skills. Best-effort, not for every question."""
 
 _SEARCH = {
     "name": "nmem_search",

--- a/nowledge-mem-hermes/skill_outcome.py
+++ b/nowledge-mem-hermes/skill_outcome.py
@@ -217,9 +217,19 @@ def _skill_id(node: dict[str, Any]) -> str:
         if isinstance(value, str) and value.strip():
             return value.strip()
     value = node.get("id")
-    if isinstance(value, str) and value.strip() and _looks_like_skill_record(node):
+    if (
+        isinstance(value, str)
+        and value.strip()
+        and _looks_like_skill_id(value)
+        and _looks_like_skill_record(node)
+    ):
         return value.strip()
     return ""
+
+
+def _looks_like_skill_id(value: str) -> bool:
+    normalized = value.strip().lower()
+    return normalized.startswith("skill_") or normalized.startswith("skill-")
 
 
 def _skill_version(node: dict[str, Any]) -> str:
@@ -232,11 +242,13 @@ def _skill_version(node: dict[str, Any]) -> str:
         value = metadata.get("version")
         if isinstance(value, (str, int, float)) and str(value).strip():
             return str(value).strip()
+    if _looks_like_skill_record(node):
+        return "1"
     return ""
 
 
 def _looks_like_skill_record(node: dict[str, Any]) -> bool:
-    return "version" in node and any(
+    return any(
         key in node
         for key in (
             "name",

--- a/nowledge-mem-hermes/skill_outcome.py
+++ b/nowledge-mem-hermes/skill_outcome.py
@@ -1,9 +1,9 @@
 """Extract Nowledge Mem managed-skill use from host transcripts.
 
 The extractor is deliberately conservative: it only reports structured
-`find_skills` tool results that contain both a skill id and version. It does not
-regex free-form assistant text, so normal conversation cannot create false
-skill outcome records.
+`find_skills` tool results with skill-style ids. Missing versions default to
+version 1 for matching skill records. It does not regex free-form assistant
+text, so normal conversation cannot create false skill outcome records.
 """
 
 from __future__ import annotations
@@ -214,7 +214,7 @@ def _parse_json_text(value: str) -> Any | None:
 def _skill_id(node: dict[str, Any]) -> str:
     for key in ("skill_id", "skillId"):
         value = node.get(key)
-        if isinstance(value, str) and value.strip():
+        if isinstance(value, str) and value.strip() and _looks_like_skill_id(value):
             return value.strip()
     value = node.get("id")
     if (

--- a/nowledge-mem-hermes/tests/test_session_sync.py
+++ b/nowledge-mem-hermes/tests/test_session_sync.py
@@ -311,6 +311,51 @@ def test_sync_turn_reports_managed_skill_outcome_from_messages_once():
     ]
 
 
+def test_sync_turn_reports_find_skills_match_without_version_as_v1():
+    instance = provider.NowledgeMemProvider()
+    instance._client = FakeClient()
+    instance._cron_skipped = False
+    instance._session_id = "session-skills-v1"
+    instance._saved_message_count = 0
+
+    messages = [
+        {
+            "role": "assistant",
+            "content": [
+                {
+                    "type": "tool_use",
+                    "id": "call-v1",
+                    "name": "mcp__nowledge-mem__find_skills",
+                    "input": {"query": "Hermes Studio LPK"},
+                }
+            ],
+        },
+        {
+            "role": "user",
+            "content": [
+                {
+                    "type": "tool_result",
+                    "tool_use_id": "call-v1",
+                    "content": '{"matches":[{"id":"skill-hermes","name":"Hermes","title":"Hermes Skill","description":"A managed skill"}]}',
+                }
+            ],
+        },
+        {"role": "user", "content": "question"},
+        {"role": "assistant", "content": "answer"},
+    ]
+
+    instance.sync_turn(
+        "question",
+        "answer",
+        session_id="session-skills-v1",
+        messages=messages,
+    )
+
+    assert instance._client.skill_outcome_calls == [
+        {"skill_id": "skill-hermes", "version": "1", "outcome": "completed"}
+    ]
+
+
 def test_initial_import_existing_thread_falls_back_to_dedup_append():
     instance = provider.NowledgeMemProvider()
     instance._client = FakeClient()

--- a/nowledge-mem-hermes/tests/test_session_sync.py
+++ b/nowledge-mem-hermes/tests/test_session_sync.py
@@ -356,6 +356,49 @@ def test_sync_turn_reports_find_skills_match_without_version_as_v1():
     ]
 
 
+def test_sync_turn_ignores_find_skills_match_with_non_skill_style_id():
+    instance = provider.NowledgeMemProvider()
+    instance._client = FakeClient()
+    instance._cron_skipped = False
+    instance._session_id = "session-skills-non-skill-id"
+    instance._saved_message_count = 0
+
+    messages = [
+        {
+            "role": "assistant",
+            "content": [
+                {
+                    "type": "tool_use",
+                    "id": "call-non-skill-id",
+                    "name": "mcp__nowledge-mem__find_skills",
+                    "input": {"query": "Hermes Studio LPK"},
+                }
+            ],
+        },
+        {
+            "role": "user",
+            "content": [
+                {
+                    "type": "tool_result",
+                    "tool_use_id": "call-non-skill-id",
+                    "content": '{"matches":[{"skill_id":"hermes","version":2,"name":"Hermes"}]}',
+                }
+            ],
+        },
+        {"role": "user", "content": "question"},
+        {"role": "assistant", "content": "answer"},
+    ]
+
+    instance.sync_turn(
+        "question",
+        "answer",
+        session_id="session-skills-non-skill-id",
+        messages=messages,
+    )
+
+    assert instance._client.skill_outcome_calls == []
+
+
 def test_initial_import_existing_thread_falls_back_to_dedup_append():
     instance = provider.NowledgeMemProvider()
     instance._client = FakeClient()

--- a/tests/plugin_e2e/test_key_plugins_e2e.py
+++ b/tests/plugin_e2e/test_key_plugins_e2e.py
@@ -291,7 +291,7 @@ def test_key_plugin_static_contracts_are_declared():
     claude_hooks = _read_json(CLAUDE_PLUGIN / "hooks" / "hooks.json")["hooks"]
     claude_save_hook = (CLAUDE_PLUGIN / "scripts" / "nmem-hook-save.py").read_text(encoding="utf-8")
     assert claude_manifest["name"] == "nowledge-mem"
-    assert claude_manifest["version"] == "0.7.16"
+    assert claude_manifest["version"] == "0.7.17"
     assert {"SessionStart", "UserPromptSubmit", "PreCompact", "Stop"} <= set(claude_hooks)
     assert "nmem-hook-read.sh" in json.dumps(claude_hooks)
     assert "nmem-hook-save.py" in json.dumps(claude_hooks)
@@ -308,7 +308,7 @@ def test_key_plugin_static_contracts_are_declared():
     codex_hooks = _read_json(CODEX_PLUGIN / "hooks" / "hooks.json")["hooks"]
     codex_save_hook = (CODEX_PLUGIN / "hooks" / "nmem-stop-save.py").read_text(encoding="utf-8")
     assert codex_manifest["name"] == "nowledge-mem"
-    assert codex_manifest["version"] == "0.1.23"
+    assert codex_manifest["version"] == "0.1.24"
     assert codex_manifest["skills"] == "./skills/"
     assert codex_manifest["mcpServers"] == "./.mcp.json"
     assert codex_manifest["hooks"] == "./hooks/hooks.json"
@@ -391,7 +391,7 @@ def test_key_plugin_static_contracts_are_declared():
 
     hermes_manifest = (HERMES_PLUGIN / "plugin.yaml").read_text(encoding="utf-8")
     assert "name: nowledge-mem" in hermes_manifest
-    assert "version: 0.5.20" in hermes_manifest
+    assert "version: 0.5.21" in hermes_manifest
     for hook in (
         "prefetch",
         "post_llm_call",


### PR DESCRIPTION
Managed skill outcome extraction now handles find_skills matches that omit an explicit version by defaulting matching skill records to version 1. Managed-skills guidance now explicitly tells agents to call find_skills before filesystem or memory searches when looking for skills (addresses #389 comment). Version bumps: Hermes 0.5.21, Codex 0.1.24, Claude Code 0.7.17. Tests added for all three plugins.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Managed skills now prioritize `find_skills` before filesystem/memory lookups.
  * Skill outcome extraction defaults missing skill versions to `1`.
  * Tightened skill ID matching to only accept valid skill-style IDs; non-conforming matches are ignored.
  * Improved runtime behavior: the Codex skill outcome extractor hook is now required and fails loudly if missing.
* **Documentation**
  * Updated Managed Skills instructions in plugin docs and agent guidance to use `find_skills` first.
* **Chores / Tests**
  * Version bumps across Claude Code, Codex, and Hermes; added/updated unit and E2E coverage for the above fixes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->