### PR TITLE
Fix Codex Stop capture on Windows

### DIFF
--- a/integrations.json
+++ b/integrations.json
@@ -229,7 +229,7 @@
       "name": "Codex",
       "category": "coding",
       "type": "plugin",
-      "version": "0.1.27",
+      "version": "0.1.28",
       "directory": "nowledge-mem-codex-plugin",
 
       "legacyDirectory": "nowledge-mem-codex-prompts",

--- a/nowledge-mem-codex-plugin/.codex-plugin/plugin.json
+++ b/nowledge-mem-codex-plugin/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "nowledge-mem",
-  "version": "0.1.27",
+  "version": "0.1.28",
   "description": "Your Codex agent remembers past decisions, finds relevant context, and learns from every session, across all your AI tools.",
   "skills": "./skills/",
   "mcpServers": "./.mcp.json",

--- a/nowledge-mem-codex-plugin/CHANGELOG.md
+++ b/nowledge-mem-codex-plugin/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [0.1.28] - 2026-07-16
+
+### Fixed
+
+- Codex Stop capture once again launches the installed `nmem.cmd` directly on native Windows. This removes a redundant `cmd.exe /s /c` layer that could turn a correctly quoted path under `Program Files` into a literal command name and prevent the thread from being saved; WSL keeps its explicit Windows bridge.
+
 ## [0.1.27] - 2026-07-14
 
 ### Improved

--- a/nowledge-mem-codex-plugin/hooks/nmem_runtime.py
+++ b/nowledge-mem-codex-plugin/hooks/nmem_runtime.py
@@ -59,8 +59,8 @@ def cmd_exe_path(path: str) -> str:
 
 def build_nmem_command(nmem: str, *args: str) -> list[str]:
     if nmem.lower().endswith((".cmd", ".bat")):
-        command = subprocess.list2cmdline([cmd_exe_path(nmem), *args])
         if os.name == "nt":
-            return [os.environ.get("COMSPEC", "cmd.exe"), "/d", "/s", "/c", command]
+            return [nmem, *args]
+        command = subprocess.list2cmdline([cmd_exe_path(nmem), *args])
         return ["cmd.exe", "/d", "/s", "/c", command]
     return [nmem, *args]

--- a/nowledge-mem-codex-plugin/scripts/validate-plugin.mjs
+++ b/nowledge-mem-codex-plugin/scripts/validate-plugin.mjs
@@ -8,7 +8,7 @@ import { fileURLToPath } from "node:url";
 const scriptDir = path.dirname(fileURLToPath(import.meta.url));
 const pluginRoot = path.resolve(scriptDir, "..");
 const repoRoot = path.resolve(pluginRoot, "..");
-const expectedVersion = "0.1.27";
+const expectedVersion = "0.1.28";
 
 const fail = (message) => {
   console.error(`FAIL: ${message}`);

--- a/nowledge-mem-codex-plugin/tests/test_codex_plugin.py
+++ b/nowledge-mem-codex-plugin/tests/test_codex_plugin.py
@@ -601,12 +601,8 @@ class RuntimeHelperTests(unittest.TestCase):
         self.assertEqual(command[:4], ["cmd.exe", "/d", "/s", "/c"])
         self.assertIn(r"C:\Users\test\AppData\Local\Nowledge Mem\cli\nmem.cmd", command[4])
 
-    def test_native_windows_batch_shim_uses_comspec(self):
-        with mock.patch.object(self.module.os, "name", "nt"), mock.patch.dict(
-            self.module.os.environ,
-            {"COMSPEC": r"C:\Windows\System32\cmd.exe"},
-            clear=False,
-        ):
+    def test_native_windows_batch_shim_executes_directly(self):
+        with mock.patch.object(self.module.os, "name", "nt"):
             command = self.module.build_nmem_command(
                 r"C:\Program Files\Nowledge Mem\nmem.bat",
                 "--json",
@@ -614,10 +610,13 @@ class RuntimeHelperTests(unittest.TestCase):
             )
 
         self.assertEqual(
-            command[:4],
-            [r"C:\Windows\System32\cmd.exe", "/d", "/s", "/c"],
+            command,
+            [
+                r"C:\Program Files\Nowledge Mem\nmem.bat",
+                "--json",
+                "context",
+            ],
         )
-        self.assertIn(r'"C:\Program Files\Nowledge Mem\nmem.bat"', command[4])
 
 
 class LauncherTests(unittest.TestCase):

--- a/nowledge-mem-codex-plugin/tests/test_codex_plugin.py
+++ b/nowledge-mem-codex-plugin/tests/test_codex_plugin.py
@@ -602,11 +602,13 @@ class RuntimeHelperTests(unittest.TestCase):
         self.assertIn(r"C:\Users\test\AppData\Local\Nowledge Mem\cli\nmem.cmd", command[4])
 
     def test_native_windows_batch_shim_executes_directly(self):
+        metacharacters = "safe&pipe|percent%caret^bang!"
         with mock.patch.object(self.module.os, "name", "nt"):
             command = self.module.build_nmem_command(
                 r"C:\Program Files\Nowledge Mem\nmem.bat",
                 "--json",
                 "context",
+                metacharacters,
             )
 
         self.assertEqual(
@@ -615,6 +617,7 @@ class RuntimeHelperTests(unittest.TestCase):
                 r"C:\Program Files\Nowledge Mem\nmem.bat",
                 "--json",
                 "context",
+                metacharacters,
             ],
         )
 

--- a/tests/plugin_e2e/test_key_plugins_e2e.py
+++ b/tests/plugin_e2e/test_key_plugins_e2e.py
@@ -354,7 +354,7 @@ def test_key_plugin_static_contracts_are_declared():
     codex_save_hook = (CODEX_PLUGIN / "hooks" / "nmem-stop-save.py").read_text(encoding="utf-8")
     codex_runtime = (CODEX_PLUGIN / "hooks" / "nmem_runtime.py").read_text(encoding="utf-8")
     assert codex_manifest["name"] == "nowledge-mem"
-    assert codex_manifest["version"] == "0.1.27"
+    assert codex_manifest["version"] == "0.1.28"
     assert registry_by_id["codex-cli"]["version"] == codex_manifest["version"]
     assert codex_manifest["skills"] == "./skills/"
     assert codex_manifest["mcpServers"] == "./.mcp.json"


### PR DESCRIPTION
Restores direct native launch for `nmem.cmd`/`.bat` in the Codex hook runtime. The shared-runtime extraction had reintroduced a redundant `cmd.exe /s /c` layer, causing paths under `Program Files` to be interpreted as quoted command names.

Validation:
- 55 Codex plugin unit tests
- 67 community plugin contract tests (6 skipped)
- plugin validator
- real Windows `nmem.cmd` launch from `C:\Program Files\Nowledge Mem\cli`, including metacharacter-safe argv handling
- WSL bridge regression remains covered

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved Codex Stop capture on native Windows by launching the installed command directly, avoiding path-quoting issues (especially under `Program Files`) that could interfere with thread saving.

- **Release**
  - Updated the Codex CLI integration and the Codex memory plugin to version **0.1.28**.

- **Tests**
  - Adjusted Windows command execution expectations and plugin version contract checks to match the **0.1.28** release.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->