### PR TITLE
fix(grok): capture lifecycle sessions

### DIFF
--- a/nowledge-mem-claude-code-plugin/CHANGELOG.md
+++ b/nowledge-mem-claude-code-plugin/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to the Nowledge Mem Claude Code plugin will be documented in
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- Grok Build capture now also runs on `SessionEnd` and `SubagentStop`, using the same detached, idempotent save worker as `Stop`. This gives remote Grok sessions a final sync opportunity on process exit and captures subagent sessions without blocking Grok's gate hooks.
+
 ## [0.7.20] - 2026-08-06
 
 ### Fixed

--- a/nowledge-mem-claude-code-plugin/README.md
+++ b/nowledge-mem-claude-code-plugin/README.md
@@ -82,10 +82,12 @@ This calls the Windows `nmem` via interop — no extra setup or network configur
 | `UserPromptSubmit` | Every user message | Injects search/save syntax as context |
 | `PreCompact` | Before manual or automatic compaction | Saves the exact Claude Code or Grok Build session by hook `session_id` before context is compressed |
 | `Stop` | Model finishes responding | Captures session to knowledge graph |
+| `SubagentStop` | Grok Build subagent finishes | Captures the subagent session without blocking the subagent gate |
+| `SessionEnd` | Grok Build process exits | Performs a final best-effort session capture after the last turn |
 
 The `SessionStart` hook tries `nmem context` first so Claude receives owner identity, AI Identity, active space, active rules, Working Memory, and KFS paths when the installed CLI supports it. It falls back to `nmem wm read`, then to `~/ai-now/memory.md` only as the **Default-space** compatibility path.
 
-The `PreCompact` hook runs the same client-side thread save before the host compresses context. The `Stop` hook runs it again after every response with a bounded retry window, so short transcript-flush delays do not turn into silent no-op saves. Claude Code uses `nmem t save --from claude-code`; Grok Build uses `nmem t save --from grok`. Both paths pass the host session id into `nmem t save`, so concurrent sessions in the same project do not have to rely on "latest session" guessing.
+The `PreCompact` hook runs the same client-side thread save before the host compresses context. The `Stop`, `SubagentStop`, and `SessionEnd` hooks run it again through a detached worker with a bounded retry window, so short transcript-flush delays or process exit do not turn into silent no-op saves. Claude Code uses `nmem t save --from claude-code`; Grok Build uses `nmem t save --from grok`. Both paths pass the host session id into `nmem t save`, so concurrent sessions in the same project do not have to rely on "latest session" guessing.
 
 If the desktop app's Claude Code file watcher is also enabled, you can leave it on. The watcher and plugin hooks converge on the same `claude-code-<sessionId>` thread, so repeated saves update the existing thread instead of creating a second one.
 
@@ -103,7 +105,7 @@ nmem config client set api-key your-key
 
 That writes the shared local client config used by `nmem` and the plugin. You can also use environment variables (`NMEM_API_URL`, `NMEM_API_KEY`) for temporary overrides.
 
-In remote mode, the Stop and PreCompact hooks still read Claude session files locally through `nmem t save --from claude-code` on the machine where Claude Code is running, then upload the normalized messages to Mem. The remote Mem server does not need direct access to your `~/.claude` directory.
+In remote mode, the lifecycle hooks still read local host session files through `nmem t save --from claude-code` or `nmem t save --from grok` on the machine where the coding agent is running, then upload the normalized messages to Mem. The remote Mem server does not need direct access to your `~/.claude` or Grok session directory.
 
 ### Import older sessions
 

--- a/nowledge-mem-claude-code-plugin/hooks/hooks.json
+++ b/nowledge-mem-claude-code-plugin/hooks/hooks.json
@@ -53,6 +53,28 @@
           }
         ]
       }
+    ],
+    "SubagentStop": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "PY=\"$(command -v python3 || command -v python || true)\"; ROOT=\"${GROK_PLUGIN_ROOT:-${CLAUDE_PLUGIN_ROOT:-}}\"; SCRIPT=\"$ROOT/scripts/nmem-hook-save.py\"; [ -n \"$PY\" ] && [ -f \"$SCRIPT\" ] && \"$PY\" \"$SCRIPT\" --event subagent-stop --detach || true",
+            "timeout": 5
+          }
+        ]
+      }
+    ],
+    "SessionEnd": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "PY=\"$(command -v python3 || command -v python || true)\"; ROOT=\"${GROK_PLUGIN_ROOT:-${CLAUDE_PLUGIN_ROOT:-}}\"; SCRIPT=\"$ROOT/scripts/nmem-hook-save.py\"; [ -n \"$PY\" ] && [ -f \"$SCRIPT\" ] && \"$PY\" \"$SCRIPT\" --event session-end --detach || true",
+            "timeout": 5
+          }
+        ]
+      }
     ]
   }
 }

--- a/nowledge-mem-claude-code-plugin/scripts/nmem-hook-save.py
+++ b/nowledge-mem-claude-code-plugin/scripts/nmem-hook-save.py
@@ -681,7 +681,7 @@ def main() -> int:
     parser.add_argument(
         "--event",
         default="hook",
-        choices=["pre-compact", "stop", "hook"],
+        choices=["pre-compact", "stop", "session-end", "subagent-stop", "hook"],
         help="Hook event label used only for diagnostics.",
     )
     parser.add_argument(

--- a/nowledge-mem-claude-code-plugin/tests/test_nmem_hook_save.py
+++ b/nowledge-mem-claude-code-plugin/tests/test_nmem_hook_save.py
@@ -323,6 +323,32 @@ def test_stop_detach_reads_stdin_before_dispatch():
     dispatch.assert_called_once_with(payload, "stop")
 
 
+def test_session_end_detach_reads_stdin_before_dispatch():
+    payload = {"session_id": "grok-session", "cwd": "/tmp/grok-project"}
+    argv = ["nmem-hook-save.py", "--event", "session-end", "--detach"]
+
+    with patch.object(nmem_hook_save.sys, "argv", argv), \
+        patch.object(nmem_hook_save.sys, "stdin") as stdin, \
+        patch.object(nmem_hook_save, "_dispatch_background_capture") as dispatch:
+        stdin.read.return_value = json.dumps(payload)
+        assert nmem_hook_save.main() == 0
+
+    dispatch.assert_called_once_with(payload, "session-end")
+
+
+def test_subagent_stop_detach_reads_stdin_before_dispatch():
+    payload = {"session_id": "grok-subagent-session", "cwd": "/tmp/grok-project"}
+    argv = ["nmem-hook-save.py", "--event", "subagent-stop", "--detach"]
+
+    with patch.object(nmem_hook_save.sys, "argv", argv), \
+        patch.object(nmem_hook_save.sys, "stdin") as stdin, \
+        patch.object(nmem_hook_save, "_dispatch_background_capture") as dispatch:
+        stdin.read.return_value = json.dumps(payload)
+        assert nmem_hook_save.main() == 0
+
+    dispatch.assert_called_once_with(payload, "subagent-stop")
+
+
 def test_run_capture_reports_uncaptured_when_transcript_never_flushes():
     proc = CompletedProcess(["nmem"], 0, stdout='{"results":[]}', stderr="")
 


### PR DESCRIPTION
## Summary

- add Grok Build `SessionEnd` and `SubagentStop` hook entries for final/subagent capture
- reuse the existing detached `nmem-hook-save.py` worker so Grok gate hooks do not block
- document remote Grok/Claude lifecycle capture behavior

## Validation

- `pytest community/nowledge-mem-claude-code-plugin/tests/test_nmem_hook_save.py`
- `python3 -m json.tool community/nowledge-mem-claude-code-plugin/hooks/hooks.json >/dev/null`
- `grok plugin validate community/nowledge-mem-claude-code-plugin`
- `claude plugin validate community/nowledge-mem-claude-code-plugin`
- temp `GROK_HOME` install/list smoke passed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added automatic Grok Build session capture when a session ends or a subagent stops.
  * Captures run in the background with bounded retries, helping preserve session data without interrupting workflows.
* **Documentation**
  * Updated lifecycle guidance to cover final-session and subagent captures.
  * Clarified remote-mode behavior for Claude Code and Grok Build uploads, including local session privacy.
* **Bug Fixes**
  * Improved reliability when processing session-end and subagent-stop capture events.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->