### PR TITLE
fix(pi): allow slow thread sync writes

### DIFF
--- a/integrations.json
+++ b/integrations.json
@@ -869,7 +869,7 @@
       "name": "Pi",
       "category": "coding",
       "type": "plugin",
-      "version": "0.8.6",
+      "version": "0.8.7",
       "directory": "nowledge-mem-pi-package",
       "transport": "plugin+cli",
       "capabilities": {

--- a/nowledge-mem-pi-package/CHANGELOG.md
+++ b/nowledge-mem-pi-package/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to the Nowledge Mem Pi package will be documented in this fi
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.8.7] - 2026-08-18
+
+### Fixed
+
+- Allow slow thread writes to finish with a 120-second default timeout instead of aborting them after 30 seconds.
+- Support `NMEM_SYNC_TIMEOUT_MS` for slower remote or busy servers, with safe timer bounds and later-lifecycle reconciliation instead of ambiguous immediate retries.
+- Restrict the legacy `/remote-api` path fallback to explicit route-mismatch responses so timeouts and transport failures cannot replay an ambiguous write immediately.
+
 ## [0.8.6] - 2026-08-13
 
 ### Fixed

--- a/nowledge-mem-pi-package/README.md
+++ b/nowledge-mem-pi-package/README.md
@@ -140,6 +140,8 @@ That keeps your custom behavior durable across package updates.
 
 **Extension diagnostics:** Automatic sync failures retry on a later lifecycle event without writing raw diagnostics into Pi's interactive editor. Set `NMEM_PLUGIN_DEBUG=1` before starting Pi when troubleshooting the extension itself.
 
+**Slow thread sync:** Thread writes allow 120 seconds by default. If a remote or heavily loaded Mem server needs a different budget, set `NMEM_SYNC_TIMEOUT_MS` before starting Pi. Values are interpreted as milliseconds and bounded between 1 second and 30 minutes. A timeout is not retried immediately because the server may have completed the write after the client stopped waiting; the next lifecycle sync safely reconciles the transcript using stable message IDs.
+
 ## Links
 
 - [Documentation](https://mem.nowledge.co/docs/integrations/pi)

--- a/nowledge-mem-pi-package/extensions/nowledge-mem.ts
+++ b/nowledge-mem-pi-package/extensions/nowledge-mem.ts
@@ -5,14 +5,26 @@ import { basename, win32 as pathWin32 } from "node:path";
 import type { ExtensionAPI, ExtensionContext } from "@earendil-works/pi-coding-agent";
 
 const DEFAULT_SOURCE_APP = "pi";
-const DEFAULT_PLUGIN_VERSION = "0.8.4";
+const DEFAULT_PLUGIN_VERSION = "0.8.7";
 const DEFAULT_API_URL = "http://127.0.0.1:14242";
 const CONFIG_PATH = `${homedir()}/.nowledge-mem/config.json`;
 const LOCAL_WORKING_MEMORY_PATH = `${homedir()}/ai-now/memory.md`;
 const MAX_MESSAGE_CHARS = 20_000;
 const FLUSH_DELAY_MS = 750;
 const STARTUP_CONTEXT_TIMEOUT_MS = 8_000;
-const THREAD_SYNC_TIMEOUT_MS = 30_000;
+const DEFAULT_THREAD_SYNC_TIMEOUT_MS = 120_000;
+const MIN_THREAD_SYNC_TIMEOUT_MS = 1_000;
+const MAX_THREAD_SYNC_TIMEOUT_MS = 30 * 60_000;
+
+export function resolveThreadSyncTimeoutMs(raw: string | undefined): number {
+	const parsed = Number(raw);
+	if (!raw?.trim() || !Number.isSafeInteger(parsed) || parsed <= 0) {
+		return DEFAULT_THREAD_SYNC_TIMEOUT_MS;
+	}
+	return Math.min(MAX_THREAD_SYNC_TIMEOUT_MS, Math.max(MIN_THREAD_SYNC_TIMEOUT_MS, parsed));
+}
+
+const THREAD_SYNC_TIMEOUT_MS = resolveThreadSyncTimeoutMs(process.env.NMEM_SYNC_TIMEOUT_MS);
 
 function sourceApp(): string {
 	return process.env.NMEM_PLUGIN_SOURCE_APP?.trim() || DEFAULT_SOURCE_APP;
@@ -188,6 +200,10 @@ function remoteApiFallbackUrls(url: string): string[] {
 	return urls;
 }
 
+export function shouldTryRemoteApiFallback(status: number): boolean {
+	return status === 404 || status === 405;
+}
+
 async function postJson(path: string, body: JsonObject): Promise<{ ok: boolean; status: number; data: unknown }> {
 	const config = resolveConfig();
 	const headers: Record<string, string> = { "Content-Type": "application/json" };
@@ -226,8 +242,9 @@ async function postJson(path: string, body: JsonObject): Promise<{ ok: boolean; 
 			const data = await response.json().catch(() => ({}));
 			last = { ok: response.ok, status: response.status, data };
 			if (response.ok) return last;
+			if (!shouldTryRemoteApiFallback(response.status)) return last;
 		} catch (error) {
-			last = {
+			return {
 				ok: false,
 				status: 0,
 				data: { error: error instanceof Error ? error.message : String(error) },

--- a/nowledge-mem-pi-package/package.json
+++ b/nowledge-mem-pi-package/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nowledge-mem-pi",
-  "version": "0.8.6",
+  "version": "0.8.7",
   "description": "Cross-tool memory for Pi. Recall past decisions, search knowledge from every AI tool, and save what matters.",
   "keywords": ["pi-package"],
   "author": "Nowledge Labs",

--- a/tests/plugin_e2e/pi_thread_sync_timeout.test.mts
+++ b/tests/plugin_e2e/pi_thread_sync_timeout.test.mts
@@ -1,0 +1,29 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+	resolveThreadSyncTimeoutMs,
+	shouldTryRemoteApiFallback,
+} from "../../nowledge-mem-pi-package/extensions/nowledge-mem.ts";
+
+test("thread sync allows slow successful writes by default", () => {
+	assert.equal(resolveThreadSyncTimeoutMs(undefined), 120_000);
+	assert.equal(resolveThreadSyncTimeoutMs(""), 120_000);
+	assert.equal(resolveThreadSyncTimeoutMs("not-a-number"), 120_000);
+	assert.equal(resolveThreadSyncTimeoutMs("-1"), 120_000);
+});
+
+test("thread sync timeout is configurable within bounded timer limits", () => {
+	assert.equal(resolveThreadSyncTimeoutMs("66000"), 66_000);
+	assert.equal(resolveThreadSyncTimeoutMs("500"), 1_000);
+	assert.equal(resolveThreadSyncTimeoutMs("3600000"), 1_800_000);
+	assert.equal(resolveThreadSyncTimeoutMs("120000.5"), 120_000);
+});
+
+test("remote API fallback only retries explicit route mismatches", () => {
+	assert.equal(shouldTryRemoteApiFallback(404), true);
+	assert.equal(shouldTryRemoteApiFallback(405), true);
+	assert.equal(shouldTryRemoteApiFallback(0), false);
+	assert.equal(shouldTryRemoteApiFallback(401), false);
+	assert.equal(shouldTryRemoteApiFallback(500), false);
+});

--- a/tests/plugin_e2e/test_key_plugins_e2e.py
+++ b/tests/plugin_e2e/test_key_plugins_e2e.py
@@ -704,7 +704,7 @@ def test_key_plugin_static_contracts_are_declared():
     pi_pkg = _read_json(PI_PLUGIN / "package.json")
     pi_extension = (PI_PLUGIN / "extensions" / "nowledge-mem.ts").read_text(encoding="utf-8")
     pi_history_sync = (PI_PLUGIN / "scripts" / "sync-history.mjs").read_text(encoding="utf-8")
-    assert pi_pkg["version"] == "0.8.6"
+    assert pi_pkg["version"] == "0.8.7"
     assert "./extensions/nowledge-mem.ts" in pi_pkg["pi"]["extensions"]
     assert "./skills" in pi_pkg["pi"]["skills"]
     assert pi_pkg["bin"]["nowledge-mem-pi-sync"] == "./scripts/sync-history.mjs"
@@ -718,6 +718,8 @@ def test_key_plugin_static_contracts_are_declared():
     assert 'metadata: {' in pi_extension
     assert "external_id" in pi_extension
     assert "deduplicate: true" in pi_extension
+    assert "NMEM_SYNC_TIMEOUT_MS" in pi_extension
+    assert "DEFAULT_THREAD_SYNC_TIMEOUT_MS = 120_000" in pi_extension
     assert "NMEM_AGENT_ID" in pi_extension
     assert "NMEM_HOST_AGENT_ID" in pi_extension
     assert "custom_message" in pi_extension
@@ -2089,6 +2091,26 @@ def test_pi_sync_does_not_amplify_transport_failures_and_keeps_latest_payload():
     env["PI_EXTENSION_URL"] = (PI_PLUGIN / "extensions" / "nowledge-mem.ts").resolve().as_uri()
     result = _run(["bun", "--eval", script], env=env, timeout=30)
     assert '"ok":true' in result.stdout.replace(" ", "")
+
+
+def test_pi_thread_sync_timeout_contract():
+    pi_pkg = _read_json(PI_PLUGIN / "package.json")
+    registry = _read_json(COMMUNITY_ROOT / "integrations.json")
+    pi_registry = next(
+        item for item in registry["integrations"] if item.get("id") == "pi"
+    )
+    extension = (PI_PLUGIN / "extensions" / "nowledge-mem.ts").read_text(encoding="utf-8")
+    readme = (PI_PLUGIN / "README.md").read_text(encoding="utf-8")
+    changelog = (PI_PLUGIN / "CHANGELOG.md").read_text(encoding="utf-8")
+
+    assert pi_pkg["version"] == "0.8.7"
+    assert pi_registry["version"] == pi_pkg["version"]
+    assert "DEFAULT_THREAD_SYNC_TIMEOUT_MS = 120_000" in extension
+    assert "resolveThreadSyncTimeoutMs(process.env.NMEM_SYNC_TIMEOUT_MS)" in extension
+    assert "shouldTryRemoteApiFallback(response.status)" in extension
+    assert "NMEM_SYNC_TIMEOUT_MS" in readme
+    assert "next lifecycle sync safely reconciles" in readme
+    assert "## [0.8.7] - 2026-08-18" in changelog
 
 
 @pytest.mark.skipif(_skip_live_host("pi"), reason="Pi live E2E not requested")


### PR DESCRIPTION
## Issue

Closes #510.

## Problem

Pi and OMP share a thread-sync runtime with a hardcoded 30-second write budget. Valid `/threads/{id}/append` calls have been measured at 32.9-66.4 seconds on a busy local server, so the extension aborts writes which would otherwise complete and reports a failed capture.

The legacy `/remote-api` compatibility fallback also retried after transport failures. A timeout is an ambiguous write outcome, so replaying immediately can issue the same write twice even though later lifecycle sync already has stable message IDs and backend deduplication.

## Change

- Raise the default write budget to 120 seconds.
- Add bounded `NMEM_SYNC_TIMEOUT_MS` configuration (1 second to 30 minutes).
- Retry the legacy path fallback only for explicit `404`/`405` route mismatches, never timeout, disconnect, auth, or server errors.
- Bump `nowledge-mem-pi` and the canonical integration registry to `0.8.7`.
- Document the operator setting and later-lifecycle reconciliation behavior.

## Validation

- `node --experimental-strip-types --test tests/plugin_e2e/pi_thread_sync_timeout.test.mts` - 3 passed.
- `uv run --with pytest pytest -q -rs ...::test_pi_thread_sync_timeout_contract ...::test_pi_sync_does_not_amplify_transport_failures_and_keeps_latest_payload ...::test_pi_live_package_install_and_extension_smoke` - 2 passed, 1 skipped because live Pi was not requested.
- `npm pack --dry-run --json` in `nowledge-mem-pi-package` - package `0.8.7`, 11 expected runtime/docs entries, no test files.

The repository-wide static contract test currently stops on an unrelated pre-existing Copilot hook assertion before reaching the Pi section; the new Pi-specific contract test isolates this change from that mainline failure.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit c7f3c9f477d928db45d94de803e6da83198b652d. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable thread synchronization timeouts through `NMEM_SYNC_TIMEOUT_MS`.
  * Added a 120-second default timeout, with supported values bounded from 1 second to 30 minutes.
  * Improved synchronization retry and reconciliation behavior for slow thread writes.
  * Limited remote API fallback to explicit HTTP 404 and 405 responses.

* **Documentation**
  * Added troubleshooting guidance for timeout configuration and retry behavior.
  * Published the Pi integration version 0.8.7 release notes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->