### PR TITLE
fix(claude-code-plugin): resolve project root from CLAUDE_PROJECT_DIR before payload cwd

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -12,7 +12,7 @@
     {
       "name": "nowledge-mem",
       "description": "Personal knowledge graph for Claude Code and Grok — remembers decisions, searches past work, captures sessions",
-      "version": "0.7.19",
+      "version": "0.7.20",
       "author": {
         "name": "Nowledge Labs",
         "url": "https://www.nowledge-labs.ai/",

--- a/integrations.json
+++ b/integrations.json
@@ -21,7 +21,7 @@
       "name": "Claude Code",
       "category": "coding",
       "type": "plugin",
-      "version": "0.7.19",
+      "version": "0.7.20",
       "directory": "nowledge-mem-claude-code-plugin",
       "transport": "cli",
       "capabilities": {
@@ -73,7 +73,7 @@
       "name": "Grok Build",
       "category": "coding",
       "type": "plugin",
-      "version": "0.7.19",
+      "version": "0.7.20",
       "directory": "nowledge-mem-claude-code-plugin",
       "transport": "cli",
       "capabilities": {

--- a/nowledge-mem-claude-code-plugin/.claude-plugin/plugin.json
+++ b/nowledge-mem-claude-code-plugin/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "nowledge-mem",
   "description": "Personal knowledge graph for Claude Code and Grok \u2014 remembers decisions, searches past work, captures sessions",
-  "version": "0.7.19",
+  "version": "0.7.20",
   "author": {
     "name": "Nowledge Labs",
     "email": "hello@nowledge-labs.ai",

--- a/nowledge-mem-claude-code-plugin/CHANGELOG.md
+++ b/nowledge-mem-claude-code-plugin/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to the Nowledge Mem Claude Code plugin will be documented in
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.7.20] - 2026-08-06
 
 ### Fixed
 

--- a/nowledge-mem-claude-code-plugin/CHANGELOG.md
+++ b/nowledge-mem-claude-code-plugin/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to the Nowledge Mem Claude Code plugin will be documented in
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- Session capture now resolves the project root from `CLAUDE_PROJECT_DIR` (then `GROK_WORKSPACE_ROOT`) before falling back to the hook payload `cwd`. The payload `cwd` samples the directory at hook time, so a mid-session `cd` into a subdirectory made the save fail with "session directory not found" / "No valid conversation sessions found" while exiting 0 (686 silent failures observed on 0.7.18 and earlier, 162 more in the 0.7.19 background log).
+
 ## [0.7.19] - 2026-07-27
 
 ### Fixed

--- a/nowledge-mem-claude-code-plugin/scripts/nmem-hook-save.py
+++ b/nowledge-mem-claude-code-plugin/scripts/nmem-hook-save.py
@@ -78,9 +78,9 @@ def _background_session_key(payload: dict[str, Any]) -> str:
         _payload_value(payload, "transcript_path", "transcriptPath") or ""
     )
     cwd = (
-        _payload_value(payload, "cwd")
+        os.environ.get("CLAUDE_PROJECT_DIR", "").strip()
         or os.environ.get("GROK_WORKSPACE_ROOT", "").strip()
-        or os.environ.get("CLAUDE_PROJECT_DIR", "").strip()
+        or _payload_value(payload, "cwd")
     )
     if session_id:
         identity = {"session_id": session_id}
@@ -388,9 +388,9 @@ def _build_command(
         args.extend(["--session-id", session_id])
 
     cwd = (
-        _payload_value(payload, "cwd")
+        os.environ.get("CLAUDE_PROJECT_DIR", "").strip()
         or os.environ.get("GROK_WORKSPACE_ROOT", "").strip()
-        or os.environ.get("CLAUDE_PROJECT_DIR", "").strip()
+        or _payload_value(payload, "cwd")
     )
     if cwd:
         project_path = Path(cwd).expanduser()

--- a/nowledge-mem-claude-code-plugin/tests/test_nmem_hook_save.py
+++ b/nowledge-mem-claude-code-plugin/tests/test_nmem_hook_save.py
@@ -1,4 +1,5 @@
 import importlib.util
+import hashlib
 import json
 import os
 import time
@@ -533,18 +534,54 @@ def json_line(value):
     return json.dumps(value, separators=(",", ":"))
 
 
+def expected_background_key(runtime, **identity):
+    encoded = json.dumps(
+        {"runtime": runtime, **identity},
+        sort_keys=True,
+        separators=(",", ":"),
+    )
+    return hashlib.sha256(encoded.encode("utf-8")).hexdigest()
+
+
 def test_build_command_prefers_claude_project_dir_over_payload_cwd(tmp_path):
     project = tmp_path / "project"
+    grok_workspace = tmp_path / "grok-workspace"
     subdir = project / "deep" / "subdir"
     subdir.mkdir(parents=True)
+    grok_workspace.mkdir()
 
-    with patch.dict(os.environ, {"CLAUDE_PROJECT_DIR": str(project)}):
+    with patch.dict(
+        os.environ,
+        {
+            "CLAUDE_PROJECT_DIR": str(project),
+            "GROK_WORKSPACE_ROOT": str(grok_workspace),
+        },
+    ):
         command = nmem_hook_save._build_command(
             "/usr/local/bin/nmem",
             {"session_id": "session-1", "cwd": str(subdir)},
         )
 
     assert command[command.index("--project") + 1] == str(project.resolve())
+
+
+def test_background_session_key_prefers_claude_project_dir_over_grok_and_payload_cwd(tmp_path):
+    project = tmp_path / "project"
+    grok_workspace = tmp_path / "grok-workspace"
+    payload_cwd = project / "deep" / "subdir"
+    payload_cwd.mkdir(parents=True)
+    grok_workspace.mkdir()
+
+    with patch.dict(
+        os.environ,
+        {
+            "CLAUDE_PROJECT_DIR": str(project),
+            "GROK_WORKSPACE_ROOT": str(grok_workspace),
+        },
+    ), patch.object(nmem_hook_save, "_host_runtime", return_value="claude-code"):
+        key = nmem_hook_save._background_session_key({"cwd": str(payload_cwd)})
+
+    assert key == expected_background_key("claude-code", cwd=str(project))
 
 
 def test_build_command_prefers_grok_workspace_root_over_payload_cwd(tmp_path):
@@ -563,6 +600,20 @@ def test_build_command_prefers_grok_workspace_root_over_payload_cwd(tmp_path):
     assert command[command.index("--project") + 1] == str(workspace.resolve())
 
 
+def test_background_session_key_prefers_grok_workspace_root_over_payload_cwd(tmp_path):
+    workspace = tmp_path / "workspace"
+    subdir = tmp_path / "elsewhere"
+    workspace.mkdir()
+    subdir.mkdir()
+
+    with patch.dict(os.environ, {"GROK_WORKSPACE_ROOT": str(workspace)}), \
+        patch.object(nmem_hook_save, "_host_runtime", return_value="grok"):
+        os.environ.pop("CLAUDE_PROJECT_DIR", None)
+        key = nmem_hook_save._background_session_key({"cwd": str(subdir)})
+
+    assert key == expected_background_key("grok", cwd=str(workspace))
+
+
 def test_build_command_falls_back_to_payload_cwd_without_env(tmp_path):
     with patch.dict(os.environ):
         os.environ.pop("CLAUDE_PROJECT_DIR", None)
@@ -573,3 +624,13 @@ def test_build_command_falls_back_to_payload_cwd_without_env(tmp_path):
         )
 
     assert command[command.index("--project") + 1] == str(tmp_path.resolve())
+
+
+def test_background_session_key_falls_back_to_payload_cwd_without_env(tmp_path):
+    with patch.dict(os.environ), \
+        patch.object(nmem_hook_save, "_host_runtime", return_value="claude-code"):
+        os.environ.pop("CLAUDE_PROJECT_DIR", None)
+        os.environ.pop("GROK_WORKSPACE_ROOT", None)
+        key = nmem_hook_save._background_session_key({"cwd": str(tmp_path)})
+
+    assert key == expected_background_key("claude-code", cwd=str(tmp_path))

--- a/nowledge-mem-claude-code-plugin/tests/test_nmem_hook_save.py
+++ b/nowledge-mem-claude-code-plugin/tests/test_nmem_hook_save.py
@@ -531,3 +531,45 @@ def json_line(value):
     import json
 
     return json.dumps(value, separators=(",", ":"))
+
+
+def test_build_command_prefers_claude_project_dir_over_payload_cwd(tmp_path):
+    project = tmp_path / "project"
+    subdir = project / "deep" / "subdir"
+    subdir.mkdir(parents=True)
+
+    with patch.dict(os.environ, {"CLAUDE_PROJECT_DIR": str(project)}):
+        command = nmem_hook_save._build_command(
+            "/usr/local/bin/nmem",
+            {"session_id": "session-1", "cwd": str(subdir)},
+        )
+
+    assert command[command.index("--project") + 1] == str(project.resolve())
+
+
+def test_build_command_prefers_grok_workspace_root_over_payload_cwd(tmp_path):
+    workspace = tmp_path / "workspace"
+    subdir = tmp_path / "elsewhere"
+    workspace.mkdir()
+    subdir.mkdir()
+
+    with patch.dict(os.environ, {"GROK_WORKSPACE_ROOT": str(workspace)}):
+        os.environ.pop("CLAUDE_PROJECT_DIR", None)
+        command = nmem_hook_save._build_command(
+            "/usr/local/bin/nmem",
+            {"session_id": "session-1", "cwd": str(subdir)},
+        )
+
+    assert command[command.index("--project") + 1] == str(workspace.resolve())
+
+
+def test_build_command_falls_back_to_payload_cwd_without_env(tmp_path):
+    with patch.dict(os.environ):
+        os.environ.pop("CLAUDE_PROJECT_DIR", None)
+        os.environ.pop("GROK_WORKSPACE_ROOT", None)
+        command = nmem_hook_save._build_command(
+            "/usr/local/bin/nmem",
+            {"session_id": "session-1", "cwd": str(tmp_path)},
+        )
+
+    assert command[command.index("--project") + 1] == str(tmp_path.resolve())

--- a/nowledge-mem-hermes/tests/test_installer_contract.py
+++ b/nowledge-mem-hermes/tests/test_installer_contract.py
@@ -68,4 +68,8 @@ def test_resolve_nmem_finds_common_user_bin_when_path_is_reduced(monkeypatch, tm
     monkeypatch.delenv("NMEM_CLI", raising=False)
     monkeypatch.setattr(client.sys, "platform", "darwin")
 
-    assert client._resolve_nmem() == str(exe)
+    resolved = client._resolve_nmem()
+    assert resolved is not None
+    assert os.path.normcase(os.path.normpath(resolved)) == os.path.normcase(
+        os.path.normpath(str(exe))
+    )

--- a/nowledge-mem-hermes/tests/test_installer_contract.py
+++ b/nowledge-mem-hermes/tests/test_installer_contract.py
@@ -47,7 +47,9 @@ def test_resolve_nmem_honors_explicit_cli_path_when_path_is_reduced(monkeypatch,
     monkeypatch.setenv("PATH", "")
     monkeypatch.setenv("NMEM_CLI_PATH", str(exe))
 
-    assert client._resolve_nmem() == str(exe)
+    assert os.path.normcase(os.path.normpath(client._resolve_nmem() or "")) == os.path.normcase(
+        os.path.normpath(str(exe))
+    )
 
 
 def test_resolve_nmem_finds_common_user_bin_when_path_is_reduced(monkeypatch, tmp_path: Path) -> None:

--- a/nowledge-mem-hermes/tests/test_installer_contract.py
+++ b/nowledge-mem-hermes/tests/test_installer_contract.py
@@ -60,6 +60,7 @@ def test_resolve_nmem_finds_common_user_bin_when_path_is_reduced(monkeypatch, tm
 
     monkeypatch.setenv("PATH", "")
     monkeypatch.setenv("HOME", str(home))
+    monkeypatch.setenv("USERPROFILE", str(home))
     monkeypatch.delenv("NMEM_CLI_PATH", raising=False)
     monkeypatch.delenv("NMEM_BIN", raising=False)
     monkeypatch.delenv("NMEM_CLI", raising=False)

--- a/nowledge-mem-hermes/tests/test_installer_contract.py
+++ b/nowledge-mem-hermes/tests/test_installer_contract.py
@@ -64,6 +64,5 @@ def test_resolve_nmem_finds_common_user_bin_when_path_is_reduced(monkeypatch, tm
     monkeypatch.delenv("NMEM_BIN", raising=False)
     monkeypatch.delenv("NMEM_CLI", raising=False)
     monkeypatch.setattr(client.sys, "platform", "darwin")
-    monkeypatch.setattr(client.os, "name", "posix", raising=False)
 
     assert client._resolve_nmem() == str(exe)

--- a/tests/plugin_e2e/test_key_plugins_e2e.py
+++ b/tests/plugin_e2e/test_key_plugins_e2e.py
@@ -332,7 +332,7 @@ def test_key_plugin_static_contracts_are_declared():
     claude_read_skill = (CLAUDE_PLUGIN / "skills" / "read-working-memory" / "SKILL.md").read_text(encoding="utf-8")
     claude_search_skill = (CLAUDE_PLUGIN / "skills" / "search-memory" / "SKILL.md").read_text(encoding="utf-8")
     assert claude_manifest["name"] == "nowledge-mem"
-    assert claude_manifest["version"] == "0.7.19"
+    assert claude_manifest["version"] == "0.7.20"
     assert claude_marketplace_plugin["version"] == claude_manifest["version"]
     assert registry_by_id["claude-code"]["version"] == claude_manifest["version"]
     assert registry_by_id["grok"]["version"] == claude_manifest["version"]


### PR DESCRIPTION
## Problem

The stop/compact save hook (`nmem-hook-save.py`) resolves the project root in this order: payload `cwd` → `GROK_WORKSPACE_ROOT` → `CLAUDE_PROJECT_DIR`.

Payload `cwd` samples the working directory **at hook time**. Any mid-session `cd` into a subdirectory (e.g. `~/.claude/hooks`, a scripts folder) makes the hook pass that subdirectory as `--project`, so nmem looks for Claude Code sessions under it and fails with:

- `Claude Code session directory not found for project: <subdir>`
- `No valid conversation sessions found in: ...`

The hook still exits 0, and since 0.7.19 the capture runs in a detached background worker, so the failure is invisible in transcripts — it only appears in `$TMPDIR/nowledge-mem/hook-save/background.log`.

Observed on one machine: **686 failed runs on ≤0.7.18, 162 on 0.7.19, 0 successes across both** (error split: 116 × "session directory not found", 27 × "No valid conversation sessions found" in the 0.7.19 log window).

## Fix

Swap the priority at both call sites: `CLAUDE_PROJECT_DIR` → `GROK_WORKSPACE_ROOT` → payload `cwd`. The env vars are stable for the whole session; the payload cwd remains as a fallback for env-less callers.

## Tests

- 2 new tests that are red on the old order (CLAUDE_PROJECT_DIR wins over payload cwd; GROK_WORKSPACE_ROOT wins over payload cwd)
- 1 regression test guarding the env-less payload-cwd fallback
- Full suite: 30/30 green

## Verification on a live machine

After applying the same change to the installed 0.7.19 cache: a probe payload with a bad subdirectory cwd plus `CLAUDE_PROJECT_DIR` set saves the real session (thread readable via `nmem t list`); with the env removed the old error class reproduces, confirming the fallback path is intact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved session capture by resolving the project location more reliably.
  * Project-specific settings now take precedence, with fallback support when unavailable.

* **Tests**
  * Added coverage for project-location precedence and fallback behavior.
  * Improved installer validation across supported platforms.

* **Documentation**
  * Updated the changelog with details of the session-capture fix.

* **Release**
  * Updated the plugin and integrations to version 0.7.20.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->