### PR TITLE
fix(copilot): use cross-shell hook runner

### DIFF
--- a/nowledge-mem-copilot-cli-plugin/hooks/copilot-hook.py
+++ b/nowledge-mem-copilot-cli-plugin/hooks/copilot-hook.py
@@ -1,0 +1,147 @@
+#!/usr/bin/env python3
+"""Cross-shell Copilot CLI hook entry point for Nowledge Mem.
+
+Copilot CLI runs hook command strings through the host shell. On Windows that
+can be PowerShell, so hooks.json must not contain POSIX shell functions or
+conditionals. This file owns the logic; the shell only starts Python.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+
+NMEM_TIMEOUT_SECS = 30
+
+
+def windows_no_window_kwargs() -> dict[str, int]:
+    if sys.platform != "win32":
+        return {}
+    return {"creationflags": getattr(subprocess, "CREATE_NO_WINDOW", 0x08000000)}
+
+
+def build_nmem_command(nmem_bin: str, *args: str) -> list[str]:
+    if nmem_bin.lower().endswith(".cmd"):
+        return ["cmd.exe", "/d", "/c", "call", nmem_bin, *args]
+    return [nmem_bin, *args]
+
+
+def nmem_bin() -> str | None:
+    return shutil.which("nmem") or shutil.which("nmem.cmd")
+
+
+def run_json(nmem: str, *args: str) -> dict:
+    proc = subprocess.run(
+        build_nmem_command(nmem, *args),
+        capture_output=True,
+        text=True,
+        timeout=NMEM_TIMEOUT_SECS,
+        **windows_no_window_kwargs(),
+    )
+    if proc.returncode != 0:
+        raise RuntimeError(proc.stderr.strip() or proc.stdout.strip() or "command failed")
+    output = proc.stdout.strip()
+    return json.loads(output) if output else {}
+
+
+def append_scope_args(args: list[str]) -> list[str]:
+    agent_id = os.environ.get("NMEM_AGENT_ID", "").strip()
+    host_agent_id = os.environ.get("NMEM_HOST_AGENT_ID", "").strip()
+    space = os.environ.get("NMEM_SPACE", "").strip() or os.environ.get("NMEM_SPACE_ID", "").strip()
+    if agent_id:
+        args.extend(["--agent-id", agent_id])
+    if host_agent_id:
+        args.extend(["--host-agent-id", host_agent_id])
+    if space:
+        args.extend(["--space", space])
+    return args
+
+
+def read_context() -> str:
+    nmem = nmem_bin()
+    if nmem:
+        try:
+            payload = run_json(
+                nmem,
+                *append_scope_args(["--json", "context", "--source-app", "copilot-cli"]),
+            )
+            content = (
+                payload.get("rendered_markdown")
+                or payload.get("markdown")
+                or payload.get("content")
+                or ""
+            )
+            if content:
+                return str(content)
+        except Exception:
+            pass
+        try:
+            payload = run_json(nmem, "--json", "wm", "read")
+            content = payload.get("content") or ""
+            if content:
+                return str(content)
+        except Exception:
+            pass
+
+    fallback = Path.home() / "ai-now" / "memory.md"
+    try:
+        return fallback.read_text(encoding="utf-8")
+    except Exception:
+        return ""
+
+
+def run_capture(event: str, raw_stdin: str) -> int:
+    script = Path(__file__).with_name("copilot-stop-save.py")
+    if not script.exists():
+        return 0
+    proc = subprocess.run(
+        [sys.executable, str(script), "--event", event],
+        input=raw_stdin,
+        text=True,
+        **windows_no_window_kwargs(),
+    )
+    return proc.returncode
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--event", default="")
+    args, _unknown = parser.parse_known_args()
+    event = (args.event or "").strip().lower()
+    raw = sys.stdin.read()
+
+    if event in {"session-start", "compact"}:
+        content = read_context()
+        if content:
+            print(content)
+        if event == "compact":
+            print(
+                "\n---\nContext was compacted. If you discovered important insights, "
+                "save them before continuing:\n  nmem m add \"<insight>\" "
+                "--title \"<short title>\" --importance 0.8"
+            )
+        return 0
+
+    if event == "user-prompt-submit":
+        if nmem_bin():
+            print(
+                "[Nowledge Mem] Search proactively when past knowledge would help: "
+                "nmem --json m search \"query\". Save decisions and learnings "
+                "autonomously: nmem m add \"content\" -t \"Title\" -i 0.8"
+            )
+        return 0
+
+    if event in {"stop", "pre-compact", "session-end"}:
+        return run_capture(event, raw)
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/nowledge-mem-copilot-cli-plugin/hooks/hooks.json
+++ b/nowledge-mem-copilot-cli-plugin/hooks/hooks.json
@@ -7,7 +7,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "command -v nmem >/dev/null 2>&1 || { command -v nmem.cmd >/dev/null 2>&1 && nmem(){ python3 -c 'import subprocess,sys; raise SystemExit(subprocess.run([\"cmd.exe\", \"/s\", \"/c\", subprocess.list2cmdline([\"nmem.cmd\", *sys.argv[1:]])]).returncode)' \"$@\"; }; }; read_context(){ set -- context --source-app copilot-cli; [ -n \"${NMEM_AGENT_ID:-}\" ] && set -- \"$@\" --agent-id \"$NMEM_AGENT_ID\"; [ -n \"${NMEM_HOST_AGENT_ID:-}\" ] && set -- \"$@\" --host-agent-id \"$NMEM_HOST_AGENT_ID\"; space=\"${NMEM_SPACE:-}\"; [ -n \"$space\" ] || space=\"${NMEM_SPACE_ID:-}\"; [ -n \"$space\" ] && set -- \"$@\" --space \"$space\"; nmem --json \"$@\" 2>/dev/null | python3 -c \"import sys,json;d=json.load(sys.stdin);c=d.get('rendered_markdown') or d.get('markdown') or d.get('content') or '';print(c) if c else sys.exit(1)\" 2>/dev/null; }; read_wm(){ nmem --json wm read 2>/dev/null | python3 -c \"import sys,json;d=json.load(sys.stdin);c=d.get('content','');print(c) if c else sys.exit(1)\" 2>/dev/null; }; read_context || read_wm || cat ~/ai-now/memory.md 2>/dev/null || true"
+            "command": "python3 -c \"import os,pathlib,runpy; r=os.environ.get('COPILOT_PLUGIN_ROOT') or os.environ.get('PLUGIN_ROOT') or os.environ.get('CLAUDE_PLUGIN_ROOT') or str(pathlib.Path.home()/'.copilot'/'nowledge-mem-hooks'); p=pathlib.Path(r)/'hooks'/'copilot-hook.py'; runpy.run_path(str(p if p.exists() else pathlib.Path(r)/'copilot-hook.py'), run_name='__main__')\" --event session-start"
           }
         ]
       },
@@ -16,7 +16,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "command -v nmem >/dev/null 2>&1 || { command -v nmem.cmd >/dev/null 2>&1 && nmem(){ python3 -c 'import subprocess,sys; raise SystemExit(subprocess.run([\"cmd.exe\", \"/s\", \"/c\", subprocess.list2cmdline([\"nmem.cmd\", *sys.argv[1:]])]).returncode)' \"$@\"; }; }; read_context(){ set -- context --source-app copilot-cli; [ -n \"${NMEM_AGENT_ID:-}\" ] && set -- \"$@\" --agent-id \"$NMEM_AGENT_ID\"; [ -n \"${NMEM_HOST_AGENT_ID:-}\" ] && set -- \"$@\" --host-agent-id \"$NMEM_HOST_AGENT_ID\"; space=\"${NMEM_SPACE:-}\"; [ -n \"$space\" ] || space=\"${NMEM_SPACE_ID:-}\"; [ -n \"$space\" ] && set -- \"$@\" --space \"$space\"; nmem --json \"$@\" 2>/dev/null | python3 -c \"import sys,json;d=json.load(sys.stdin);c=d.get('rendered_markdown') or d.get('markdown') or d.get('content') or '';print(c) if c else sys.exit(1)\" 2>/dev/null; }; read_wm(){ nmem --json wm read 2>/dev/null | python3 -c \"import sys,json;d=json.load(sys.stdin);c=d.get('content','');print(c) if c else sys.exit(1)\" 2>/dev/null; }; { read_context || read_wm || cat ~/ai-now/memory.md 2>/dev/null || true; } && printf '\\n---\\nContext was compacted. If you discovered important insights, save them before continuing:\\n  nmem m add \"<insight>\" --title \"<short title>\" --importance 0.8\\n'"
+            "command": "python3 -c \"import os,pathlib,runpy; r=os.environ.get('COPILOT_PLUGIN_ROOT') or os.environ.get('PLUGIN_ROOT') or os.environ.get('CLAUDE_PLUGIN_ROOT') or str(pathlib.Path.home()/'.copilot'/'nowledge-mem-hooks'); p=pathlib.Path(r)/'hooks'/'copilot-hook.py'; runpy.run_path(str(p if p.exists() else pathlib.Path(r)/'copilot-hook.py'), run_name='__main__')\" --event compact"
           }
         ]
       }
@@ -26,7 +26,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "command -v nmem >/dev/null 2>&1 || { command -v nmem.cmd >/dev/null 2>&1 && nmem(){ python3 -c 'import subprocess,sys; raise SystemExit(subprocess.run([\"cmd.exe\", \"/s\", \"/c\", subprocess.list2cmdline([\"nmem.cmd\", *sys.argv[1:]])]).returncode)' \"$@\"; }; }; command -v nmem >/dev/null 2>&1 && printf '[Nowledge Mem] Search proactively when past knowledge would help: nmem --json m search \"query\". Save decisions and learnings autonomously: nmem m add \"content\" -t \"Title\" -i 0.8' || true"
+            "command": "python3 -c \"import os,pathlib,runpy; r=os.environ.get('COPILOT_PLUGIN_ROOT') or os.environ.get('PLUGIN_ROOT') or os.environ.get('CLAUDE_PLUGIN_ROOT') or str(pathlib.Path.home()/'.copilot'/'nowledge-mem-hooks'); p=pathlib.Path(r)/'hooks'/'copilot-hook.py'; runpy.run_path(str(p if p.exists() else pathlib.Path(r)/'copilot-hook.py'), run_name='__main__')\" --event user-prompt-submit"
           }
         ]
       }
@@ -36,7 +36,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "PLUGIN_HOOK_DIR=\"${COPILOT_PLUGIN_ROOT:-${PLUGIN_ROOT:-${CLAUDE_PLUGIN_ROOT:-}}}/hooks\"; FALLBACK_HOOK_DIR=\"${HOME}/.copilot/nowledge-mem-hooks\"; if [ -f \"${PLUGIN_HOOK_DIR}/copilot-stop-save.py\" ]; then python3 \"${PLUGIN_HOOK_DIR}/copilot-stop-save.py\" --event stop || true; elif [ -f \"${FALLBACK_HOOK_DIR}/copilot-stop-save.py\" ]; then python3 \"${FALLBACK_HOOK_DIR}/copilot-stop-save.py\" --event stop || true; else true; fi",
+            "command": "python3 -c \"import os,pathlib,runpy; r=os.environ.get('COPILOT_PLUGIN_ROOT') or os.environ.get('PLUGIN_ROOT') or os.environ.get('CLAUDE_PLUGIN_ROOT') or str(pathlib.Path.home()/'.copilot'/'nowledge-mem-hooks'); p=pathlib.Path(r)/'hooks'/'copilot-hook.py'; runpy.run_path(str(p if p.exists() else pathlib.Path(r)/'copilot-hook.py'), run_name='__main__')\" --event stop",
             "async": true
           }
         ]
@@ -47,7 +47,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "PLUGIN_HOOK_DIR=\"${COPILOT_PLUGIN_ROOT:-${PLUGIN_ROOT:-${CLAUDE_PLUGIN_ROOT:-}}}/hooks\"; FALLBACK_HOOK_DIR=\"${HOME}/.copilot/nowledge-mem-hooks\"; if [ -f \"${PLUGIN_HOOK_DIR}/copilot-stop-save.py\" ]; then python3 \"${PLUGIN_HOOK_DIR}/copilot-stop-save.py\" --event pre-compact || true; elif [ -f \"${FALLBACK_HOOK_DIR}/copilot-stop-save.py\" ]; then python3 \"${FALLBACK_HOOK_DIR}/copilot-stop-save.py\" --event pre-compact || true; else true; fi",
+            "command": "python3 -c \"import os,pathlib,runpy; r=os.environ.get('COPILOT_PLUGIN_ROOT') or os.environ.get('PLUGIN_ROOT') or os.environ.get('CLAUDE_PLUGIN_ROOT') or str(pathlib.Path.home()/'.copilot'/'nowledge-mem-hooks'); p=pathlib.Path(r)/'hooks'/'copilot-hook.py'; runpy.run_path(str(p if p.exists() else pathlib.Path(r)/'copilot-hook.py'), run_name='__main__')\" --event pre-compact",
             "timeout": 35
           }
         ]
@@ -58,7 +58,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "PLUGIN_HOOK_DIR=\"${COPILOT_PLUGIN_ROOT:-${PLUGIN_ROOT:-${CLAUDE_PLUGIN_ROOT:-}}}/hooks\"; FALLBACK_HOOK_DIR=\"${HOME}/.copilot/nowledge-mem-hooks\"; if [ -f \"${PLUGIN_HOOK_DIR}/copilot-stop-save.py\" ]; then python3 \"${PLUGIN_HOOK_DIR}/copilot-stop-save.py\" --event session-end || true; elif [ -f \"${FALLBACK_HOOK_DIR}/copilot-stop-save.py\" ]; then python3 \"${FALLBACK_HOOK_DIR}/copilot-stop-save.py\" --event session-end || true; else true; fi",
+            "command": "python3 -c \"import os,pathlib,runpy; r=os.environ.get('COPILOT_PLUGIN_ROOT') or os.environ.get('PLUGIN_ROOT') or os.environ.get('CLAUDE_PLUGIN_ROOT') or str(pathlib.Path.home()/'.copilot'/'nowledge-mem-hooks'); p=pathlib.Path(r)/'hooks'/'copilot-hook.py'; runpy.run_path(str(p if p.exists() else pathlib.Path(r)/'copilot-hook.py'), run_name='__main__')\" --event session-end",
             "timeout": 35
           }
         ]

--- a/nowledge-mem-copilot-cli-plugin/tests/test_copilot_plugin.py
+++ b/nowledge-mem-copilot-cli-plugin/tests/test_copilot_plugin.py
@@ -61,6 +61,23 @@ def test_boundary_capture_hooks_are_synchronous():
     assert session_end.get("timeout") == 35
 
 
+def test_hooks_use_cross_shell_python_runner():
+    repo_root = Path(__file__).parent.parent
+    hooks = json.loads((repo_root / "hooks" / "hooks.json").read_text())["hooks"]
+    commands = []
+    for groups in hooks.values():
+        for group in groups:
+            for hook in group["hooks"]:
+                commands.append(hook["command"])
+
+    assert commands
+    for command in commands:
+        assert "copilot-hook.py" in command
+        assert "python3 -c" in command
+        for posix_only in ("function ", "${", "command -v", ">/dev/null", "||", "&&", "if ["):
+            assert posix_only not in command
+
+
 # ---------------------------------------------------------------------------
 # Fixtures
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Issue Number: close #505

## Background
Copilot CLI hooks run through the host shell. On Windows that may be PowerShell, so POSIX shell functions and conditionals in hooks.json fail before the Nowledge Mem hook code can run.

## Problem
The Copilot plugin shipped lifecycle hook commands that assumed a POSIX shell (`command -v`, shell functions, `[ -f ... ]`, `||`). Native Windows Copilot CLI users reported syntax failures when the hook loaded.

## How it works
- Move hook logic into a packaged Python entry point, `hooks/copilot-hook.py`.
- Keep hooks.json as a minimal cross-shell Python launcher.
- Preserve existing behavior: Context Bundle / Working Memory injection, compact reminder, proactive prompt hint, and Stop/PreCompact/SessionEnd capture delegation.
- Add a fixture test that rejects POSIX-only shell tokens in hook commands.

## Tests
- `pytest -q community/nowledge-mem-copilot-cli-plugin/tests/test_copilot_plugin.py` -> 56 passed
- `python3 -m json.tool community/nowledge-mem-copilot-cli-plugin/hooks/hooks.json` -> valid JSON
- `COPILOT_PLUGIN_ROOT=$PWD/community/nowledge-mem-copilot-cli-plugin python3 -c "...copilot-hook.py..." --event user-prompt-submit` -> prints the Nowledge Mem prompt hint


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added cross-platform Copilot CLI hook support across session, prompt, compaction, and completion events.
  * Added scoped context handling for agents and spaces.
  * Added graceful fallback and bounded execution when memory services are unavailable.

* **Bug Fixes**
  * Improved Windows compatibility by preventing unwanted console windows.
  * Removed reliance on POSIX-only shell syntax.

* **Tests**
  * Added coverage confirming all configured hooks use the cross-platform dispatcher.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->