### PR TITLE
fix(amp): harden nmem thread sync (pagination, canonical append, long uploads)

### DIFF
--- a/integrations.json
+++ b/integrations.json
@@ -1050,7 +1050,7 @@
         "distill": "guided",
         "threads": "automatic-capture",
         "bestResultRequires": [
-          "Run nowledge-mem-amp-plugin/scripts/install.sh from the community repository root to install the plugin entrypoint, plugin bundle, and skill into the resolved Amp config directory",
+          "Install from the community repository into the Amp Personal Plugins project for an account-wide installation, or run nowledge-mem-amp-plugin/scripts/install.sh for one machine",
           "Restart Amp so the plugin registers its tools, agent.end capture hook, and commands",
           "Keep nmem available for memory operations, provenance-stamped saves, and handoff flows",
           "Run nmem config client set url/api-key once when Mem is remote"
@@ -1059,6 +1059,7 @@
       "install": {
         "command": "bash nowledge-mem-amp-plugin/scripts/install.sh",
         "updateCommand": "bash nowledge-mem-amp-plugin/scripts/install.sh",
+        "configRequired": "For an account-wide install, ask Amp in a thread to install https://github.com/nowledge-co/community/tree/main/nowledge-mem-amp-plugin into your Personal Plugins project, commit and push that project, and reload plugins. Personal plugins apply everywhere you use Amp. The install script remains the direct option for one machine and writes to the resolved Amp config directory.",
         "detectionHint": "Running as Amp agent; ~/.config/amp/ or .amp/ exists",
         "agentGuide": {
           "prompt": "Read https://mem.nowledge.co/SKILL.md and follow the instructions to install or update Nowledge Mem for Amp. Verify with nmem status and the Context Bundle or Working Memory check, then summarize what changed.",

--- a/nowledge-mem-amp-plugin/CHANGELOG.md
+++ b/nowledge-mem-amp-plugin/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## Unreleased
+
+### Fixed
+
+- Read Amp transcripts from the start in pages so captures include messages
+  beyond the SDK's default trailing page.
+- Append to canonical threads when the server reports an existing thread as
+  either `409 Conflict` or an explicit `422` already-exists response.
+- Allow up to two minutes for large thread uploads before timing out.
+
 ## [0.1.1] - 2026-08-10
 
 ### Fixed

--- a/nowledge-mem-amp-plugin/README.md
+++ b/nowledge-mem-amp-plugin/README.md
@@ -26,6 +26,22 @@ amp --version   # Amp is available
 
 ## Setup
 
+### Install as a personal plugin
+
+Use Amp's Personal Plugins project when you want Nowledge Mem available everywhere you use Amp. Open an Amp thread and send this prompt:
+
+```text
+Install the Nowledge Mem Amp plugin from
+https://github.com/nowledge-co/community/tree/main/nowledge-mem-amp-plugin
+into my Personal Plugins project. Commit and push the project, then reload my plugins.
+```
+
+Amp checks out your Personal Plugins project, installs the plugin from this repository, and asks before pushing the change. After the push, new threads load the plugin automatically. To load it in the current thread, open the command palette and run `plugins: reload`.
+
+The Personal Plugins project syncs the plugin through your Amp account. You still need the `nmem` CLI and access to the Nowledge Mem server in each environment where Amp runs.
+
+### Install on one machine
+
 From the `community` repository root, run the install script:
 
 ```bash

--- a/nowledge-mem-amp-plugin/src/http.ts
+++ b/nowledge-mem-amp-plugin/src/http.ts
@@ -30,7 +30,7 @@ export type NmemHttp = (
 ) => Promise<HttpResponse>
 
 /** Default request timeout (milliseconds). */
-const DEFAULT_TIMEOUT_MS = 30_000
+const DEFAULT_TIMEOUT_MS = 120_000
 
 /** Normalised HTTP response. */
 export interface HttpResponse {

--- a/nowledge-mem-amp-plugin/src/index.ts
+++ b/nowledge-mem-amp-plugin/src/index.ts
@@ -89,9 +89,18 @@ function toConverterMessages(messages: readonly ThreadMessage[]): unknown[] {
  * @param threadId - The thread id to read.
  * @returns The transcript as a loose array for the converter.
  */
-async function readThreadMessagesViaSdk(amp: PluginAPI, threadId: ThreadID): Promise<unknown[]> {
+export async function readThreadMessagesViaSdk(amp: PluginAPI, threadId: ThreadID): Promise<unknown[]> {
   const thread = amp.threads.get(threadId)
-  const messages = await thread.messages({ full: true })
+  const messages: ThreadMessage[] = []
+  let offset = 0
+
+  while (true) {
+    const page = await thread.messages({ full: true, from: "start", offset, limit: 20 })
+    messages.push(...page)
+    if (page.length < 20) break
+    offset += page.length
+  }
+
   return toConverterMessages(messages)
 }
 

--- a/nowledge-mem-amp-plugin/src/sync.ts
+++ b/nowledge-mem-amp-plugin/src/sync.ts
@@ -296,10 +296,20 @@ export class SessionSyncManager {
 
     let response = await this.ports.nmemApi("/threads", body)
 
-    // Only fall back to append when the thread already exists (409 Conflict).
+    const responseData = response.data
+    const conflictMessage =
+      typeof responseData === "object" && responseData !== null
+        ? Reflect.get(responseData, "detail") ?? Reflect.get(responseData, "error")
+        : undefined
+    const threadAlreadyExists =
+      response.status === 409
+      || (response.status === 422 && typeof conflictMessage === "string" && conflictMessage.includes("already exists"))
+
+    // Only fall back to append when the thread already exists. The current
+    // server uses 422 for this condition while older deployments use 409.
     // Other errors (auth, server, permission) should surface the original
     // failure rather than doubling API calls with a doomed append.
-    if (!response.ok && response.status === 409) {
+    if (!response.ok && threadAlreadyExists) {
       const appendBody = {
         messages: threadMessages,
         deduplicate: true,

--- a/nowledge-mem-amp-plugin/src/sync.ts
+++ b/nowledge-mem-amp-plugin/src/sync.ts
@@ -296,14 +296,11 @@ export class SessionSyncManager {
 
     let response = await this.ports.nmemApi("/threads", body)
 
-    const responseData = response.data
-    const conflictMessage =
-      typeof responseData === "object" && responseData !== null
-        ? Reflect.get(responseData, "detail") ?? Reflect.get(responseData, "error")
-        : undefined
+    const conflictText = JSON.stringify(response.data)?.toLowerCase() ?? ""
     const threadAlreadyExists =
       response.status === 409
-      || (response.status === 422 && typeof conflictMessage === "string" && conflictMessage.includes("already exists"))
+      || (response.status === 422
+        && (conflictText.includes("already exists") || conflictText.includes("thread exists")))
 
     // Only fall back to append when the thread already exists. The current
     // server uses 422 for this condition while older deployments use 409.

--- a/nowledge-mem-amp-plugin/tests/http.test.ts
+++ b/nowledge-mem-amp-plugin/tests/http.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi } from "vitest"
+import { afterEach, describe, expect, it, vi } from "vitest"
 
 import { createNmemHttp } from "../src/http"
 import type { ResolvedConfig } from "../src/config"
@@ -27,6 +27,10 @@ const AUTHED_CONFIG: ResolvedConfig = { ...NO_AUTH_CONFIG, apiKey: AUTH_FIXTURE 
 
 /** Config with an ambient space. */
 const SPACED_CONFIG: ResolvedConfig = { ...NO_AUTH_CONFIG, ambientSpaceId: "Research" }
+
+afterEach(() => {
+  vi.restoreAllMocks()
+})
 
 /** A minimal Response-like object for the fake fetch. */
 interface FakeResponse {

--- a/nowledge-mem-amp-plugin/tests/http.test.ts
+++ b/nowledge-mem-amp-plugin/tests/http.test.ts
@@ -120,6 +120,17 @@ describe("createNmemHttp", () => {
     expect(data.error).toContain("timed out")
   })
 
+  it("allows two minutes for a request by default", async () => {
+    const setTimeoutSpy = vi.spyOn(globalThis, "setTimeout")
+    const fetch = fakeFetch({ ok: true, status: 200, json: async () => null })
+    const nmemApi = createNmemHttp(NO_AUTH_CONFIG, { fetch, createAbortController: realAbortController })
+
+    await nmemApi("/threads", {})
+
+    expect(setTimeoutSpy).toHaveBeenCalledWith(expect.any(Function), 120_000)
+    setTimeoutSpy.mockRestore()
+  })
+
   it("normalises a generic network error into status 0", async () => {
     const fetch = vi.fn(async () => {
       throw new Error("ECONNREFUSED")

--- a/nowledge-mem-amp-plugin/tests/index.test.ts
+++ b/nowledge-mem-amp-plugin/tests/index.test.ts
@@ -33,7 +33,16 @@ interface FakeAmp {
   }) => Promise<void>>
   readonly logger: { readonly log: (message: string) => void }
   readonly system: { readonly workspaceRoot: { readonly toString: () => string } | null }
-  readonly threads: { readonly get: (threadId: string) => { readonly messages: (options: { readonly full: boolean }) => Promise<unknown[]> } }
+  readonly threads: {
+    readonly get: (threadId: string) => {
+      readonly messages: (options: {
+        readonly full: boolean
+        readonly from: "start" | "end"
+        readonly offset: number
+        readonly limit: number
+      }) => Promise<unknown[]>
+    }
+  }
   readonly registerTool: (definition: {
     readonly name: string
     readonly execute: (input: Record<string, unknown>, ctx: { readonly thread: { readonly id: string } }) => Promise<unknown>
@@ -127,6 +136,43 @@ describe("Amp plugin entrypoint", () => {
     agentEnd!({ thread: { id: "T-one" } })
     amp.disposers[0]!()
     expect(amp.logger.log).toHaveBeenCalled()
+  })
+
+  it("paginates the full transcript from the start", async () => {
+    const calls: Array<{ full: boolean; from: "start" | "end"; offset: number; limit: number }> = []
+    const transcript = Array.from({ length: 45 }, (_, index) => ({
+      role: index % 2 === 0 ? "user" : "assistant",
+      id: `message-${index}`,
+      content: [{ type: "text", text: `message ${index}` }],
+    }))
+    const amp = createFakeAmp()
+    const paginatedAmp = {
+      ...amp,
+      threads: {
+        get: () => ({
+          messages: async (options: { full: boolean; from: "start" | "end"; offset: number; limit: number }) => {
+            calls.push(options)
+            return transcript.slice(options.offset, options.offset + options.limit)
+          },
+        }),
+      },
+    }
+    const mod = await import("../src/index")
+
+    const messages = await mod.readThreadMessagesViaSdk(
+      paginatedAmp as unknown as Parameters<typeof mod.readThreadMessagesViaSdk>[0],
+      "T-one" as Parameters<typeof mod.readThreadMessagesViaSdk>[1],
+    )
+
+    expect(messages).toHaveLength(45)
+    expect(messages.map((message) => (message as { id: string }).id)).toEqual(
+      transcript.map((message) => message.id),
+    )
+    expect(calls).toEqual([
+      { full: true, from: "start", offset: 0, limit: 20 },
+      { full: true, from: "start", offset: 20, limit: 20 },
+      { full: true, from: "start", offset: 40, limit: 20 },
+    ])
   })
 
   it("preloads bootstrap on session.start and consumes it once on agent.start", async () => {

--- a/nowledge-mem-amp-plugin/tests/sync.test.ts
+++ b/nowledge-mem-amp-plugin/tests/sync.test.ts
@@ -103,6 +103,8 @@ describe("SessionSyncManager.syncNow", () => {
     [409, { error: "exists" }],
     [422, { detail: "Thread amp-t-abc123 already exists in space default." }],
     [422, { error: "Thread amp-t-abc123 already exists in space default." }],
+    [422, "THREAD amp-t-abc123 ALREADY EXISTS in space default."],
+    [422, { error: { message: "Thread exists in space default." } }],
   ])("falls back to append when create returns the existing-thread response %i", async (status, data) => {
     const nmemApi = fakeNmemApi({
       "/threads": () => ({ ok: false, status, data }),

--- a/nowledge-mem-amp-plugin/tests/sync.test.ts
+++ b/nowledge-mem-amp-plugin/tests/sync.test.ts
@@ -99,9 +99,13 @@ describe("SessionSyncManager.syncNow", () => {
     expect(nmemApi.calls).toEqual(["/threads"])
   })
 
-  it("falls back to append when create returns 409", async () => {
+  it.each([
+    [409, { error: "exists" }],
+    [422, { detail: "Thread amp-t-abc123 already exists in space default." }],
+    [422, { error: "Thread amp-t-abc123 already exists in space default." }],
+  ])("falls back to append when create returns the existing-thread response %i", async (status, data) => {
     const nmemApi = fakeNmemApi({
-      "/threads": () => ({ ok: false, status: 409, data: { error: "exists" } }),
+      "/threads": () => ({ ok: false, status, data }),
       "/threads/amp-t-abc123/append": () => ({ ok: true, status: 200, data: { appended: true } }),
     })
     const manager = new SessionSyncManager(managerOptions({ nmemApi, ambientSpaceId: "Research" }))
@@ -109,6 +113,22 @@ describe("SessionSyncManager.syncNow", () => {
 
     expect(result.success).toBe(true)
     expect(nmemApi.calls).toEqual(["/threads", "/threads/amp-t-abc123/append"])
+  })
+
+  it.each([
+    { detail: "messages are invalid" },
+    "messages are invalid",
+  ])("preserves an unrelated 422 create failure", async (data) => {
+    const nmemApi = fakeNmemApi({
+      "/threads": () => ({ ok: false, status: 422, data }),
+      "/threads/amp-t-abc123/append": () => ({ ok: true, status: 200, data: { appended: true } }),
+    })
+    const manager = new SessionSyncManager(managerOptions({ nmemApi }))
+    const result = await manager.syncNow(THREAD_ID)
+
+    expect(result.success).toBeUndefined()
+    expect(result.error).toContain("Thread save failed (422)")
+    expect(nmemApi.calls).toEqual(["/threads"])
   })
 
   it("preserves the original create failure when it is not a conflict", async () => {
@@ -149,7 +169,11 @@ describe("SessionSyncManager.syncNow", () => {
     const manager = new SessionSyncManager(managerOptions({ nmemApi: wrapped, ambientSpaceId: "Research" }))
     await manager.syncNow(THREAD_ID)
 
-    expect(capturedBody).toMatchObject({ space_id: "Research", idempotency_key: "amp:live:amp-t-abc123" })
+    expect(capturedBody).toMatchObject({
+      space_id: "Research",
+      deduplicate: true,
+      idempotency_key: "amp:live:amp-t-abc123",
+    })
   })
 
   it("returns an append error result when create conflicts and append fails", async () => {


### PR DESCRIPTION
## Summary

Hardens the Amp `nmem` thread sync path so long transcripts are complete, existing canonical threads append safely, and large uploads have enough time to finish. It also documents account-wide installation through Amp Personal Plugins.

## Changes

- Paginate Amp thread messages in ordered pages of 20 until the complete transcript is loaded.
- Append after `409 Conflict` or a qualifying `422` response. The 422 check normalizes the complete payload, including string and nested-object bodies, and recognizes `already exists` and `thread exists` case-insensitively.
- Use a 120-second default HTTP timeout for large thread uploads.
- Document Personal Plugins installation alongside the existing one-machine install script, and record the account-wide option in `integrations.json`.
- Add regression coverage for pagination, canonical append behavior, timeout scheduling, and failure-safe spy cleanup.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved retrieval of long Amp transcripts by loading messages in pages while preserving their order.
  - Existing-thread conflicts now fall back to appending messages when recognized; unrelated errors remain unchanged.
  - Increased the default request timeout to 120 seconds for larger uploads and slower connections.

- **Documentation**
  - Added guidance for installing and reloading the integration through Amp Personal Plugins.
  - Clarified account-wide and single-machine installation options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->