### PR TITLE
fix(codex): bound Stop hook timeout budget

### DIFF
--- a/integrations.json
+++ b/integrations.json
@@ -302,7 +302,7 @@
       "name": "Codex",
       "category": "coding",
       "type": "plugin",
-      "version": "0.1.30",
+      "version": "0.1.31",
       "directory": "nowledge-mem-codex-plugin",
 
       "legacyDirectory": "nowledge-mem-codex-prompts",

--- a/nowledge-mem-codex-plugin/.codex-plugin/plugin.json
+++ b/nowledge-mem-codex-plugin/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "nowledge-mem",
-  "version": "0.1.30",
+  "version": "0.1.31",
   "description": "Your Codex agent remembers past decisions, finds relevant context, and learns from every session, across all your AI tools.",
   "skills": "./skills/",
   "mcpServers": "./.mcp.json",

--- a/nowledge-mem-codex-plugin/CHANGELOG.md
+++ b/nowledge-mem-codex-plugin/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## [0.1.31] - 2026-08-13
+
+### Fixed
+
+- Codex Stop capture now gives the synchronous save path a coherent timeout
+  budget: the packaged and installed hooks allow 120 seconds, while capture
+  work uses one 105-second monotonic deadline, 25-second per-call caps, and
+  deadline-aware retry sleeps. Transcript capture remains the priority; optional
+  skill outcome reporting only runs when budget remains.
+
 ## [0.1.30] - 2026-08-08
 
 ### Added

--- a/nowledge-mem-codex-plugin/hooks/hooks.json
+++ b/nowledge-mem-codex-plugin/hooks/hooks.json
@@ -48,7 +48,7 @@
             "type": "command",
             "command": "python3 -c \"import os, runpy, sys; p = os.path.join(os.environ['PLUGIN_ROOT'], 'hooks', 'nmem-stop-launch.py'); sys.argv = [p, *sys.argv[1:]]; runpy.run_path(p, run_name='__main__')\" --event stop || python -c \"import os, runpy, sys; p = os.path.join(os.environ['PLUGIN_ROOT'], 'hooks', 'nmem-stop-launch.py'); sys.argv = [p, *sys.argv[1:]]; runpy.run_path(p, run_name='__main__')\" --event stop || py -3 -c \"import os, runpy, sys; p = os.path.join(os.environ['PLUGIN_ROOT'], 'hooks', 'nmem-stop-launch.py'); sys.argv = [p, *sys.argv[1:]]; runpy.run_path(p, run_name='__main__')\" --event stop",
             "commandWindows": "py -3 -c \"import os, runpy, sys; p = os.path.join(os.environ['PLUGIN_ROOT'], 'hooks', 'nmem-stop-launch.py'); sys.argv = [p, *sys.argv[1:]]; runpy.run_path(p, run_name='__main__')\" --event stop || python -c \"import os, runpy, sys; p = os.path.join(os.environ['PLUGIN_ROOT'], 'hooks', 'nmem-stop-launch.py'); sys.argv = [p, *sys.argv[1:]]; runpy.run_path(p, run_name='__main__')\" --event stop || python3 -c \"import os, runpy, sys; p = os.path.join(os.environ['PLUGIN_ROOT'], 'hooks', 'nmem-stop-launch.py'); sys.argv = [p, *sys.argv[1:]]; runpy.run_path(p, run_name='__main__')\" --event stop",
-            "timeout": 40,
+            "timeout": 120,
             "statusMessage": "Saving Codex thread to Nowledge Mem..."
           }
         ]

--- a/nowledge-mem-codex-plugin/hooks/nmem-stop-save.py
+++ b/nowledge-mem-codex-plugin/hooks/nmem-stop-save.py
@@ -15,10 +15,12 @@ from pathlib import Path
 from typing import Any
 
 
-ATTEMPT_TIMEOUT_SECONDS = 8
-SAVE_RETRY_DELAYS_SECONDS = (0.0, 0.5, 1.5, 3.0)
+CAPTURE_DEADLINE_SECONDS = 105.0
+CAPTURE_ATTEMPT_TIMEOUT_SECONDS = 25.0
+MIN_CAPTURE_ATTEMPT_SECONDS = 1.0
+SAVE_RETRY_DELAYS_SECONDS = (0.0, 1.0, 3.0, 6.0)
 CAPTURE_LOCK_STALE_SECONDS = 90
-SKILL_OUTCOME_TIMEOUT_SECONDS = 8
+SKILL_OUTCOME_TIMEOUT_SECONDS = 8.0
 SESSION_NOT_FOUND_MARKERS = (
     "No codex sessions found",
     "Codex sessions directory not found",
@@ -155,6 +157,44 @@ def _log(message: str) -> None:
             handle.write(f"[{timestamp}] {message}\n")
     except Exception:
         pass
+
+
+def _deadline_after(seconds: float) -> float:
+    return time.monotonic() + max(0.0, seconds)
+
+
+def _remaining_seconds(deadline: float | None) -> float | None:
+    if deadline is None:
+        return None
+    return max(0.0, deadline - time.monotonic())
+
+
+def _attempt_timeout_seconds(deadline: float | None) -> float | None:
+    remaining = _remaining_seconds(deadline)
+    if remaining is None:
+        return CAPTURE_ATTEMPT_TIMEOUT_SECONDS
+    if remaining < MIN_CAPTURE_ATTEMPT_SECONDS:
+        return None
+    return min(CAPTURE_ATTEMPT_TIMEOUT_SECONDS, remaining)
+
+
+def _sleep_with_deadline(delay: float, deadline: float | None) -> bool:
+    if delay <= 0:
+        return _attempt_timeout_seconds(deadline) is not None
+    remaining = _remaining_seconds(deadline)
+    if remaining is None:
+        time.sleep(delay)
+        return True
+    if remaining < MIN_CAPTURE_ATTEMPT_SECONDS:
+        return False
+    time.sleep(min(delay, max(0.0, remaining - MIN_CAPTURE_ATTEMPT_SECONDS)))
+    return _attempt_timeout_seconds(deadline) is not None
+
+
+def _timeout_message(prefix: str, timeout_seconds: float | None) -> str:
+    if timeout_seconds is None:
+        return f"{prefix} timed out"
+    return f"{prefix} timed out after {timeout_seconds:.1f}s"
 
 
 def _capture_lock_root(payload: dict[str, Any]) -> Path:
@@ -309,6 +349,7 @@ def _run_save(
     *,
     include_session_id: bool,
     json_output: bool = True,
+    timeout_seconds: float = CAPTURE_ATTEMPT_TIMEOUT_SECONDS,
 ) -> subprocess.CompletedProcess[str]:
     command = _build_save_command(
         nmem,
@@ -325,7 +366,7 @@ def _run_save(
         text=True,
         encoding="utf-8",
         errors="replace",
-        timeout=ATTEMPT_TIMEOUT_SECONDS,
+        timeout=timeout_seconds,
         check=False,
         **_windows_no_window_kwargs(),
     )
@@ -383,7 +424,12 @@ def _release_skill_outcome_claim(lock_path: Path | None) -> None:
         pass
 
 
-def _report_skill_outcomes(nmem: str, payload: dict[str, Any]) -> None:
+def _report_skill_outcomes(
+    nmem: str,
+    payload: dict[str, Any],
+    *,
+    deadline: float | None = None,
+) -> None:
     if extract_skill_outcomes_from_file is None or build_outcome_args is None:
         _log("skill-outcome: extractor unavailable")
         return
@@ -394,6 +440,15 @@ def _report_skill_outcomes(nmem: str, payload: dict[str, Any]) -> None:
 
     env = _build_env(payload)
     for skill_id, version in outcomes:
+        remaining = _remaining_seconds(deadline)
+        if remaining is not None and remaining < MIN_CAPTURE_ATTEMPT_SECONDS:
+            _log("skill-outcome: skipped because Stop hook budget is exhausted")
+            return
+        timeout_seconds = (
+            SKILL_OUTCOME_TIMEOUT_SECONDS
+            if remaining is None
+            else min(SKILL_OUTCOME_TIMEOUT_SECONDS, remaining)
+        )
         lock_path = _claim_skill_outcome_report(payload, skill_id, version)
         if lock_path is None:
             continue
@@ -407,7 +462,7 @@ def _report_skill_outcomes(nmem: str, payload: dict[str, Any]) -> None:
                 text=True,
                 encoding="utf-8",
                 errors="replace",
-                timeout=SKILL_OUTCOME_TIMEOUT_SECONDS,
+                timeout=timeout_seconds,
                 check=False,
                 **_windows_no_window_kwargs(),
             )
@@ -452,43 +507,67 @@ def _run_save_with_retries(
     payload: dict[str, Any],
     *,
     include_session_id: bool,
+    deadline: float | None = None,
 ) -> tuple[bool, subprocess.CompletedProcess[str]]:
     last_proc = subprocess.CompletedProcess([], 0, stdout="", stderr="")
     for delay in SAVE_RETRY_DELAYS_SECONDS:
-        if delay:
-            time.sleep(delay)
+        if not _sleep_with_deadline(delay, deadline):
+            last_proc = subprocess.CompletedProcess(
+                [],
+                124,
+                stdout="",
+                stderr="capture deadline exhausted before next attempt",
+            )
+            break
+        timeout_seconds = _attempt_timeout_seconds(deadline)
+        if timeout_seconds is None:
+            last_proc = subprocess.CompletedProcess(
+                [],
+                124,
+                stdout="",
+                stderr="capture deadline exhausted before next attempt",
+            )
+            break
         try:
             last_proc = _run_save(
                 nmem,
                 payload,
                 include_session_id=include_session_id,
                 json_output=True,
+                timeout_seconds=timeout_seconds,
             )
         except subprocess.TimeoutExpired as exc:
             last_proc = subprocess.CompletedProcess(
                 [],
                 124,
                 stdout=exc.stdout or "",
-                stderr=f"capture attempt timed out after {ATTEMPT_TIMEOUT_SECONDS}s",
+                stderr=_timeout_message("capture attempt", timeout_seconds),
             )
             continue
         if last_proc.returncode != 0 and _json_flag_unsupported(last_proc):
+            timeout_seconds = _attempt_timeout_seconds(deadline)
+            if timeout_seconds is None:
+                last_proc = subprocess.CompletedProcess(
+                    [],
+                    124,
+                    stdout="",
+                    stderr="capture deadline exhausted before legacy retry",
+                )
+                break
             try:
                 last_proc = _run_save(
                     nmem,
                     payload,
                     include_session_id=include_session_id,
                     json_output=False,
+                    timeout_seconds=timeout_seconds,
                 )
             except subprocess.TimeoutExpired as exc:
                 last_proc = subprocess.CompletedProcess(
                     [],
                     124,
                     stdout=exc.stdout or "",
-                    stderr=(
-                        f"legacy capture attempt timed out after "
-                        f"{ATTEMPT_TIMEOUT_SECONDS}s"
-                    ),
+                    stderr=_timeout_message("legacy capture attempt", timeout_seconds),
                 )
                 continue
             if last_proc.returncode == 0:
@@ -530,13 +609,14 @@ def main() -> int:
         _log("skip: duplicate Stop hook event already claimed")
         return 0
 
+    deadline = _deadline_after(CAPTURE_DEADLINE_SECONDS)
     delegated_originator = _delegated_conversation_originator(payload)
     if delegated_originator:
         # Raft owns the real channel/thread boundary. Its long-lived Codex
         # rollout is an execution trace containing inbox control notices and
         # empty final answers, not a user conversation. Keep skill telemetry,
         # but never persist that rollout as a Codex Thread.
-        _report_skill_outcomes(nmem, payload)
+        _report_skill_outcomes(nmem, payload, deadline=deadline)
         _log(
             "skip: delegated conversation host owns thread capture "
             f"originator={delegated_originator}"
@@ -545,7 +625,10 @@ def main() -> int:
 
     try:
         captured, proc = _run_save_with_retries(
-            nmem, payload, include_session_id=bool(session_id)
+            nmem,
+            payload,
+            include_session_id=bool(session_id),
+            deadline=deadline,
         )
     except Exception as exc:
         _log(f"skip: capture failed: {exc}")
@@ -555,7 +638,10 @@ def main() -> int:
         _log("retry: session-id lookup missed; falling back to latest project session")
         try:
             captured, proc = _run_save_with_retries(
-                nmem, payload, include_session_id=False
+                nmem,
+                payload,
+                include_session_id=False,
+                deadline=deadline,
             )
         except Exception as exc:
             _log(f"skip: fallback capture failed: {exc}")
@@ -564,7 +650,7 @@ def main() -> int:
     if proc.returncode == 0 and not captured:
         _log("skip: no flushed transcript found")
     if captured:
-        _report_skill_outcomes(nmem, payload)
+        _report_skill_outcomes(nmem, payload, deadline=deadline)
 
     _log(f"nmem_exit={proc.returncode}")
     if proc.stdout.strip():

--- a/nowledge-mem-codex-plugin/scripts/install_hooks.py
+++ b/nowledge-mem-codex-plugin/scripts/install_hooks.py
@@ -173,7 +173,7 @@ def merge_hooks_json() -> None:
                 {
                     "type": "command",
                     "command": _hook_command(),
-                    "timeout": 40,
+                    "timeout": 120,
                     "statusMessage": "Saving Codex thread to Nowledge Mem...",
                 }
             ],

--- a/nowledge-mem-codex-plugin/tests/test_codex_plugin.py
+++ b/nowledge-mem-codex-plugin/tests/test_codex_plugin.py
@@ -91,7 +91,7 @@ class HookTests(unittest.TestCase):
     def test_retry_without_session_id_on_lookup_miss(self):
         calls = []
 
-        def fake_run(nmem, payload, *, include_session_id):
+        def fake_run(nmem, payload, *, include_session_id, deadline=None):
             calls.append(include_session_id)
             proc = mock.Mock(
                 returncode=1 if include_session_id else 0,
@@ -111,6 +111,16 @@ class HookTests(unittest.TestCase):
 
         self.assertEqual(calls, [True, False])
 
+    def test_stop_capture_budget_matches_packaged_hook_timeout(self):
+        payload = json.loads(HOOKS_JSON_PATH.read_text(encoding="utf-8"))
+        hook = payload["hooks"]["Stop"][0]["hooks"][0]
+
+        self.assertEqual(hook["timeout"], 120)
+        self.assertEqual(self.module.CAPTURE_DEADLINE_SECONDS, 105.0)
+        self.assertEqual(self.module.CAPTURE_ATTEMPT_TIMEOUT_SECONDS, 25.0)
+        self.assertEqual(self.module.SAVE_RETRY_DELAYS_SECONDS, (0.0, 1.0, 3.0, 6.0))
+        self.assertLess(self.module.CAPTURE_DEADLINE_SECONDS, hook["timeout"])
+
     def test_run_save_retries_until_nmem_reports_saved_result(self):
         calls = [
             mock.Mock(returncode=0, stdout='{"results":[]}', stderr=""),
@@ -123,11 +133,49 @@ class HookTests(unittest.TestCase):
                 "/usr/local/bin/nmem",
                 {"session_id": "019abc"},
                 include_session_id=True,
+                deadline=None,
             )
 
         self.assertTrue(captured)
         self.assertEqual(proc.stdout, '{"results":[{"action":"created"}]}')
         self.assertEqual(run.call_count, 2)
+
+    def test_run_save_retries_use_deadline_aware_attempt_timeout(self):
+        calls = [
+            mock.Mock(returncode=0, stdout='{"results":[]}', stderr=""),
+            mock.Mock(returncode=0, stdout='{"results":[{"action":"created"}]}', stderr=""),
+        ]
+
+        with mock.patch.object(self.module, "SAVE_RETRY_DELAYS_SECONDS", (0.0, 0.0)), \
+             mock.patch.object(self.module.time, "monotonic", side_effect=[0.0, 0.0, 90.0, 90.0]), \
+             mock.patch.object(self.module, "_run_save", side_effect=calls) as run:
+            captured, proc = self.module._run_save_with_retries(
+                "/usr/local/bin/nmem",
+                {"session_id": "019abc"},
+                include_session_id=True,
+                deadline=100.0,
+            )
+
+        self.assertTrue(captured)
+        self.assertEqual(proc.stdout, '{"results":[{"action":"created"}]}')
+        self.assertEqual(run.call_args_list[0].kwargs["timeout_seconds"], 25.0)
+        self.assertEqual(run.call_args_list[1].kwargs["timeout_seconds"], 10.0)
+
+    def test_run_save_retries_do_not_start_when_deadline_is_exhausted(self):
+        with mock.patch.object(self.module, "SAVE_RETRY_DELAYS_SECONDS", (0.0,)), \
+             mock.patch.object(self.module.time, "monotonic", return_value=99.5), \
+             mock.patch.object(self.module, "_run_save") as run:
+            captured, proc = self.module._run_save_with_retries(
+                "/usr/local/bin/nmem",
+                {"session_id": "019abc"},
+                include_session_id=True,
+                deadline=100.0,
+            )
+
+        self.assertFalse(captured)
+        self.assertEqual(proc.returncode, 124)
+        self.assertIn("deadline exhausted", proc.stderr)
+        run.assert_not_called()
 
     def test_run_save_hides_child_console_on_windows(self):
         with mock.patch.object(self.module, "_build_save_command", return_value=["nmem.cmd", "--version"]), \
@@ -142,6 +190,10 @@ class HookTests(unittest.TestCase):
             )
 
         self.assertEqual(run.call_args.kwargs["creationflags"], 0x08000000)
+        self.assertEqual(
+            run.call_args.kwargs["timeout"],
+            self.module.CAPTURE_ATTEMPT_TIMEOUT_SECONDS,
+        )
 
     def test_run_save_does_not_pass_windows_creationflags_on_posix(self):
         with mock.patch.object(self.module, "_build_save_command", return_value=["nmem", "--version"]), \
@@ -169,6 +221,7 @@ class HookTests(unittest.TestCase):
                 "/usr/local/bin/nmem",
                 {"session_id": "019abc"},
                 include_session_id=True,
+                deadline=None,
             )
 
         self.assertTrue(captured)
@@ -981,7 +1034,7 @@ class InstallHookTests(unittest.TestCase):
         self.assertIn("echo keep", stop[0]["hooks"][0]["command"])
         self.assertIn("nowledge-mem-stop-save.py", stop[1]["hooks"][0]["command"])
         self.assertNotIn("async", stop[1]["hooks"][0])
-        self.assertEqual(stop[1]["hooks"][0]["timeout"], 40)
+        self.assertEqual(stop[1]["hooks"][0]["timeout"], 120)
         self.assertIn("statusMessage", stop[1]["hooks"][0])
         self.assertNotIn("/old/nmem-stop-save.py", json.dumps(stop))
 

--- a/tests/plugin_e2e/test_key_plugins_e2e.py
+++ b/tests/plugin_e2e/test_key_plugins_e2e.py
@@ -399,7 +399,7 @@ def test_key_plugin_static_contracts_are_declared():
     codex_save_hook = (CODEX_PLUGIN / "hooks" / "nmem-stop-save.py").read_text(encoding="utf-8")
     codex_runtime = (CODEX_PLUGIN / "hooks" / "nmem_runtime.py").read_text(encoding="utf-8")
     assert codex_manifest["name"] == "nowledge-mem"
-    assert codex_manifest["version"] == "0.1.30"
+    assert codex_manifest["version"] == "0.1.31"
     assert registry_by_id["codex-cli"]["version"] == codex_manifest["version"]
     assert codex_manifest["skills"] == "./skills/"
     assert codex_manifest["mcpServers"] == "./.mcp.json"


### PR DESCRIPTION
## Summary

Fixes the Codex plugin Stop-hook timeout budget mismatch reported in #498 and releases the plugin metadata as `0.1.31`.

## What changed

- Raises the packaged and installer-written Codex Stop hook timeout from 40s to 120s.
- Gives Stop capture one 105s monotonic deadline with 25s per-call caps.
- Makes retry sleeps, legacy `--json` fallback, session-id fallback, and optional skill outcome reporting consume that same deadline.
- Keeps transcript capture as the priority; skill outcome reporting is skipped when the Stop-hook budget is exhausted.
- Updates the plugin changelog, manifest version, integration registry version, and static contract expectation.

Closes #498.

## Tests

- `uv run --with pytest pytest community/nowledge-mem-codex-plugin/tests/test_codex_plugin.py -q`
  - `70 passed in 20.46s`
- `uv run --with pytest pytest community/tests/plugin_e2e/test_key_plugins_e2e.py -q`
  - `24 passed, 6 skipped in 13.09s`
- `node community/nowledge-mem-codex-plugin/scripts/validate-plugin.mjs`
  - `Codex plugin validation passed.`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Codex Stop capture reliability with unified timeout handling and deadline-aware retries.
  * Increased the Stop hook timeout to 120 seconds, with safer per-attempt limits and clearer handling when time expires.

* **Chores**
  * Updated the Codex integration and plugin version to 0.1.31.
  * Added release notes documenting the timeout and capture improvements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 06827ac0a22dd90322f8dd44e2c022a5cb724e9d. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->