### PR TITLE
fix(opencode): allow slow automatic thread sync

### DIFF
--- a/integrations.json
+++ b/integrations.json
@@ -1092,7 +1092,7 @@
       "name": "OpenCode",
       "category": "coding",
       "type": "plugin",
-      "version": "0.3.7",
+      "version": "0.3.8",
       "directory": "nowledge-mem-opencode-plugin",
       "transport": "cli+http",
       "capabilities": {

--- a/nowledge-mem-opencode-plugin/CHANGELOG.md
+++ b/nowledge-mem-opencode-plugin/CHANGELOG.md
@@ -1,12 +1,14 @@
 # Changelog
 
-## Unreleased
+## [0.3.8] - 2026-08-19
 
 ### Fixed
 
 - Idle capture now uploads only the suffix after the last acknowledged
   OpenCode message ID. Exact snapshots are no-ops and compacted sessions reset
   to a deduplicating replay.
+- Automatic idle and pre-compaction thread sync now allow 120 seconds by default
+  and honor bounded `NMEM_SYNC_TIMEOUT_MS` overrides for slow remote servers.
 
 ## [0.3.7] - 2026-08-13
 

--- a/nowledge-mem-opencode-plugin/README.md
+++ b/nowledge-mem-opencode-plugin/README.md
@@ -57,7 +57,7 @@ The plugin follows OpenCode's standard plugin update mechanism. To pin a specifi
 
 ```json
 {
-  "plugin": ["opencode-nowledge-mem@0.3.7"]
+  "plugin": ["opencode-nowledge-mem@0.3.8"]
 }
 ```
 
@@ -136,6 +136,7 @@ No config needed for local use.
 |-------------|---------|-------------|
 | `NMEM_API_URL` | *(local)* | Remote Nowledge Mem server URL |
 | `NMEM_API_KEY` | *(none)* | API key for remote access |
+| `NMEM_SYNC_TIMEOUT_MS` | `120000` | Automatic thread-sync timeout in milliseconds, bounded between 1 second and 30 minutes |
 
 The plugin also reads `~/.nowledge-mem/config.json` (shared with all Nowledge Mem integrations). Environment variables take priority.
 
@@ -180,6 +181,7 @@ Shared spaces, default retrieval, and agent guidance still come from Mem's own s
 
 - **nmem not found.** Install with `pip install nmem-cli`, or on Arch Linux `yay -S nmem-cli` / `paru -S nmem-cli`, then run `nmem status` to verify.
 - **Server not responding.** Start the Nowledge Mem desktop app, or check `nmem status` for diagnostics.
+- **Slow automatic thread sync.** Thread writes allow 120 seconds by default. If a remote or heavily loaded Mem server needs a different budget, set `NMEM_SYNC_TIMEOUT_MS` before starting OpenCode. A timeout is not retried immediately because the server may still have completed the write; a later lifecycle sync safely reconciles the transcript through stable message IDs.
 - **Plugin not loading.** Confirm `"opencode-nowledge-mem"` appears in your `opencode.json` plugin array. Restart OpenCode after changes.
 - **OpenCode Desktop sees the package but no tools appear.** Fully quit OpenCode Desktop, clear the OpenCode package cache, then restart so it installs the latest package. On Windows the cache is `%USERPROFILE%\.cache\opencode`; on macOS/Linux it is `~/.cache/opencode`.
 

--- a/nowledge-mem-opencode-plugin/dist/index.js
+++ b/nowledge-mem-opencode-plugin/dist/index.js
@@ -94,7 +94,20 @@ function selectAcknowledgedDelta(messages, cursor, externalId, messageFingerprin
   };
 }
 
+// nowledge-mem-opencode-plugin/src/thread-sync-timeout.ts
+var DEFAULT_THREAD_SYNC_TIMEOUT_MS = 12e4;
+var MIN_THREAD_SYNC_TIMEOUT_MS = 1e3;
+var MAX_THREAD_SYNC_TIMEOUT_MS = 30 * 6e4;
+function resolveThreadSyncTimeoutMs(raw) {
+  const parsed = Number(raw);
+  if (!raw?.trim() || !Number.isSafeInteger(parsed) || parsed <= 0) {
+    return DEFAULT_THREAD_SYNC_TIMEOUT_MS;
+  }
+  return Math.min(MAX_THREAD_SYNC_TIMEOUT_MS, Math.max(MIN_THREAD_SYNC_TIMEOUT_MS, parsed));
+}
+
 // nowledge-mem-opencode-plugin/src/index.ts
+var THREAD_SYNC_TIMEOUT_MS = resolveThreadSyncTimeoutMs(process.env.NMEM_SYNC_TIMEOUT_MS);
 var BEHAVIORAL_GUIDANCE = `## Nowledge Mem
 
 You have Nowledge Mem tools for cross-tool knowledge management. Use them proactively.
@@ -515,7 +528,7 @@ ${reasoning}
       }
       state.inFlight = syncSessionThread(
         { sessionID, directory },
-        { reason, force: false, timeoutMs: 1e4 }
+        { reason, force: false, timeoutMs: THREAD_SYNC_TIMEOUT_MS }
       ).then((result) => {
         if ("error" in result) {
           console.warn("[nowledge-mem] automatic OpenCode thread sync failed:", result.error);
@@ -713,7 +726,7 @@ ${reasoning}
         if (input2.sessionID) {
           await syncSessionThread(
             { sessionID: input2.sessionID, directory },
-            { reason: "session_compacting", force: false, timeoutMs: 1e4 }
+            { reason: "session_compacting", force: false, timeoutMs: THREAD_SYNC_TIMEOUT_MS }
           ).catch((err) => {
             console.warn("[nowledge-mem] pre-compaction OpenCode thread sync failed:", err?.message ?? err);
           });

--- a/nowledge-mem-opencode-plugin/package.json
+++ b/nowledge-mem-opencode-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "opencode-nowledge-mem",
-  "version": "0.3.7",
+  "version": "0.3.8",
   "description": "Nowledge Mem plugin for OpenCode. Cross-tool knowledge with idle-event thread capture, Context Bundle, search, save, and handoffs.",
   "type": "module",
   "main": "dist/index.js",

--- a/nowledge-mem-opencode-plugin/src/index.ts
+++ b/nowledge-mem-opencode-plugin/src/index.ts
@@ -17,6 +17,9 @@ import {
   stableMessageFingerprint,
   type AcknowledgedCursor,
 } from "./session-delta"
+import { resolveThreadSyncTimeoutMs } from "./thread-sync-timeout"
+
+const THREAD_SYNC_TIMEOUT_MS = resolveThreadSyncTimeoutMs(process.env.NMEM_SYNC_TIMEOUT_MS)
 
 const BEHAVIORAL_GUIDANCE = `## Nowledge Mem
 
@@ -552,7 +555,7 @@ export default {
       }
       state.inFlight = syncSessionThread(
         { sessionID, directory },
-        { reason, force: false, timeoutMs: 10_000 },
+        { reason, force: false, timeoutMs: THREAD_SYNC_TIMEOUT_MS },
       )
         .then((result) => {
           if ("error" in result) {
@@ -823,7 +826,7 @@ export default {
         if (input.sessionID) {
           await syncSessionThread(
             { sessionID: input.sessionID, directory },
-            { reason: "session_compacting", force: false, timeoutMs: 10_000 },
+            { reason: "session_compacting", force: false, timeoutMs: THREAD_SYNC_TIMEOUT_MS },
           ).catch((err: any) => {
             console.warn("[nowledge-mem] pre-compaction OpenCode thread sync failed:", err?.message ?? err)
           })

--- a/nowledge-mem-opencode-plugin/src/thread-sync-timeout.ts
+++ b/nowledge-mem-opencode-plugin/src/thread-sync-timeout.ts
@@ -1,0 +1,11 @@
+const DEFAULT_THREAD_SYNC_TIMEOUT_MS = 120_000
+const MIN_THREAD_SYNC_TIMEOUT_MS = 1_000
+const MAX_THREAD_SYNC_TIMEOUT_MS = 30 * 60_000
+
+export function resolveThreadSyncTimeoutMs(raw: string | undefined): number {
+  const parsed = Number(raw)
+  if (!raw?.trim() || !Number.isSafeInteger(parsed) || parsed <= 0) {
+    return DEFAULT_THREAD_SYNC_TIMEOUT_MS
+  }
+  return Math.min(MAX_THREAD_SYNC_TIMEOUT_MS, Math.max(MIN_THREAD_SYNC_TIMEOUT_MS, parsed))
+}

--- a/tests/plugin_e2e/opencode_thread_sync_timeout.test.mts
+++ b/tests/plugin_e2e/opencode_thread_sync_timeout.test.mts
@@ -1,0 +1,18 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { resolveThreadSyncTimeoutMs } from "../../nowledge-mem-opencode-plugin/src/thread-sync-timeout.ts";
+
+test("automatic thread sync allows slow successful writes by default", () => {
+	assert.equal(resolveThreadSyncTimeoutMs(undefined), 120_000);
+	assert.equal(resolveThreadSyncTimeoutMs(""), 120_000);
+	assert.equal(resolveThreadSyncTimeoutMs("not-a-number"), 120_000);
+	assert.equal(resolveThreadSyncTimeoutMs("-1"), 120_000);
+});
+
+test("automatic thread sync timeout is configurable within timer limits", () => {
+	assert.equal(resolveThreadSyncTimeoutMs("66000"), 66_000);
+	assert.equal(resolveThreadSyncTimeoutMs("500"), 1_000);
+	assert.equal(resolveThreadSyncTimeoutMs("3600000"), 1_800_000);
+	assert.equal(resolveThreadSyncTimeoutMs("120000.5"), 120_000);
+});

--- a/tests/plugin_e2e/test_key_plugins_e2e.py
+++ b/tests/plugin_e2e/test_key_plugins_e2e.py
@@ -520,7 +520,7 @@ def test_key_plugin_static_contracts_are_declared():
     opencode_pkg = _read_json(OPENCODE_PLUGIN / "package.json")
     opencode_source = (OPENCODE_PLUGIN / "src" / "index.ts").read_text(encoding="utf-8")
     assert opencode_pkg["name"] == "opencode-nowledge-mem"
-    assert opencode_pkg["version"] == "0.3.7"
+    assert opencode_pkg["version"] == "0.3.8"
     assert registry_by_id["opencode"]["version"] == opencode_pkg["version"]
     assert registry_by_id["opencode"]["capabilities"]["autoCapture"] is True
     assert registry_by_id["opencode"]["autonomy"]["threads"] == "automatic-capture"
@@ -544,7 +544,7 @@ def test_key_plugin_static_contracts_are_declared():
     assert 'statusType === "idle"' in opencode_source
     assert 'event.type === "session.idle"' in opencode_source
     assert "syncSessionThread" in opencode_source
-    assert "idempotency_key: `opencode:live:${ctx.sessionID}`" in opencode_source
+    assert "idempotency_key: `opencode:live:${ctx.sessionID}:${delta.start}-${delta.end}" in opencode_source
 
     copilot_manifest = _read_json(COPILOT_PLUGIN / ".claude-plugin" / "plugin.json")
     copilot_hooks = _read_json(COPILOT_PLUGIN / "hooks" / "hooks.json")
@@ -1461,7 +1461,7 @@ def test_registry_connect_contract_points_agent_prompts_to_universal_skill():
     assert by_id["droid"]["version"] == "0.1.1"
     assert by_id["openclaw"]["version"] == "0.8.31"
     assert by_id["proma"]["version"] == "0.1.5"
-    assert by_id["opencode"]["version"] == "0.3.7"
+    assert by_id["opencode"]["version"] == "0.3.8"
     assert by_id["pi"]["version"] == "0.8.7"
     assert by_id["pi"]["capabilities"]["autoRecall"] is True
     assert by_id["pi"]["autonomy"]["recall"] == "startup-context-injection"
@@ -1683,7 +1683,7 @@ def test_opencode_plugin_static_contract_is_self_contained():
     assert "fetchSessionMessages" in source
     assert "path: { id: ctx.sessionID }" in source
     assert "syncSessionThread" in source
-    assert "idempotency_key: `opencode:live:${ctx.sessionID}`" in source
+    assert "idempotency_key: `opencode:live:${ctx.sessionID}:${delta.start}-${delta.end}" in source
     assert "event: async ({ event })" in source
     assert 'event.type === "session.status"' in source
     assert 'statusType === "idle"' in source
@@ -1697,6 +1697,30 @@ def test_opencode_plugin_static_contract_is_self_contained():
     assert "OpenCode integration guide" in readme
     assert "Explicit tool arguments override" in readme
     assert "compaction hook now injects" in changelog
+
+
+def test_opencode_thread_sync_timeout_contract():
+    pkg = _read_json(OPENCODE_PLUGIN / "package.json")
+    registry = _read_json(COMMUNITY_ROOT / "integrations.json")
+    opencode_registry = next(
+        item for item in registry["integrations"] if item.get("id") == "opencode"
+    )
+    source = (OPENCODE_PLUGIN / "src" / "index.ts").read_text(encoding="utf-8")
+    timeout_source = (OPENCODE_PLUGIN / "src" / "thread-sync-timeout.ts").read_text(
+        encoding="utf-8"
+    )
+    readme = (OPENCODE_PLUGIN / "README.md").read_text(encoding="utf-8")
+    changelog = (OPENCODE_PLUGIN / "CHANGELOG.md").read_text(encoding="utf-8")
+
+    assert pkg["version"] == "0.3.8"
+    assert opencode_registry["version"] == pkg["version"]
+    assert "DEFAULT_THREAD_SYNC_TIMEOUT_MS = 120_000" in timeout_source
+    assert "resolveThreadSyncTimeoutMs(process.env.NMEM_SYNC_TIMEOUT_MS)" in source
+    assert source.count("timeoutMs: THREAD_SYNC_TIMEOUT_MS") == 2
+    assert "timeoutMs: 10_000" not in source
+    assert "NMEM_SYNC_TIMEOUT_MS" in readme
+    assert "later lifecycle sync safely reconciles" in readme
+    assert "## [0.3.8] - 2026-08-19" in changelog
 
 
 def test_amp_plugin_static_contract_is_self_contained():


### PR DESCRIPTION
## Issue

Closes #517.

Refs nowledge-co/mem#1378.

## Problem

OpenCode automatic thread capture used a hardcoded 10-second request timeout for both idle-event sync and the pre-compaction flush. Slow remote or CPU-bound Mem servers could complete valid thread writes after that deadline, so the plugin reported a failed capture even though the same workload already works with the longer Pi connector budget.

## Change

- Use a 120-second default for automatic idle and pre-compaction thread sync.
- Honor `NMEM_SYNC_TIMEOUT_MS` with the same 1-second to 30-minute bounds as the Pi connector.
- Keep the explicit manual save tool's existing 30-second behavior unchanged.
- Publish the OpenCode package and canonical registry as `0.3.8`, update operator documentation and release notes, and regenerate the checked-in bundle.
- Update stale OpenCode static assertions left by the incremental-capture merge so they validate the current checkpoint idempotency key.

Timeouts are not immediately replayed: the existing lifecycle path preserves the acknowledged cursor and lets a later sync reconcile through stable message IDs.

## Validation

- `node --experimental-strip-types --test tests/plugin_e2e/opencode_thread_sync_timeout.test.mts` - 2 passed.
- `node --test nowledge-mem-opencode-plugin/tests/session-delta.test.mjs` - 9 passed.
- `node --check nowledge-mem-opencode-plugin/dist/index.js` - passed.
- Targeted OpenCode registry, package, and timeout static contracts - 3 passed.
- `npm run check` - bundle build and syntax check passed.
- `npm pack --dry-run --json` - package `0.3.8` contains the expected runtime, source, and documentation files.

The repository-wide aggregate static-contract test still reaches an unrelated pre-existing Copilot hook assertion on `main`; the OpenCode-specific contracts above pass independently.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added configurable thread synchronization timeouts, with validation, defaults, and safe limits.
  - Improved automatic synchronization behavior for idle captures, snapshots, and compacted sessions.
  - Added follow-up reconciliation when synchronization times out.

- **Documentation**
  - Updated setup guidance, configuration details, troubleshooting instructions, and release notes for version 0.3.8.

- **Bug Fixes**
  - Improved handling of no-op snapshots and replay state resets.
  - Enhanced synchronization idempotency and session tracking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->