### PR TITLE
Fix Grok hook routing under Claude-compatible plugin roots

### DIFF
--- a/nowledge-mem-claude-code-plugin/.claude-plugin/plugin.json
+++ b/nowledge-mem-claude-code-plugin/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "nowledge-mem",
   "description": "Personal knowledge graph for Claude Code and Grok \u2014 remembers decisions, searches past work, captures sessions",
-  "version": "0.7.22",
+  "version": "0.7.23",
   "author": {
     "name": "Nowledge Labs",
     "email": "hello@nowledge-labs.ai",

--- a/nowledge-mem-claude-code-plugin/CHANGELOG.md
+++ b/nowledge-mem-claude-code-plugin/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.7.23] - 2026-08-10
+
+### Fixed
+
+- Grok Build hook routing now also recognizes the Claude-compatible plugin
+  environment when `CLAUDE_PLUGIN_ROOT` points inside `~/.grok/`. This prevents
+  Context Bundle reads and automatic thread capture from falling back to
+  `claude-code` on Grok installs that run shared hooks through the compatibility
+  plugin layer.
+
 ## [0.7.22] - 2026-08-08
 
 ### Added

--- a/nowledge-mem-claude-code-plugin/scripts/nmem-hook-read.sh
+++ b/nowledge-mem-claude-code-plugin/scripts/nmem-hook-read.sh
@@ -37,6 +37,9 @@ SOURCE_APP="claude-code"
 if [ -n "${GROK_SESSION_ID:-}" ] || [ -n "${GROK_HOOK_EVENT:-}" ] || [ -n "${GROK_WORKSPACE_ROOT:-}" ] || [ -n "${GROK_PLUGIN_ROOT:-}" ]; then
   SOURCE_APP="grok"
 fi
+case "${CLAUDE_PLUGIN_ROOT:-}" in
+  */.grok/*|*\\.grok\\*) SOURCE_APP="grok" ;;
+esac
 
 parse_context='import sys,json; d=json.load(sys.stdin); c=d.get("rendered_markdown") or d.get("content") or ""; print(c) if c else sys.exit(1)'
 parse_existing_space_wm='import sys,json; d=json.load(sys.stdin); c=d.get("content",""); print(c) if d.get("exists") and c else sys.exit(1)'

--- a/nowledge-mem-claude-code-plugin/scripts/nmem-hook-save.py
+++ b/nowledge-mem-claude-code-plugin/scripts/nmem-hook-save.py
@@ -286,12 +286,20 @@ def _nmem_command() -> str | None:
     return shutil.which("nmem") or shutil.which("nmem.cmd")
 
 
+def _looks_like_grok_path(value: str | None) -> bool:
+    if not value:
+        return False
+    normalized = value.replace("\\", "/")
+    return "/.grok/" in normalized or normalized.endswith("/.grok")
+
+
 def _host_runtime() -> str:
     if (
         os.environ.get("GROK_SESSION_ID")
         or os.environ.get("GROK_HOOK_EVENT")
         or os.environ.get("GROK_WORKSPACE_ROOT")
         or os.environ.get("GROK_PLUGIN_ROOT")
+        or _looks_like_grok_path(os.environ.get("CLAUDE_PLUGIN_ROOT"))
     ):
         return "grok"
     return "claude-code"

--- a/nowledge-mem-claude-code-plugin/tests/test_nmem_hook_read.py
+++ b/nowledge-mem-claude-code-plugin/tests/test_nmem_hook_read.py
@@ -187,6 +187,43 @@ esac
     assert "context --source-app grok" in command_log
 
 
+def test_read_hook_uses_grok_source_app_for_claude_compat_plugin_root(tmp_path):
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    calls = tmp_path / "calls.log"
+    _write_fake_nmem(
+        bin_dir,
+        f"""
+printf '%s\\n' "$*" >> "{calls}"
+case "$*" in
+  *"--source-app grok"*) printf '%s\\n' '{{"rendered_markdown": "grok compat context"}}' ;;
+  *) exit 2 ;;
+esac
+""",
+    )
+
+    result = _run_hook(
+        tmp_path,
+        cwd=tmp_path,
+        env={
+            "PATH": f"{bin_dir}:{os.environ['PATH']}",
+            "CLAUDE_PLUGIN_ROOT": str(
+                tmp_path / ".grok" / "installed-plugins" / "nowledge-mem-claude-code-plugin"
+            ),
+            "GROK_PLUGIN_ROOT": "",
+            "GROK_SESSION_ID": "",
+            "GROK_HOOK_EVENT": "",
+            "GROK_WORKSPACE_ROOT": "",
+            "NMEM_SPACE": "",
+        },
+    )
+
+    assert result.returncode == 0
+    assert result.stdout.strip() == "grok compat context"
+    command_log = calls.read_text(encoding="utf-8")
+    assert "context --source-app grok" in command_log
+
+
 def test_read_hook_falls_back_to_default_space_when_project_space_empty(tmp_path):
     bin_dir = tmp_path / "bin"
     bin_dir.mkdir()

--- a/nowledge-mem-claude-code-plugin/tests/test_nmem_hook_save.py
+++ b/nowledge-mem-claude-code-plugin/tests/test_nmem_hook_save.py
@@ -147,6 +147,30 @@ def test_build_command_uses_grok_runtime_from_plugin_root_only(tmp_path):
     assert command[command.index("--session-id") + 1] == "plugin-root-session"
 
 
+def test_build_command_uses_grok_runtime_from_claude_compat_plugin_root(tmp_path):
+    plugin_root = tmp_path / ".grok" / "installed-plugins" / "nowledge-mem-claude-code-plugin"
+    with patch.dict(
+        os.environ,
+        {
+            "CLAUDE_PLUGIN_ROOT": str(plugin_root),
+            "GROK_PLUGIN_ROOT": "",
+            "GROK_SESSION_ID": "",
+            "GROK_WORKSPACE_ROOT": "",
+            "GROK_HOOK_EVENT": "",
+            "NMEM_SPACE": "",
+        },
+    ):
+        command = nmem_hook_save._build_command(
+            "/usr/local/bin/nmem",
+            {"session_id": "grok-compat-session", "cwd": str(tmp_path)},
+        )
+
+    assert "--from" in command
+    assert command[command.index("--from") + 1] == "grok"
+    assert "--session-id" in command
+    assert command[command.index("--session-id") + 1] == "grok-compat-session"
+
+
 def test_build_command_resolves_project_symlink(tmp_path):
     real_project = tmp_path / "real-project"
     real_project.mkdir()


### PR DESCRIPTION
## Summary
- Treat `CLAUDE_PLUGIN_ROOT` paths under `~/.grok/` as Grok Build runtime signals for automatic save hooks.
- Apply the same compat-root detection to the SessionStart/context read hook.
- Bump the Claude/Grok plugin package to 0.7.23 and document the user-visible fix.

## Validation
- `uvx pytest tests/test_nmem_hook_save.py tests/test_nmem_hook_read.py` (46 passed)
- `git diff --check`

## Notes
- This addresses the case where Grok hooks do run but route as `claude-code`.
- The separate Grok host-trust case, where hooks never register at all, still needs host diagnostics.
