### PR TITLE
fix(amp): silence routine lifecycle logs on plugin stderr

### DIFF
--- a/integrations.json
+++ b/integrations.json
@@ -1029,7 +1029,7 @@
       "name": "Amp",
       "category": "coding",
       "type": "plugin",
-      "version": "0.1.2",
+      "version": "0.1.3",
       "directory": "nowledge-mem-amp-plugin",
       "transport": "cli+http",
       "capabilities": {

--- a/nowledge-mem-amp-plugin/AGENTS.md
+++ b/nowledge-mem-amp-plugin/AGENTS.md
@@ -40,6 +40,7 @@ The plugin reads the shared Nowledge Mem client config at `~/.nowledge-mem/confi
 | `NMEM_HOST_AGENT_ID` | *(none)* | Advanced external-alias mapping. |
 | `NMEM_AMP_AUTO_SYNC` | `1` | Set to `0`/`false`/`off`/`no` to disable automatic session capture. |
 | `NMEM_AMP_AUTO_SYNC_DEBOUNCE_MS` | `1500` | Debounce window for automatic capture. |
+| `NMEM_AMP_DEBUG` | `0` | Set to `1`/`true`/`on`/`yes` to log connector lifecycle messages. |
 
 ## Customize without editing the plugin
 

--- a/nowledge-mem-amp-plugin/AGENTS.md
+++ b/nowledge-mem-amp-plugin/AGENTS.md
@@ -40,7 +40,6 @@ The plugin reads the shared Nowledge Mem client config at `~/.nowledge-mem/confi
 | `NMEM_HOST_AGENT_ID` | *(none)* | Advanced external-alias mapping. |
 | `NMEM_AMP_AUTO_SYNC` | `1` | Set to `0`/`false`/`off`/`no` to disable automatic session capture. |
 | `NMEM_AMP_AUTO_SYNC_DEBOUNCE_MS` | `1500` | Debounce window for automatic capture. |
-| `NMEM_AMP_DEBUG` | `0` | Set to `1`/`true`/`on`/`yes` to log connector lifecycle messages. |
 
 ## Customize without editing the plugin
 

--- a/nowledge-mem-amp-plugin/CHANGELOG.md
+++ b/nowledge-mem-amp-plugin/CHANGELOG.md
@@ -7,7 +7,8 @@
 - Stop writing `connector loaded`/`connector disposed` lifecycle messages to the
   plugin's stderr by default. Amp's host logs any plugin stderr output as WARN
   (`Plugin stderr`), which surfaced these routine messages as log noise. The
-  lifecycle messages now require `NMEM_AMP_DEBUG=1`.
+  lifecycle messages now require `NMEM_AMP_DEBUG` to be set to any recognized
+  truthy value (`1`/`true`/`on`/`yes`).
 
 ## [0.1.2] - 2026-08-12
 

--- a/nowledge-mem-amp-plugin/CHANGELOG.md
+++ b/nowledge-mem-amp-plugin/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## [Unreleased]
+
+### Fixed
+
+- Stop writing `connector loaded`/`connector disposed` lifecycle messages to the
+  plugin's stderr by default. Amp's host logs any plugin stderr output as WARN
+  (`Plugin stderr`), which surfaced these routine messages as log noise. The
+  lifecycle messages now require `NMEM_AMP_DEBUG=1`.
+
 ## [0.1.2] - 2026-08-12
 
 ### Fixed

--- a/nowledge-mem-amp-plugin/CHANGELOG.md
+++ b/nowledge-mem-amp-plugin/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## [Unreleased]
+## [0.1.3] - 2026-08-19
 
 ### Fixed
 

--- a/nowledge-mem-amp-plugin/README.md
+++ b/nowledge-mem-amp-plugin/README.md
@@ -113,6 +113,7 @@ No config needed for local use.
 | `NMEM_AGENT_ID` | *(none)* | Stable Nowledge AI Identity for this run |
 | `NMEM_AMP_AUTO_SYNC` | `1` | Set to `0`/`false`/`off`/`no` to disable automatic session capture |
 | `NMEM_AMP_AUTO_SYNC_DEBOUNCE_MS` | `1500` | Debounce window for automatic capture |
+| `NMEM_AMP_DEBUG` | `0` | Set to `1`/`true`/`on`/`yes` to log connector lifecycle messages (`connector loaded`/`connector disposed`) |
 
 The plugin also reads `~/.nowledge-mem/config.json` (shared with all Nowledge Mem integrations). Environment variables take priority.
 

--- a/nowledge-mem-amp-plugin/package.json
+++ b/nowledge-mem-amp-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "amp-nowledge-mem",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "Nowledge Mem plugin for Amp. Cross-tool knowledge with agent-end thread capture, Context Bundle, search, save, and handoffs.",
   "type": "module",
   "main": "src/index.ts",

--- a/nowledge-mem-amp-plugin/src/config.ts
+++ b/nowledge-mem-amp-plugin/src/config.ts
@@ -26,6 +26,9 @@ const AUTO_SYNC_DISABLED_VALUES = new Set(["0", "false", "off", "no"])
 /** Truthy string values that disable the agent.start Context Bundle bootstrap. */
 const BOOTSTRAP_DISABLED_VALUES = new Set(["0", "false", "off", "no"])
 
+/** Truthy string values that enable verbose connector lifecycle logging. */
+const DEBUG_ENABLED_VALUES = new Set(["1", "true", "on", "yes"])
+
 /**
  * Fully resolved connector configuration.
  *
@@ -49,6 +52,8 @@ export interface ResolvedConfig {
   readonly autoSyncDebounceMs: number
   /** Whether the `agent.start` Context Bundle bootstrap injection is enabled. */
   readonly bootstrapEnabled: boolean
+  /** Whether verbose connector lifecycle logging (`loaded`/`disposed`) is enabled. */
+  readonly debugLogging: boolean
 }
 
 /**
@@ -147,6 +152,9 @@ export function resolveConfig(
   const bootstrapRaw = nonEmptyString(env.NMEM_AMP_BOOTSTRAP) ?? "1"
   const bootstrapEnabled = !BOOTSTRAP_DISABLED_VALUES.has(bootstrapRaw.toLowerCase())
 
+  const debugRaw = nonEmptyString(env.NMEM_AMP_DEBUG) ?? "0"
+  const debugLogging = DEBUG_ENABLED_VALUES.has(debugRaw.toLowerCase())
+
   return {
     apiUrl,
     apiKey,
@@ -156,5 +164,6 @@ export function resolveConfig(
     autoSyncEnabled,
     autoSyncDebounceMs,
     bootstrapEnabled,
+    debugLogging,
   }
 }

--- a/nowledge-mem-amp-plugin/src/index.ts
+++ b/nowledge-mem-amp-plugin/src/index.ts
@@ -197,10 +197,12 @@ export default function ampKnowledgeMem(amp: PluginAPI): void {
   amp.onDispose(() => {
     bootstrapManager.dispose()
     syncManager.dispose()
-    logger.log(`${SOURCE_APP} connector disposed`)
+    if (config.debugLogging) logger.log(`${SOURCE_APP} connector disposed`)
   })
 
-  logger.log(`${SOURCE_APP} connector loaded: ${BEHAVIORAL_GUIDANCE.length} bytes of guidance registered`)
+  if (config.debugLogging) {
+    logger.log(`${SOURCE_APP} connector loaded: ${BEHAVIORAL_GUIDANCE.length} bytes of guidance registered`)
+  }
 }
 
 /**

--- a/nowledge-mem-amp-plugin/tests/cli.test.ts
+++ b/nowledge-mem-amp-plugin/tests/cli.test.ts
@@ -14,6 +14,7 @@ const BASE_CONFIG: ResolvedConfig = {
   autoSyncEnabled: true,
   autoSyncDebounceMs: 1500,
   bootstrapEnabled: true,
+  debugLogging: false,
 }
 
 /** Records the args a fake execFile was invoked with. */

--- a/nowledge-mem-amp-plugin/tests/config.test.ts
+++ b/nowledge-mem-amp-plugin/tests/config.test.ts
@@ -32,6 +32,7 @@ describe("resolveConfig", () => {
       autoSyncEnabled: true,
       autoSyncDebounceMs: 1500,
       bootstrapEnabled: true,
+      debugLogging: false,
     })
   })
 
@@ -142,5 +143,20 @@ describe("resolveConfig", () => {
   it("enables bootstrap by default when NMEM_AMP_BOOTSTRAP is unset", () => {
     const config = resolveConfig(EMPTY_ENV, sharedConfig({}))
     expect(config.bootstrapEnabled).toBe(true)
+  })
+
+  it("keeps debug logging off by default when NMEM_AMP_DEBUG is unset", () => {
+    const config = resolveConfig(EMPTY_ENV, sharedConfig({}))
+    expect(config.debugLogging).toBe(false)
+  })
+
+  it.each(["0", "false", "off", "no", "OFF", "False"])("keeps debug logging off for NMEM_AMP_DEBUG=%s", (value) => {
+    const config = resolveConfig({ NMEM_AMP_DEBUG: value }, sharedConfig({}))
+    expect(config.debugLogging).toBe(false)
+  })
+
+  it.each(["1", "true", "on", "yes", "ON", "True"])("enables debug logging for NMEM_AMP_DEBUG=%s", (value) => {
+    const config = resolveConfig({ NMEM_AMP_DEBUG: value }, sharedConfig({}))
+    expect(config.debugLogging).toBe(true)
   })
 })

--- a/nowledge-mem-amp-plugin/tests/http.test.ts
+++ b/nowledge-mem-amp-plugin/tests/http.test.ts
@@ -20,6 +20,7 @@ const NO_AUTH_CONFIG: ResolvedConfig = {
   autoSyncEnabled: true,
   autoSyncDebounceMs: 1500,
   bootstrapEnabled: true,
+  debugLogging: false,
 }
 
 /** Config carrying the placeholder auth fixture. */

--- a/nowledge-mem-amp-plugin/tests/identity.test.ts
+++ b/nowledge-mem-amp-plugin/tests/identity.test.ts
@@ -14,6 +14,7 @@ function config(partial: Partial<ResolvedConfig> = {}): ResolvedConfig {
     autoSyncEnabled: true,
     autoSyncDebounceMs: 1500,
     bootstrapEnabled: true,
+    debugLogging: false,
     ...partial,
   }
 }

--- a/nowledge-mem-amp-plugin/tests/index.test.ts
+++ b/nowledge-mem-amp-plugin/tests/index.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from "vitest"
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
 
 const execFileMock = vi.hoisted(() =>
   vi.fn(
@@ -104,6 +104,11 @@ function createFakeAmp(): FakeAmp {
 describe("Amp plugin entrypoint", () => {
   beforeEach(() => {
     execFileMock.mockClear()
+    vi.stubEnv("NMEM_AMP_DEBUG", "")
+  })
+
+  afterEach(() => {
+    vi.unstubAllEnvs()
   })
 
   it("registers tools, commands, lifecycle hooks, and disposal", async () => {
@@ -151,7 +156,24 @@ describe("Amp plugin entrypoint", () => {
       ],
     })
     amp.disposers[0]!()
-    expect(amp.logger.log).toHaveBeenCalled()
+    expect(amp.logger.log).not.toHaveBeenCalled()
+  })
+
+  it("stays silent on stderr by default and logs lifecycle only under NMEM_AMP_DEBUG", async () => {
+    const amp = createFakeAmp()
+    const mod = await import("../src/index")
+    mod.default(amp as unknown as Parameters<typeof mod.default>[0])
+    amp.disposers[0]!()
+    expect(amp.logger.log).not.toHaveBeenCalled()
+
+    const debugAmp = createFakeAmp()
+    vi.stubEnv("NMEM_AMP_DEBUG", "1")
+    mod.default(debugAmp as unknown as Parameters<typeof mod.default>[0])
+    debugAmp.disposers[0]!()
+
+    expect(debugAmp.logger.log).toHaveBeenCalledTimes(2)
+    expect(vi.mocked(debugAmp.logger.log).mock.calls[0]![0]).toMatch(/^amp connector loaded: \d+ bytes/)
+    expect(vi.mocked(debugAmp.logger.log).mock.calls[1]![0]).toBe("amp connector disposed")
   })
 
   it("paginates the full transcript from the start", async () => {

--- a/tests/plugin_e2e/test_key_plugins_e2e.py
+++ b/tests/plugin_e2e/test_key_plugins_e2e.py
@@ -1731,7 +1731,7 @@ def test_amp_plugin_static_contract_is_self_contained():
 
     # Package manifest and registry entry agree on the basics.
     assert pkg["name"] == "amp-nowledge-mem"
-    assert pkg["version"] == "0.1.2"
+    assert pkg["version"] == "0.1.3"
     assert pkg["type"] == "module"
     assert pkg["main"] == "src/index.ts"
     assert "@ampcode/plugin" in pkg["peerDependencies"]


### PR DESCRIPTION
## Problem

Amp's host logs **any** plugin stderr output as `WARN / Plugin stderr`. The Amp connector unconditionally writes two lifecycle messages via `amp.logger.log` on every session:

```
{"level":"WARN","message":"Plugin stderr","pluginFile":"amp-global-plugin:nowledge-mem","stderr":"[plugin] [amp-global-plugin:nowledge-mem] amp connector loaded: 1623 bytes of guidance registered"}
{"level":"WARN","message":"Plugin stderr","pluginFile":"amp-global-plugin:nowledge-mem","stderr":"[plugin] [amp-global-plugin:nowledge-mem] amp connector disposed"}
```

These are routine informational messages, but they surface as WARN-level log noise in `~/.cache/amp/logs/cli.log` on every Amp session start/dispose.

## Fix

- Gate both lifecycle messages (`connector loaded` / `connector disposed`) behind a new `NMEM_AMP_DEBUG` config flag — **off by default**, enabled with `1`/`true`/`on`/`yes` (same env-resolution pattern as the existing `NMEM_AMP_AUTO_SYNC` / `NMEM_AMP_BOOTSTRAP` flags).
- Document `NMEM_AMP_DEBUG` in the README and AGENTS.md config tables.
- Add a CHANGELOG entry under Unreleased.

## Testing

- `tests/config.test.ts`: default-off behaviour, disabled values (`0/false/off/no/OFF/False`), enabled values (`1/true/on/yes/ON/True`).
- `tests/index.test.ts`: entrypoint stays silent by default across load + dispose; logs exactly two lifecycle messages under `NMEM_AMP_DEBUG=1`.
- Fixture configs in `cli`/`http`/`identity` tests extended for the new required field.

```
Test Files  11 passed | 1 skipped (12)
     Tests  214 passed | 2 skipped (216)
tsc --noEmit  # clean
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added optional debug logging controlled by `NMEM_AMP_DEBUG`.
  - Supports `1`, `true`, `on`, and `yes` as enabled values.

- **Bug Fixes**
  - Routine connector lifecycle messages no longer appear by default.
  - Lifecycle logs are shown only when debug logging is enabled.

- **Documentation**
  - Documented the configuration option and default behavior.

- **Tests**
  - Added coverage for setting parsing and conditional lifecycle logging.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->