### PR TITLE
feat(codex): propagate ambient Mem identity

### DIFF
--- a/integrations.json
+++ b/integrations.json
@@ -229,7 +229,7 @@
       "name": "Codex",
       "category": "coding",
       "type": "plugin",
-      "version": "0.1.26",
+      "version": "0.1.27",
       "directory": "nowledge-mem-codex-plugin",
 
       "legacyDirectory": "nowledge-mem-codex-prompts",

--- a/nowledge-mem-codex-plugin/.codex-plugin/plugin.json
+++ b/nowledge-mem-codex-plugin/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "nowledge-mem",
-  "version": "0.1.26",
+  "version": "0.1.27",
   "description": "Your Codex agent remembers past decisions, finds relevant context, and learns from every session, across all your AI tools.",
   "skills": "./skills/",
   "mcpServers": "./.mcp.json",

--- a/nowledge-mem-codex-plugin/CHANGELOG.md
+++ b/nowledge-mem-codex-plugin/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [0.1.27] - 2026-07-14
+
+### Improved
+
+- Codex MCP requests now carry `NMEM_AGENT_ID`, `NMEM_HOST_AGENT_ID`, and `NMEM_SPACE` through Codex's native environment-backed HTTP headers. Named agents such as Raft workers can use their own context, attribution, and default Space without duplicating identity setup in Mem.
+- Hook setup now installs the managed local MCP override even when localhost needs no API key, because the plugin-bundled static endpoint cannot resolve per-agent environment values. Existing user-owned MCP blocks remain untouched.
+
 ## [0.1.26] - 2026-07-14
 
 ### Added

--- a/nowledge-mem-codex-plugin/README.md
+++ b/nowledge-mem-codex-plugin/README.md
@@ -161,9 +161,9 @@ Use `-p /path/to/project` instead of `--all-projects` when you only want one pro
 
 On current Codex builds, enabled plugins contribute `hooks/hooks.json` automatically. Older builds may still need `plugin_hooks = true`; the setup script detects that from `codex features list`. In `/hooks`, the Nowledge Mem SessionStart, UserPromptSubmit, and Stop hooks should be both enabled and trusted.
 
-The same setup also asks `nmem` for a Codex MCP config. If `nmem` has a saved API key or a non-default endpoint, the script writes a managed `mcp_servers.nowledge-mem` block into `~/.codex/config.toml`. This is the safest path for remote Mem and for localhost setups that require auth.
+The same setup asks `nmem` for a Codex MCP config and writes a managed `mcp_servers.nowledge-mem` block into `~/.codex/config.toml`. Besides remote URL and authentication, this block maps `NMEM_AGENT_ID`, `NMEM_HOST_AGENT_ID`, and `NMEM_SPACE` through Codex's native environment-backed HTTP headers. A named Raft/Codex worker therefore appears automatically under **Context → AI Identities**, and its MCP searches and writes use that identity's configured default Space. Existing user-owned MCP blocks are never replaced.
 
-The package already includes a local Nowledge Mem MCP server at `http://127.0.0.1:14242/mcp/`. Codex uses your `~/.codex/config.toml` entry if you define `mcp_servers.nowledge-mem` yourself, so remote Mem and custom local ports stay explicit.
+The package still includes a local fallback MCP server at `http://127.0.0.1:14242/mcp/`, but its static plugin manifest cannot resolve process-specific environment values. Rerun `scripts/install_hooks.py` after updating the plugin so named agents receive the identity-aware managed block.
 
 If you prefer to copy a bundled example, see [`codex.config.example.toml`](./codex.config.example.toml).
 

--- a/nowledge-mem-codex-plugin/codex.config.example.toml
+++ b/nowledge-mem-codex-plugin/codex.config.example.toml
@@ -1,8 +1,8 @@
 # Recommended local setup for Codex.
 #
-# The plugin package already bundles a local Nowledge Mem MCP server at
-# http://127.0.0.1:14242/mcp/. Add an mcp_servers.nowledge-mem block only when
-# you need to override that default, for example remote Mem or a custom port.
+# The setup script writes a managed mcp_servers.nowledge-mem block so Codex can
+# resolve per-agent NMEM_AGENT_ID/NMEM_HOST_AGENT_ID/NMEM_SPACE environment
+# values. The plugin-bundled local endpoint remains a static fallback.
 
 [features]
 plugins = true
@@ -43,6 +43,7 @@ enabled = true
 #
 # [mcp_servers.nowledge-mem]
 # url = "https://mem.example.com/mcp/"
+# env_http_headers = { "X-Nmem-Agent-Id" = "NMEM_AGENT_ID", "X-Nmem-Host-Agent-Id" = "NMEM_HOST_AGENT_ID", "X-Nmem-Space-Id" = "NMEM_SPACE" }
 #
 # [mcp_servers.nowledge-mem.http_headers]
 # APP = "Codex"

--- a/nowledge-mem-codex-plugin/scripts/install_hooks.py
+++ b/nowledge-mem-codex-plugin/scripts/install_hooks.py
@@ -429,15 +429,6 @@ def _remove_managed_mcp_block(lines: list[str]) -> tuple[list[str], bool, bool]:
     return cleaned, removed, False
 
 
-def _should_install_mcp_override(payload: dict) -> bool:
-    if payload.get("apiKeyConfigured"):
-        return True
-    endpoint = str(payload.get("endpoint") or "")
-    if endpoint and endpoint != "http://127.0.0.1:14242/mcp/":
-        return True
-    return False
-
-
 def _write_codex_config_lines(
     lines: list[str],
     *,
@@ -497,23 +488,11 @@ def _install_mcp_config_from_payload(payload: dict) -> bool:
         )
         return False
 
-    if not _should_install_mcp_override(payload):
-        print(
-            "Codex MCP config: using the plugin-bundled local endpoint. "
-            "If 'codex mcp list' shows Not logged in, ensure nmem is up to date, "
-            "install or update the CLI from the Nowledge Mem desktop app, refresh "
-            "desktop credentials if needed, then rerun this setup.",
-            file=sys.stderr,
-        )
-        if removed_managed_block:
-            _write_codex_config_lines(lines, restrict_permissions=False)
-            return True
-        return False
-
     if _has_existing_unmanaged_nowledge_mcp(lines):
         print(
             "Codex MCP config: existing mcp_servers.nowledge-mem block left unchanged. "
-            "Replace it with 'nmem config mcp show --host codex' if Codex MCP reports Not logged in.",
+            "Replace it with 'nmem config mcp show --host codex' to carry per-agent "
+            "NMEM_AGENT_ID/NMEM_HOST_AGENT_ID values into MCP requests.",
             file=sys.stderr,
         )
         return False

--- a/nowledge-mem-codex-plugin/scripts/validate-plugin.mjs
+++ b/nowledge-mem-codex-plugin/scripts/validate-plugin.mjs
@@ -8,7 +8,7 @@ import { fileURLToPath } from "node:url";
 const scriptDir = path.dirname(fileURLToPath(import.meta.url));
 const pluginRoot = path.resolve(scriptDir, "..");
 const repoRoot = path.resolve(pluginRoot, "..");
-const expectedVersion = "0.1.26";
+const expectedVersion = "0.1.27";
 
 const fail = (message) => {
   console.error(`FAIL: ${message}`);

--- a/nowledge-mem-codex-plugin/tests/test_codex_plugin.py
+++ b/nowledge-mem-codex-plugin/tests/test_codex_plugin.py
@@ -1122,7 +1122,7 @@ class InstallHookTests(unittest.TestCase):
         self.assertNotIn(self.module.MCP_MANAGED_BEGIN, updated)
         self.assertNotIn("nmem_test", updated)
 
-    def test_install_codex_mcp_config_skips_default_local_without_key(self):
+    def test_install_codex_mcp_config_writes_identity_aware_local_override(self):
         payload = {
             "apiKeyConfigured": False,
             "endpoint": "http://127.0.0.1:14242/mcp/",
@@ -1131,6 +1131,7 @@ class InstallHookTests(unittest.TestCase):
                 [
                     "[mcp_servers.nowledge-mem]",
                     'url = "http://127.0.0.1:14242/mcp/"',
+                    'env_http_headers = { "X-Nmem-Agent-Id" = "NMEM_AGENT_ID" }',
                     "",
                     "[mcp_servers.nowledge-mem.http_headers]",
                     'APP = "Codex"',
@@ -1139,11 +1140,13 @@ class InstallHookTests(unittest.TestCase):
         }
 
         with mock.patch.object(self.module, "_load_codex_mcp_payload", return_value=payload):
-            self.assertFalse(self.module.install_codex_mcp_config())
+            self.assertTrue(self.module.install_codex_mcp_config())
 
-        self.assertFalse(self.module.CONFIG_FILE.exists())
+        updated = self.module.CONFIG_FILE.read_text(encoding="utf-8")
+        self.assertIn(self.module.MCP_MANAGED_BEGIN, updated)
+        self.assertIn('"X-Nmem-Agent-Id" = "NMEM_AGENT_ID"', updated)
 
-    def test_install_codex_mcp_config_removes_stale_managed_override(self):
+    def test_install_codex_mcp_config_replaces_stale_managed_override(self):
         self.module.CONFIG_FILE.parent.mkdir(parents=True, exist_ok=True)
         self.module.CONFIG_FILE.write_text(
             "\n".join(
@@ -1171,6 +1174,7 @@ class InstallHookTests(unittest.TestCase):
                 [
                     "[mcp_servers.nowledge-mem]",
                     'url = "http://127.0.0.1:14242/mcp/"',
+                    'env_http_headers = { "X-Nmem-Agent-Id" = "NMEM_AGENT_ID" }',
                     "",
                     "[mcp_servers.nowledge-mem.http_headers]",
                     'APP = "Codex"',
@@ -1183,7 +1187,8 @@ class InstallHookTests(unittest.TestCase):
 
         updated = self.module.CONFIG_FILE.read_text(encoding="utf-8")
         self.assertIn("[features]\nhooks = true", updated)
-        self.assertNotIn(self.module.MCP_MANAGED_BEGIN, updated)
+        self.assertIn(self.module.MCP_MANAGED_BEGIN, updated)
+        self.assertIn('"X-Nmem-Agent-Id" = "NMEM_AGENT_ID"', updated)
         self.assertNotIn("old_key", updated)
 
     def test_install_codex_mcp_config_preserves_unterminated_managed_block(self):

--- a/tests/plugin_e2e/test_key_plugins_e2e.py
+++ b/tests/plugin_e2e/test_key_plugins_e2e.py
@@ -354,7 +354,7 @@ def test_key_plugin_static_contracts_are_declared():
     codex_save_hook = (CODEX_PLUGIN / "hooks" / "nmem-stop-save.py").read_text(encoding="utf-8")
     codex_runtime = (CODEX_PLUGIN / "hooks" / "nmem_runtime.py").read_text(encoding="utf-8")
     assert codex_manifest["name"] == "nowledge-mem"
-    assert codex_manifest["version"] == "0.1.26"
+    assert codex_manifest["version"] == "0.1.27"
     assert registry_by_id["codex-cli"]["version"] == codex_manifest["version"]
     assert codex_manifest["skills"] == "./skills/"
     assert codex_manifest["mcpServers"] == "./.mcp.json"


### PR DESCRIPTION
## What changed

- Map `NMEM_AGENT_ID`, `NMEM_HOST_AGENT_ID`, and `NMEM_SPACE` into Codex HTTP MCP requests through `env_http_headers`.
- Install the managed identity-aware MCP override for local as well as remote Mem connections.
- Preserve user-owned MCP blocks and explain the one-time setup rerun after updating.

## Why

Raft can launch named Codex workers such as Cloudy, and the hooks already received that worker identity. The plugin's static MCP manifest could not resolve per-process environment values, so MCP context, search, and writes silently fell back to the default identity.

This change carries the stable worker identity across the host boundary without treating it as authentication or overwriting user configuration.

## Validation

- `uv run --with pytest pytest tests/plugin_e2e -q` (67 passed, 6 skipped)
- `node nowledge-mem-codex-plugin/scripts/validate-plugin.mjs`
- Codex plugin unit suite (55 passed)
- Generated TOML parsed with Python `tomllib`

Depends on the matching server-side identity enrollment and routing change in nowledge-co/mem#342.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Codex MCP requests now preserve agent identity and Space context through environment-backed headers.
  * Managed MCP configuration is installed even without a localhost API key.
  * Existing user-managed MCP configurations remain unchanged.
  * Local fallback MCP support remains available.

* **Documentation**
  * Updated setup guidance and configuration examples for identity-aware MCP connections.

* **Chores**
  * Released Codex integration version 0.1.27.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->