### PR TITLE
fix(amp): capture agent-end messages incrementally

### DIFF
--- a/integrations.json
+++ b/integrations.json
@@ -1028,7 +1028,7 @@
       "name": "Amp",
       "category": "coding",
       "type": "plugin",
-      "version": "0.1.1",
+      "version": "0.1.2",
       "directory": "nowledge-mem-amp-plugin",
       "transport": "cli+http",
       "capabilities": {
@@ -1042,7 +1042,7 @@
       },
       "threadSave": {
         "method": "sdk-extract+agent-end",
-        "note": "Plugin listens for the Amp agent.end event, reads the full thread transcript through Amp's thread API, and posts to Nowledge Mem's thread API over HTTP; save_thread remains an explicit idempotent fallback"
+        "note": "Plugin listens for the Amp agent.end event, posts the event's completed turn messages to Nowledge Mem's thread API over HTTP, and keeps save_thread as an explicit idempotent full-transcript fallback"
       },
       "autonomy": {
         "bootstrap": "guided",

--- a/nowledge-mem-amp-plugin/CHANGELOG.md
+++ b/nowledge-mem-amp-plugin/CHANGELOG.md
@@ -1,11 +1,15 @@
 # Changelog
 
-## Unreleased
+## [0.1.2] - 2026-08-12
 
 ### Fixed
 
+- Capture automatic `agent.end` turns from Amp's event payload instead of
+  reading the full thread transcript on every turn.
+- Preserve all pending incremental turn batches while debounce or another
+  capture is in flight.
 - Read Amp transcripts from the start in pages so captures include messages
-  beyond the SDK's default trailing page.
+  beyond the SDK's default trailing page during manual full-session saves.
 - Append to canonical threads when the server reports an existing thread as
   either `409 Conflict` or an explicit `422` already-exists response.
 - Allow up to two minutes for large thread uploads before timing out.

--- a/nowledge-mem-amp-plugin/README.md
+++ b/nowledge-mem-amp-plugin/README.md
@@ -87,9 +87,9 @@ Re-run `bash nowledge-mem-amp-plugin/scripts/install.sh` from the `community` re
 
 ## How session capture works
 
-1. **Automatic live capture.** At the end of each agent turn (`agent.end`), the plugin reads the full transcript through Amp's thread API and creates or appends the matching `amp-<threadID>` thread in Nowledge Mem over HTTP. This works in local and remote mode because the plugin runs where Amp owns the session.
+1. **Automatic live capture.** At the end of each agent turn (`agent.end`), the plugin saves the completed turn messages that Amp already provides and creates or appends the matching `amp-<threadID>` thread in Nowledge Mem over HTTP. This avoids an expensive transcript read during normal work while still preserving every turn.
 
-2. **Manual full session capture.** `nowledge_mem_save_thread` uses the same capture path on demand. It is idempotent (safe to call multiple times) and handles large sessions via HTTP, not shell arguments.
+2. **Manual full session capture.** `nowledge_mem_save_thread` reads the full transcript from the start in pages and uses the same HTTP thread API on demand. It is idempotent (safe to call multiple times) and handles large sessions via HTTP, not shell arguments.
 
 3. **Plugin proactive knowledge save.** `nowledge_mem_save` captures individual decisions and insights as they happen, stamped with `source=amp`. `nowledge_mem_save_handoff` creates a curated summary at wrap-up.
 

--- a/nowledge-mem-amp-plugin/package.json
+++ b/nowledge-mem-amp-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "amp-nowledge-mem",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "Nowledge Mem plugin for Amp. Cross-tool knowledge with agent-end thread capture, Context Bundle, search, save, and handoffs.",
   "type": "module",
   "main": "src/index.ts",

--- a/nowledge-mem-amp-plugin/src/index.ts
+++ b/nowledge-mem-amp-plugin/src/index.ts
@@ -83,7 +83,12 @@ function toConverterMessages(messages: readonly ThreadMessage[]): unknown[] {
 }
 
 /**
- * Reads the full message transcript for a thread through the Amp SDK.
+ * Reads the full message transcript for an explicit manual save through the
+ * Amp SDK.
+ *
+ * Automatic capture uses the messages already included in the `agent.end`
+ * event, avoiding a Plugin RPC entirely. Manual saves retain their full-history
+ * contract even though that explicit operation may require a large RPC read.
  *
  * @param amp - The Amp plugin API.
  * @param threadId - The thread id to read.
@@ -177,7 +182,7 @@ export default function ampKnowledgeMem(amp: PluginAPI): void {
 
   const logger = amp.logger
   amp.on("agent.end", (event) => {
-    syncManager.scheduleSync(event.thread.id)
+    syncManager.scheduleSync(event.thread.id, toConverterMessages(event.messages))
   })
 
   const bootstrapManager = new BootstrapManager(

--- a/nowledge-mem-amp-plugin/src/sync.ts
+++ b/nowledge-mem-amp-plugin/src/sync.ts
@@ -60,6 +60,8 @@ interface SyncState {
   inFlight: Promise<unknown> | undefined
   /** Flag set when a sync was requested while one was already running. */
   pending: boolean
+  /** Messages supplied by pending automatic captures, if any. */
+  pendingMessages: readonly unknown[] | undefined
   /** Signature of the last successfully captured transcript. */
   lastSignature: string | undefined
   /** Serialized manual-capture queue for this thread. */
@@ -125,16 +127,21 @@ export class SessionSyncManager {
    * call fires. If automatic capture is disabled, this is a no-op.
    *
    * @param threadId - The thread to capture.
+   * @param messages - Messages supplied by the host's `agent.end` event. When
+   * omitted, the caller reads the complete thread transcript through the SDK.
    */
-  public scheduleSync(threadId: ThreadID): void {
+  public scheduleSync(threadId: ThreadID, messages?: readonly unknown[]): void {
     if (this.disposed || !this.autoSyncEnabled) return
     const state = this.stateFor(threadId)
+    state.pendingMessages = mergeMessageBatches(state.pendingMessages, messages)
     if (state.timer !== undefined) {
       this.ports.clearTimer(state.timer)
     }
     state.timer = this.ports.setTimer(() => {
       state.timer = undefined
-      void this.runAutoSync(threadId)
+      const pendingMessages = state.pendingMessages
+      state.pendingMessages = undefined
+      void this.runAutoSync(threadId, pendingMessages)
     }, this.autoSyncDebounceMs)
   }
 
@@ -181,7 +188,9 @@ export class SessionSyncManager {
       state.manualQueue = undefined
       if (!this.disposed && state.pending) {
         state.pending = false
-        this.scheduleSync(threadId)
+        const pendingMessages = state.pendingMessages
+        state.pendingMessages = undefined
+        this.scheduleSync(threadId, pendingMessages)
       }
     })
     state.manualQueue = guarded
@@ -211,14 +220,17 @@ export class SessionSyncManager {
    * re-schedules one final capture once the in-flight run completes.
    *
    * @param threadId - The thread to capture.
+   * @param messages - Messages from the `agent.end` event that triggered this
+   * capture, when available.
    */
-  private async runAutoSync(threadId: ThreadID): Promise<void> {
+  private async runAutoSync(threadId: ThreadID, messages?: readonly unknown[]): Promise<void> {
     const state = this.stateFor(threadId)
     if (state.inFlight !== undefined || state.manualQueue !== undefined) {
       state.pending = true
+      state.pendingMessages = mergeMessageBatches(state.pendingMessages, messages)
       return
     }
-    const run = this.captureThread(threadId, { force: false })
+    const run = this.captureThread(threadId, { force: false, messages })
       .catch(() => undefined)
     let guarded: Promise<CaptureResult | undefined>
     guarded = run.finally(() => {
@@ -229,7 +241,9 @@ export class SessionSyncManager {
       state.inFlight = undefined
       if (!this.disposed && state.pending) {
         state.pending = false
-        this.scheduleSync(threadId)
+        const pendingMessages = state.pendingMessages
+        state.pendingMessages = undefined
+        this.scheduleSync(threadId, pendingMessages)
       }
     })
     state.inFlight = guarded
@@ -240,13 +254,17 @@ export class SessionSyncManager {
    * Captures a thread, applying signature-based dedup unless `force` is set.
    *
    * @param threadId - The thread to capture.
-   * @param options - Capture options controlling the force flag.
+   * @param options - Capture options controlling the force flag and an optional
+   * host-supplied incremental message batch.
    * @returns The capture result.
    */
-  private async captureThread(threadId: ThreadID, options: { force: boolean }): Promise<CaptureResult> {
+  private async captureThread(
+    threadId: ThreadID,
+    options: { force: boolean; messages?: readonly unknown[] },
+  ): Promise<CaptureResult> {
     const stableThreadId = this.stableThreadId(threadId)
 
-    const rawMessages = await this.ports.readThreadMessages(threadId)
+    const rawMessages = options.messages ?? await this.ports.readThreadMessages(threadId)
     const sdkMessages = normalizeMessages(rawMessages)
     if (sdkMessages.length === 0) {
       return skipped("no_messages", stableThreadId)
@@ -342,7 +360,14 @@ export class SessionSyncManager {
   private stateFor(threadId: ThreadID): SyncState {
     let state = this.states.get(threadId)
     if (state === undefined) {
-      state = { timer: undefined, inFlight: undefined, pending: false, lastSignature: undefined, manualQueue: undefined }
+      state = {
+        timer: undefined,
+        inFlight: undefined,
+        pending: false,
+        pendingMessages: undefined,
+        lastSignature: undefined,
+        manualQueue: undefined,
+      }
       this.states.set(threadId, state)
     }
     return state
@@ -401,4 +426,49 @@ function hasUserAndAssistant(messages: readonly ThreadMessage[]): boolean {
     else hasAssistant = true
   }
   return hasUser && hasAssistant
+}
+
+/**
+ * Merges host-supplied incremental batches without dropping earlier debounced
+ * or in-flight agent.end payloads. Amp documents agent.end messages as the
+ * messages since agent.start, so they are not safe to replace wholesale.
+ *
+ * @param existing - Previously queued automatic messages.
+ * @param next - New automatic messages from the host.
+ * @returns A stable-order merged batch, or `undefined` when neither exists.
+ */
+function mergeMessageBatches(
+  existing: readonly unknown[] | undefined,
+  next: readonly unknown[] | undefined,
+): readonly unknown[] | undefined {
+  if (next === undefined) return existing
+  if (existing === undefined || existing.length === 0) return next
+  if (next.length === 0) return existing
+
+  const merged: unknown[] = []
+  const seen = new Set<string>()
+  for (const message of [...existing, ...next]) {
+    const key = messageKey(message)
+    if (seen.has(key)) continue
+    seen.add(key)
+    merged.push(message)
+  }
+  return merged
+}
+
+/**
+ * Returns a stable key for a raw SDK message before normalization. Prefer the
+ * host message id; fall back to the serialized shape for defensive de-dupe.
+ *
+ * @param message - Raw SDK message-like value.
+ * @returns A stable key for merge-time de-duplication.
+ */
+function messageKey(message: unknown): string {
+  if (typeof message === "object" && message !== null && "id" in message) {
+    const id = (message as { readonly id?: unknown }).id
+    if (typeof id === "string" || typeof id === "number") {
+      return `id:${String(id)}`
+    }
+  }
+  return `json:${JSON.stringify(message)}`
 }

--- a/nowledge-mem-amp-plugin/tests/index.test.ts
+++ b/nowledge-mem-amp-plugin/tests/index.test.ts
@@ -33,6 +33,12 @@ interface FakeAmp {
   }) => Promise<void>>
   readonly logger: { readonly log: (message: string) => void }
   readonly system: { readonly workspaceRoot: { readonly toString: () => string } | null }
+  readonly threadMessageOptions: Array<{
+    readonly full: boolean
+    readonly from: "start" | "end"
+    readonly offset: number
+    readonly limit: number
+  }>
   readonly threads: {
     readonly get: (threadId: string) => {
       readonly messages: (options: {
@@ -59,6 +65,7 @@ function createFakeAmp(): FakeAmp {
   const toolDefinitions: FakeAmp["toolDefinitions"] = []
   const commands: string[] = []
   const commandHandlers: FakeAmp["commandHandlers"] = new Map()
+  const threadMessageOptions: FakeAmp["threadMessageOptions"] = []
   return {
     events,
     disposers,
@@ -66,13 +73,15 @@ function createFakeAmp(): FakeAmp {
     toolDefinitions,
     commands,
     commandHandlers,
+    threadMessageOptions,
     logger: { log: vi.fn() },
     system: { workspaceRoot: { toString: () => "/workspace" } },
     threads: {
       get: () => ({
-        messages: async () => [
-          { role: "user", id: "u1", content: [{ type: "text", text: "hello" }] },
-        ],
+        messages: async (options) => {
+          threadMessageOptions.push(options)
+          return [{ role: "user", id: "u1", content: [{ type: "text", text: "hello" }] }]
+        },
       }),
     },
     registerTool: (definition) => {
@@ -116,6 +125,7 @@ describe("Amp plugin entrypoint", () => {
     expect(saveThread).toBeDefined()
     const toolResult = await saveThread!.execute({}, { thread: { id: "T-one" } })
     expect(JSON.parse(String(toolResult))).toMatchObject({ skipped: true, reason: "incomplete_turn" })
+    expect(amp.threadMessageOptions).toEqual([{ full: true, from: "start", offset: 0, limit: 20 }])
 
     const statusCommand = amp.commandHandlers.get("nowledge-mem:status")
     expect(statusCommand).toBeDefined()
@@ -133,7 +143,13 @@ describe("Amp plugin entrypoint", () => {
 
     const agentEnd = amp.events.get("agent.end")
     expect(agentEnd).toBeDefined()
-    agentEnd!({ thread: { id: "T-one" } })
+    agentEnd!({
+      thread: { id: "T-one" },
+      messages: [
+        { role: "user", id: "u2", content: [{ type: "text", text: "follow up" }] },
+        { role: "assistant", id: "a2", content: [{ type: "text", text: "done" }] },
+      ],
+    })
     amp.disposers[0]!()
     expect(amp.logger.log).toHaveBeenCalled()
   })

--- a/nowledge-mem-amp-plugin/tests/sync.test.ts
+++ b/nowledge-mem-amp-plugin/tests/sync.test.ts
@@ -20,21 +20,30 @@ const FULL_TRANSCRIPT = [
   { role: "assistant", id: "a1", parts: [{ type: "text", text: "hi back" }] },
 ]
 
+/** A second incremental agent-end batch. */
+const FOLLOW_UP_TRANSCRIPT = [
+  { role: "user", id: "u2", parts: [{ type: "text", text: "second turn" }] },
+  { role: "assistant", id: "a2", parts: [{ type: "text", text: "second answer" }] },
+]
+
 /** A transcript missing an assistant turn. */
 const INCOMPLETE_TRANSCRIPT = [{ role: "user", id: "u1", parts: [{ type: "text", text: "hello" }] }]
 
 /** Builds a fake nmemApi that responds per-path. Handlers may be async. */
 function fakeNmemApi(
   handlers: Record<string, (() => HttpResponse) | (() => Promise<HttpResponse>)>,
-): SessionSyncManagerOptions["nmemApi"] & { calls: string[] } {
+): SessionSyncManagerOptions["nmemApi"] & { calls: string[]; bodies: unknown[] } {
   const calls: string[] = []
-  const fn = ((path: string) => {
+  const bodies: unknown[] = []
+  const fn = ((path: string, body: unknown) => {
     calls.push(path)
+    bodies.push(body)
     const handler = handlers[path] ?? handlers["default"]
     if (handler === undefined) return Promise.resolve({ ok: false, status: 500, data: { error: "no handler" } })
     return Promise.resolve(handler())
-  }) as unknown as SessionSyncManagerOptions["nmemApi"] & { calls: string[] }
+  }) as unknown as SessionSyncManagerOptions["nmemApi"] & { calls: string[]; bodies: unknown[] }
   fn.calls = calls
+  fn.bodies = bodies
   return fn
 }
 
@@ -326,6 +335,41 @@ describe("SessionSyncManager.scheduleSync", () => {
     expect(nmemApi.calls).toEqual(["/threads"])
   })
 
+  it("persists the incremental agent.end messages without reading the thread", async () => {
+    const timers = fakeTimers()
+    const nmemApi = fakeNmemApi({ "/threads": () => ({ ok: true, status: 200, data: {} }) })
+    const readThreadMessages = vi.fn(async () => FULL_TRANSCRIPT)
+    const manager = new SessionSyncManager(managerOptions({ nmemApi, readThreadMessages, ...timers }))
+
+    manager.scheduleSync(THREAD_ID, FULL_TRANSCRIPT)
+    timers.fireAll()
+    await flushMicrotasks()
+
+    expect(nmemApi.calls).toEqual(["/threads"])
+    expect(readThreadMessages).not.toHaveBeenCalled()
+  })
+
+  it("merges incremental messages scheduled inside the debounce window", async () => {
+    const timers = fakeTimers()
+    const nmemApi = fakeNmemApi({ "/threads": () => ({ ok: true, status: 200, data: {} }) })
+    const readThreadMessages = vi.fn(async () => FULL_TRANSCRIPT)
+    const manager = new SessionSyncManager(managerOptions({ nmemApi, readThreadMessages, ...timers }))
+
+    manager.scheduleSync(THREAD_ID, FULL_TRANSCRIPT)
+    manager.scheduleSync(THREAD_ID, FOLLOW_UP_TRANSCRIPT)
+    timers.fireAll()
+    await flushMicrotasks()
+
+    const body = nmemApi.bodies[0] as { readonly messages: Array<{ readonly metadata: { readonly external_id: string } }> }
+    expect(body.messages.map((message) => message.metadata.external_id)).toEqual([
+      "amp-msg-u1",
+      "amp-msg-a1",
+      "amp-msg-u2",
+      "amp-msg-a2",
+    ])
+    expect(readThreadMessages).not.toHaveBeenCalled()
+  })
+
   it("skips an unchanged transcript on a second non-forced schedule", async () => {
     const timers = fakeTimers()
     const nmemApi = fakeNmemApi({ "/threads": () => ({ ok: true, status: 200, data: {} }) })
@@ -386,6 +430,50 @@ describe("SessionSyncManager.scheduleSync", () => {
 
     // Dedup prevents further persistence of the same signature.
     expect(nmemApi.calls).toEqual(["/threads"])
+  })
+
+  it("preserves pending incremental messages while another capture is in flight", async () => {
+    let resolveFirst: (value: HttpResponse) => void
+    const firstInFlight = new Promise<HttpResponse>((resolve) => {
+      resolveFirst = resolve
+    })
+    let callCount = 0
+    const nmemApi = fakeNmemApi({
+      "/threads": async () => {
+        callCount += 1
+        return callCount === 1 ? await firstInFlight : { ok: true, status: 200, data: {} }
+      },
+    })
+    const timers = fakeTimers()
+    const manager = new SessionSyncManager(managerOptions({ nmemApi, ...timers }))
+
+    manager.scheduleSync(THREAD_ID, FULL_TRANSCRIPT)
+    timers.fireAll()
+    await flushMicrotasks()
+    expect(nmemApi.calls).toEqual(["/threads"])
+
+    manager.scheduleSync(THREAD_ID, FOLLOW_UP_TRANSCRIPT)
+    manager.scheduleSync(THREAD_ID, [
+      FOLLOW_UP_TRANSCRIPT[1],
+      { role: "user", id: "u3", parts: [{ type: "text", text: "third turn" }] },
+      { role: "assistant", id: "a3", parts: [{ type: "text", text: "third answer" }] },
+    ])
+    timers.fireAll()
+    await flushMicrotasks()
+    expect(nmemApi.calls).toEqual(["/threads"])
+
+    resolveFirst!({ ok: true, status: 200, data: {} })
+    await vi.waitFor(() => expect(timers.handles).toHaveLength(1))
+    timers.fireAll()
+    await vi.waitFor(() => expect(nmemApi.bodies).toHaveLength(2))
+
+    const body = nmemApi.bodies[1] as { readonly messages: Array<{ readonly metadata: { readonly external_id: string } }> }
+    expect(body.messages.map((message) => message.metadata.external_id)).toEqual([
+      "amp-msg-u2",
+      "amp-msg-a2",
+      "amp-msg-u3",
+      "amp-msg-a3",
+    ])
   })
 })
 

--- a/tests/plugin_e2e/test_key_plugins_e2e.py
+++ b/tests/plugin_e2e/test_key_plugins_e2e.py
@@ -1626,7 +1626,7 @@ def test_amp_plugin_static_contract_is_self_contained():
 
     # Package manifest and registry entry agree on the basics.
     assert pkg["name"] == "amp-nowledge-mem"
-    assert pkg["version"] == "0.1.1"
+    assert pkg["version"] == "0.1.2"
     assert pkg["type"] == "module"
     assert pkg["main"] == "src/index.ts"
     assert "@ampcode/plugin" in pkg["peerDependencies"]


### PR DESCRIPTION
## Summary

- Capture automatic Amp session updates from the `agent.end` payload instead of querying the thread transcript.
- Keep explicit manual saves as full-history captures.
- Preserve the latest `agent.end` payload when another capture is already in flight.

This removes the expensive Plugin RPC read from the automatic `agent.end` path, which can stall long Amp sessions. Manual save retains its full-history contract.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance Improvements**
  * Improved automatic synchronization by using messages already available from completed agent events.
  * Prevented unnecessary transcript reads during incremental message capture.

* **Bug Fixes**
  * Manual saves now read the complete conversation transcript.
  * Preserved the latest message batch when synchronization is delayed or rescheduled.
  * Ensured incremental messages are saved even when synchronization is already in progress.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->