### PR TITLE
fix(amp): make session capture checkpointed and retry-safe

### DIFF
--- a/integrations.json
+++ b/integrations.json
@@ -1029,7 +1029,7 @@
       "name": "Amp",
       "category": "coding",
       "type": "plugin",
-      "version": "0.1.3",
+      "version": "0.1.4",
       "directory": "nowledge-mem-amp-plugin",
       "transport": "cli+http",
       "capabilities": {

--- a/nowledge-mem-amp-plugin/AGENTS.md
+++ b/nowledge-mem-amp-plugin/AGENTS.md
@@ -40,6 +40,7 @@ The plugin reads the shared Nowledge Mem client config at `~/.nowledge-mem/confi
 | `NMEM_HOST_AGENT_ID` | *(none)* | Advanced external-alias mapping. |
 | `NMEM_AMP_AUTO_SYNC` | `1` | Set to `0`/`false`/`off`/`no` to disable automatic session capture. |
 | `NMEM_AMP_AUTO_SYNC_DEBOUNCE_MS` | `1500` | Debounce window for automatic capture. |
+| `NMEM_SYNC_TIMEOUT_MS` | `120000` | Automatic thread-sync timeout (1s–30min). Manual save stays at 120s. |
 
 ## Customize without editing the plugin
 

--- a/nowledge-mem-amp-plugin/CHANGELOG.md
+++ b/nowledge-mem-amp-plugin/CHANGELOG.md
@@ -16,6 +16,8 @@
 - Automatic capture honors `NMEM_SYNC_TIMEOUT_MS` with the same 1-second to
   30-minute bounds as the Pi and OpenCode connectors. Explicit manual saves keep
   their existing two-minute timeout.
+- Graceful plugin shutdown now waits for active captures and flushes any
+  completed turn still queued behind the debounce timer.
 
 ## [0.1.3] - 2026-08-19
 

--- a/nowledge-mem-amp-plugin/CHANGELOG.md
+++ b/nowledge-mem-amp-plugin/CHANGELOG.md
@@ -1,5 +1,22 @@
 # Changelog
 
+## [0.1.4] - 2026-08-19
+
+### Fixed
+
+- Automatic session capture now uploads acknowledged suffixes instead of
+  resending the complete local snapshot after every turn.
+- Suffix appends require the paired Mem checkpoint contract
+  (`expected_message_count`, a content-bound idempotency key, and
+  `append_mode: "checkpointed"`) before the local cursor advances.
+- Same-length and earlier-prefix replacements reset to a full replay; HTTP 400
+  `Thread not found` recreates the complete snapshot.
+- Destination-lane cursor state is isolated by API URL, credentials, space, and
+  identity so two spaces never share a checkpoint.
+- Automatic capture honors `NMEM_SYNC_TIMEOUT_MS` with the same 1-second to
+  30-minute bounds as the Pi and OpenCode connectors. Explicit manual saves keep
+  their existing two-minute timeout.
+
 ## [0.1.3] - 2026-08-19
 
 ### Fixed

--- a/nowledge-mem-amp-plugin/README.md
+++ b/nowledge-mem-amp-plugin/README.md
@@ -113,6 +113,7 @@ No config needed for local use.
 | `NMEM_AGENT_ID` | *(none)* | Stable Nowledge AI Identity for this run |
 | `NMEM_AMP_AUTO_SYNC` | `1` | Set to `0`/`false`/`off`/`no` to disable automatic session capture |
 | `NMEM_AMP_AUTO_SYNC_DEBOUNCE_MS` | `1500` | Debounce window for automatic capture |
+| `NMEM_SYNC_TIMEOUT_MS` | `120000` | Automatic thread-sync timeout (1s–30min; manual save stays at 120s) |
 | `NMEM_AMP_DEBUG` | `0` | Set to `1`/`true`/`on`/`yes` to log connector lifecycle messages (`connector loaded`/`connector disposed`) |
 
 The plugin also reads `~/.nowledge-mem/config.json` (shared with all Nowledge Mem integrations). Environment variables take priority.

--- a/nowledge-mem-amp-plugin/package.json
+++ b/nowledge-mem-amp-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "amp-nowledge-mem",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "description": "Nowledge Mem plugin for Amp. Cross-tool knowledge with agent-end thread capture, Context Bundle, search, save, and handoffs.",
   "type": "module",
   "main": "src/index.ts",

--- a/nowledge-mem-amp-plugin/src/config.ts
+++ b/nowledge-mem-amp-plugin/src/config.ts
@@ -29,6 +29,15 @@ const BOOTSTRAP_DISABLED_VALUES = new Set(["0", "false", "off", "no"])
 /** Truthy string values that enable verbose connector lifecycle logging. */
 const DEBUG_ENABLED_VALUES = new Set(["1", "true", "on", "yes"])
 
+/** Default HTTP timeout (milliseconds) for automatic thread sync. */
+const DEFAULT_THREAD_SYNC_TIMEOUT_MS = 120_000
+
+/** Minimum accepted `NMEM_SYNC_TIMEOUT_MS` value. */
+const MIN_THREAD_SYNC_TIMEOUT_MS = 1_000
+
+/** Maximum accepted `NMEM_SYNC_TIMEOUT_MS` value (30 minutes). */
+const MAX_THREAD_SYNC_TIMEOUT_MS = 30 * 60_000
+
 /**
  * Fully resolved connector configuration.
  *
@@ -54,6 +63,8 @@ export interface ResolvedConfig {
   readonly bootstrapEnabled: boolean
   /** Whether verbose connector lifecycle logging (`loaded`/`disposed`) is enabled. */
   readonly debugLogging: boolean
+  /** HTTP timeout (milliseconds) for automatic thread sync. */
+  readonly threadSyncTimeoutMs: number
 }
 
 /**
@@ -155,6 +166,8 @@ export function resolveConfig(
   const debugRaw = nonEmptyString(env.NMEM_AMP_DEBUG) ?? "0"
   const debugLogging = DEBUG_ENABLED_VALUES.has(debugRaw.toLowerCase())
 
+  const threadSyncTimeoutMs = resolveThreadSyncTimeoutMs(env.NMEM_SYNC_TIMEOUT_MS)
+
   return {
     apiUrl,
     apiKey,
@@ -165,5 +178,24 @@ export function resolveConfig(
     autoSyncDebounceMs,
     bootstrapEnabled,
     debugLogging,
+    threadSyncTimeoutMs,
   }
+}
+
+/**
+ * Resolves the automatic thread-sync timeout from `NMEM_SYNC_TIMEOUT_MS`.
+ *
+ * Unset, empty, or non-integer values fall back to two minutes. Values are
+ * clamped to the same 1-second–30-minute bounds used by the Pi and OpenCode
+ * connectors. The explicit manual save tool keeps its own existing timeout.
+ *
+ * @param raw - Raw environment value.
+ * @returns A timeout in milliseconds.
+ */
+export function resolveThreadSyncTimeoutMs(raw: string | undefined): number {
+  const parsed = Number(raw)
+  if (!raw?.trim() || !Number.isSafeInteger(parsed) || parsed <= 0) {
+    return DEFAULT_THREAD_SYNC_TIMEOUT_MS
+  }
+  return Math.min(MAX_THREAD_SYNC_TIMEOUT_MS, Math.max(MIN_THREAD_SYNC_TIMEOUT_MS, parsed))
 }

--- a/nowledge-mem-amp-plugin/src/index.ts
+++ b/nowledge-mem-amp-plugin/src/index.ts
@@ -162,7 +162,12 @@ export default function ampKnowledgeMem(amp: PluginAPI): void {
     projectPath: workspaceRoot,
     autoSyncEnabled: config.autoSyncEnabled,
     autoSyncDebounceMs: config.autoSyncDebounceMs,
+    autoSyncTimeoutMs: config.threadSyncTimeoutMs,
+    apiUrl: config.apiUrl,
+    apiKey: config.apiKey,
     ambientSpaceId: config.ambientSpaceId,
+    ambientAgentId: config.ambientAgentId,
+    ambientHostAgentId: config.ambientHostAgentId,
   })
 
   const toolExecutors = createToolExecutors({ nmem, syncManager })
@@ -181,6 +186,9 @@ export default function ampKnowledgeMem(amp: PluginAPI): void {
   }
 
   const logger = amp.logger
+  // Observe-only. Amp's agent.end may return { action: "continue" } to start
+  // another turn; capture must never do that or it would loop/steal the turn.
+  // There is no session.end event — automatic capture stays on agent.end.
   amp.on("agent.end", (event) => {
     syncManager.scheduleSync(event.thread.id, toConverterMessages(event.messages))
   })

--- a/nowledge-mem-amp-plugin/src/index.ts
+++ b/nowledge-mem-amp-plugin/src/index.ts
@@ -202,9 +202,9 @@ export default function ampKnowledgeMem(amp: PluginAPI): void {
   })
   amp.on("agent.start", async (event) => bootstrapManager.consume(event.thread.id))
 
-  amp.onDispose(() => {
+  amp.onDispose(async () => {
     bootstrapManager.dispose()
-    syncManager.dispose()
+    await syncManager.dispose()
     if (config.debugLogging) logger.log(`${SOURCE_APP} connector disposed`)
   })
 

--- a/nowledge-mem-amp-plugin/src/session-delta.ts
+++ b/nowledge-mem-amp-plugin/src/session-delta.ts
@@ -55,7 +55,7 @@ export function sessionSyncLaneKey(
   hostAgentId: string | undefined,
 ): string {
   const destination = createHash("sha256")
-    .update([apiUrl, apiKey ?? "", spaceId ?? "", agentId ?? "", hostAgentId ?? ""].join("\0"))
+    .update(JSON.stringify([apiUrl, apiKey ?? null, spaceId ?? null, agentId ?? null, hostAgentId ?? null]))
     .digest("hex")
   return `${destination}\0${threadId}`
 }

--- a/nowledge-mem-amp-plugin/src/session-delta.ts
+++ b/nowledge-mem-amp-plugin/src/session-delta.ts
@@ -1,0 +1,285 @@
+/**
+ * Incremental session-capture helpers for the Amp connector.
+ *
+ * These functions implement the paired Mem checkpoint contract used by the
+ * HTTP-native connectors (OpenCode, Pi): upload only the unacknowledged suffix,
+ * bind appends to a content fingerprint, and refuse to advance the local cursor
+ * until the server returns an explicit persistence acknowledgement.
+ */
+
+import { createHash } from "node:crypto"
+
+/** Local cursor stored after a semantically acknowledged persist. */
+export type AcknowledgedCursor = {
+  /** Number of locally observed messages covered by this cursor. */
+  readonly count: number
+  /** Server-reported thread length at acknowledgement time. */
+  readonly remoteCount: number
+  /** External id of the last acknowledged message, when present. */
+  readonly lastExternalId?: string
+  /** Stable hash of the acknowledged prefix, used to detect in-place edits. */
+  readonly prefixFingerprint: string
+}
+
+/** Result of comparing a local snapshot against the last acknowledged cursor. */
+export type AcknowledgedDelta<T> = {
+  /** Inclusive start index of the unacknowledged suffix. */
+  readonly start: number
+  /** Exclusive end index of the snapshot. */
+  readonly end: number
+  /** Messages that still need to be persisted. */
+  readonly messages: T[]
+  /** Cursor to store after a successful acknowledgement. */
+  readonly next: AcknowledgedCursor
+  /** Whether the previous prefix was invalid and a full replay is required. */
+  readonly reset: boolean
+}
+
+/**
+ * Builds a destination-lane key so cursor state never crosses spaces or servers.
+ *
+ * @param threadId - Host thread id.
+ * @param apiUrl - Resolved Mem API URL.
+ * @param apiKey - Optional API key.
+ * @param spaceId - Ambient space id.
+ * @param agentId - Ambient AI Identity.
+ * @param hostAgentId - Optional host-agent alias.
+ * @returns A stable lane key.
+ */
+export function sessionSyncLaneKey(
+  threadId: string,
+  apiUrl: string,
+  apiKey: string | undefined,
+  spaceId: string | undefined,
+  agentId: string | undefined,
+  hostAgentId: string | undefined,
+): string {
+  const destination = createHash("sha256")
+    .update([apiUrl, apiKey ?? "", spaceId ?? "", agentId ?? "", hostAgentId ?? ""].join("\0"))
+    .digest("hex")
+  return `${destination}\0${threadId}`
+}
+
+/**
+ * Returns a stable JSON fingerprint for a message value.
+ *
+ * @param message - Message to fingerprint.
+ * @returns Canonical JSON for the message.
+ */
+export function stableMessageFingerprint(message: unknown): string {
+  return JSON.stringify(message)
+}
+
+/**
+ * Hashes the acknowledged prefix so same-length replacements are detected.
+ *
+ * @param messages - Complete local snapshot.
+ * @param end - Exclusive end of the prefix.
+ * @param messageFingerprint - Per-message fingerprint function.
+ * @returns Hex-encoded SHA-256 digest of the prefix.
+ */
+function prefixFingerprint<T>(
+  messages: readonly T[],
+  end: number,
+  messageFingerprint: (message: T) => string,
+): string {
+  const hash = createHash("sha256")
+  for (const message of messages.slice(0, end)) {
+    const value = messageFingerprint(message)
+    hash.update(String(Buffer.byteLength(value)))
+    hash.update(":")
+    hash.update(value)
+  }
+  return hash.digest("hex")
+}
+
+/**
+ * Detects a missing-thread response, including HTTP 400 `Thread not found`.
+ *
+ * @param status - HTTP status code.
+ * @param data - Parsed response body.
+ * @returns `true` when the server reported that the thread is missing.
+ */
+export function isThreadNotFoundResponse(status: number, data: unknown): boolean {
+  if (
+    typeof data === "object"
+    && data !== null
+    && (data as { error_code?: unknown }).error_code === "thread_not_found"
+  ) {
+    return true
+  }
+  if (status === 404) return true
+  return JSON.stringify(data).toLowerCase().includes("thread not found")
+}
+
+/**
+ * Detects a create-time "thread already exists" conflict.
+ *
+ * @param status - HTTP status code.
+ * @param data - Parsed response body.
+ * @returns `true` when the thread already exists in the destination space.
+ */
+export function isThreadAlreadyExistsResponse(status: number, data: unknown): boolean {
+  if (status === 409) return true
+  const text = JSON.stringify(data).toLowerCase()
+  return (
+    text.includes("thread already exists")
+    || text.includes("already exists in space")
+    || text.includes("already exists")
+    || text.includes("thread exists")
+  )
+}
+
+/**
+ * Detects a checkpoint conflict that requires full reconciliation.
+ *
+ * @param data - Parsed response body.
+ * @returns `true` when the server rejected the expected message count.
+ */
+export function isCheckpointConflictResponse(data: unknown): boolean {
+  return (
+    typeof data === "object"
+    && data !== null
+    && (data as { error_code?: unknown }).error_code === "checkpoint_conflict"
+  )
+}
+
+/**
+ * Validates an explicit checkpointed-append acknowledgement.
+ *
+ * @param data - Parsed response body.
+ * @returns `true` when the server confirmed a checkpointed suffix write.
+ */
+export function isCheckpointedAppendAck(data: unknown): boolean {
+  return (
+    typeof data === "object"
+    && data !== null
+    && (data as { success?: unknown }).success === true
+    && Number.isInteger((data as { messages_added?: unknown }).messages_added)
+    && Number.isInteger((data as { total_messages?: unknown }).total_messages)
+    && (data as { append_mode?: unknown }).append_mode === "checkpointed"
+  )
+}
+
+/**
+ * Reads the remote message count from a generic append acknowledgement.
+ *
+ * @param data - Parsed response body.
+ * @returns The server-reported total, or `undefined` when the ack is incomplete.
+ */
+export function appendAcknowledgedRemoteCount(data: unknown): number | undefined {
+  if (
+    typeof data !== "object"
+    || data === null
+    || (data as { success?: unknown }).success !== true
+    || !Number.isInteger((data as { messages_added?: unknown }).messages_added)
+    || !Number.isInteger((data as { total_messages?: unknown }).total_messages)
+  ) {
+    return undefined
+  }
+  return (data as { total_messages: number }).total_messages
+}
+
+/**
+ * Reads the remote message count from a create acknowledgement.
+ *
+ * @param data - Parsed response body.
+ * @param expectedThreadId - Thread id that must match the created thread.
+ * @returns The server-reported count, or `undefined` when the ack is incomplete.
+ */
+export function createAcknowledgedRemoteCount(
+  data: unknown,
+  expectedThreadId: string,
+): number | undefined {
+  if (typeof data !== "object" || data === null) return undefined
+  const thread = (data as { thread?: unknown }).thread
+  if (typeof thread !== "object" || thread === null) return undefined
+  if ((thread as { thread_id?: unknown }).thread_id !== expectedThreadId) return undefined
+  const messageCount = (thread as { message_count?: unknown }).message_count
+  if (Number.isInteger(messageCount) && (messageCount as number) >= 0) {
+    return messageCount as number
+  }
+  const messages = (data as { messages?: unknown }).messages
+  return Array.isArray(messages) ? messages.length : undefined
+}
+
+/** Normalised HTTP response used by missing-thread recovery. */
+export type ThreadSyncResponse = {
+  /** Whether the request completed with a 2xx status. */
+  readonly ok: boolean
+  /** HTTP status code. */
+  readonly status: number
+  /** Parsed response body. */
+  readonly data: unknown
+}
+
+/**
+ * Recreates a thread after the server reports that it no longer exists.
+ *
+ * @param response - The failed persist response.
+ * @param recreate - Callback that POSTs a complete create body.
+ * @returns The original or recreated response, plus a recreation flag.
+ */
+export async function recreateMissingThread(
+  response: ThreadSyncResponse,
+  recreate: () => Promise<ThreadSyncResponse>,
+): Promise<{ response: ThreadSyncResponse; recreated: boolean }> {
+  if (response.ok || !isThreadNotFoundResponse(response.status, response.data)) {
+    return { response, recreated: false }
+  }
+  return { response: await recreate(), recreated: true }
+}
+
+/**
+ * Selects the unacknowledged suffix of a local snapshot.
+ *
+ * A cursor is trusted only when its count is in range, the last external id
+ * still matches, and the prefix fingerprint is unchanged. Same-length and
+ * earlier-prefix replacements therefore reset to a full replay.
+ *
+ * @param messages - Complete local snapshot.
+ * @param cursor - Last acknowledged cursor, if any.
+ * @param externalId - Extracts the stable external id from a message.
+ * @param messageFingerprint - Optional content fingerprint; defaults to JSON.
+ * @returns The suffix to upload and the cursor to store after acknowledgement.
+ */
+export function selectAcknowledgedDelta<T>(
+  messages: readonly T[],
+  cursor: AcknowledgedCursor | undefined,
+  externalId: (message: T) => string,
+  messageFingerprint: (message: T) => string = stableMessageFingerprint,
+): AcknowledgedDelta<T> {
+  let start = cursor?.count ?? 0
+  let reset = false
+  const acknowledgedPrefix =
+    start >= 0 && start <= messages.length
+      ? prefixFingerprint(messages, start, messageFingerprint)
+      : ""
+  if (
+    start < 0
+    || start > messages.length
+    || (
+      start > 0
+      && (
+        externalId(messages[start - 1] as T) !== cursor?.lastExternalId
+        || acknowledgedPrefix !== cursor?.prefixFingerprint
+      )
+    )
+  ) {
+    start = 0
+    reset = true
+  }
+  const end = messages.length
+  return {
+    start,
+    end,
+    messages: messages.slice(start),
+    next: {
+      count: end,
+      remoteCount: cursor?.remoteCount ?? end,
+      ...(end > 0 ? { lastExternalId: externalId(messages[end - 1] as T) } : {}),
+      prefixFingerprint: prefixFingerprint(messages, end, messageFingerprint),
+    },
+    reset,
+  }
+}

--- a/nowledge-mem-amp-plugin/src/session-delta.ts
+++ b/nowledge-mem-amp-plugin/src/session-delta.ts
@@ -109,7 +109,7 @@ export function isThreadNotFoundResponse(status: number, data: unknown): boolean
     return true
   }
   if (status === 404) return true
-  return JSON.stringify(data).toLowerCase().includes("thread not found")
+  return status === 400 && JSON.stringify(data).toLowerCase().includes("thread not found")
 }
 
 /**
@@ -157,6 +157,8 @@ export function isCheckpointedAppendAck(data: unknown): boolean {
     && (data as { success?: unknown }).success === true
     && Number.isInteger((data as { messages_added?: unknown }).messages_added)
     && Number.isInteger((data as { total_messages?: unknown }).total_messages)
+    && (data as { messages_added: number }).messages_added >= 0
+    && (data as { total_messages: number }).total_messages >= 0
     && (data as { append_mode?: unknown }).append_mode === "checkpointed"
   )
 }
@@ -174,6 +176,8 @@ export function appendAcknowledgedRemoteCount(data: unknown): number | undefined
     || (data as { success?: unknown }).success !== true
     || !Number.isInteger((data as { messages_added?: unknown }).messages_added)
     || !Number.isInteger((data as { total_messages?: unknown }).total_messages)
+    || (data as { messages_added: number }).messages_added < 0
+    || (data as { total_messages: number }).total_messages < 0
   ) {
     return undefined
   }

--- a/nowledge-mem-amp-plugin/src/sync.ts
+++ b/nowledge-mem-amp-plugin/src/sync.ts
@@ -301,8 +301,8 @@ export class SessionSyncManager {
    *
    * Automatic `agent.end` batches are merged into a local snapshot so the
    * checkpoint cursor can see the complete prefix. Manual saves read the full
-   * SDK transcript. Failed incremental persists fall back to that full snapshot
-   * once so a dropped turn can be recovered.
+   * SDK transcript. An automatic failure preserves that snapshot and cursor for
+   * a later lifecycle event rather than retrying immediately.
    *
    * @param threadId - The thread to capture.
    * @param options - Capture options controlling force, timeout, and an optional
@@ -313,22 +313,14 @@ export class SessionSyncManager {
     threadId: ThreadID,
     options: { force: boolean; timeoutMs: number; messages?: readonly unknown[] },
   ): Promise<CaptureResult> {
-    const incremental = options.messages !== undefined && !options.force
+    const incremental = !options.force
     const rawMessages = options.messages ?? await this.ports.readThreadMessages(threadId)
     const result = await this.persistSnapshot(threadId, rawMessages, {
       force: options.force,
       incremental,
       timeoutMs: options.timeoutMs,
     })
-    if (result.error === undefined || !incremental) {
-      return result
-    }
-    const fullMessages = await this.ports.readThreadMessages(threadId)
-    return this.persistSnapshot(threadId, fullMessages, {
-      force: true,
-      incremental: false,
-      timeoutMs: options.timeoutMs,
-    })
+    return result
   }
 
   /**
@@ -356,9 +348,17 @@ export class SessionSyncManager {
     }
 
     const state = this.stateFor(threadId)
-    const threadMessages = options.incremental
+    const snapshot = options.incremental
       ? mergeThreadMessages(state.localSnapshot, incoming)
       : incoming
+    if (options.incremental) {
+      // Keep even an unanswered user tail (and keep it across persist errors),
+      // so a later agent.end batch can complete and upload that turn.
+      state.localSnapshot = snapshot
+    }
+    const threadMessages = options.incremental
+      ? throughLastAssistant(snapshot)
+      : snapshot
     if (!hasUserAndAssistant(threadMessages)) {
       return skipped("incomplete_turn", stableThreadId)
     }
@@ -368,7 +368,7 @@ export class SessionSyncManager {
       timeoutMs: options.timeoutMs,
       state,
     })
-    if (result.error === undefined) {
+    if (!options.incremental && result.error === undefined) {
       state.localSnapshot = threadMessages
     }
     return result
@@ -591,6 +591,14 @@ function hasUserAndAssistant(messages: readonly ThreadMessage[]): boolean {
     else hasAssistant = true
   }
   return hasUser && hasAssistant
+}
+
+/** Returns the prefix ending at the last answered assistant turn. */
+function throughLastAssistant(messages: readonly ThreadMessage[]): ThreadMessage[] {
+  for (let index = messages.length - 1; index >= 0; index -= 1) {
+    if (messages[index]?.role === "assistant") return messages.slice(0, index + 1)
+  }
+  return []
 }
 
 /**

--- a/nowledge-mem-amp-plugin/src/sync.ts
+++ b/nowledge-mem-amp-plugin/src/sync.ts
@@ -78,6 +78,8 @@ export interface SessionSyncManagerOptions extends SyncPorts {
 
 /** Per-thread state used for debounce, in-flight coalescing, and checkpoints. */
 interface SyncState {
+  /** Raw Amp thread id associated with this destination-lane state. */
+  readonly threadId: ThreadID
   /** Pending debounce timer handle, if a sync is scheduled. */
   timer: TimerHandle | undefined
   /** In-flight capture promise, if a sync is currently running. */
@@ -128,7 +130,7 @@ function skipped(reason: string, threadId: string): CaptureResult {
  *
  * One instance serves all threads for a plugin run. Per-thread state is kept in
  * a map keyed by destination lane. Call {@link dispose} on plugin teardown to
- * clear any pending debounce timers.
+ * flush pending captures and clear their debounce timers.
  */
 export class SessionSyncManager {
   private readonly ports: SyncPorts
@@ -239,19 +241,33 @@ export class SessionSyncManager {
     return guarded
   }
 
-  /**
-   * Clears all pending debounce timers.
-   *
-   * Called from the plugin's `onDispose` hook so no timer fires after teardown.
-   */
-  public dispose(): void {
+  /** Flushes pending captures and waits for active work during teardown. */
+  public async dispose(): Promise<void> {
     this.disposed = true
+    const flushes: Promise<unknown>[] = []
     for (const state of this.states.values()) {
+      const shouldFlush = state.timer !== undefined || state.pending
       if (state.timer !== undefined) {
         this.ports.clearTimer(state.timer)
         state.timer = undefined
       }
+      const pendingMessages = state.pendingMessages
+      state.pending = false
+      state.pendingMessages = undefined
+      flushes.push((async () => {
+        await Promise.allSettled(
+          [state.inFlight, state.manualQueue].filter((run) => run !== undefined),
+        )
+        if (shouldFlush) {
+          await this.captureThread(state.threadId, {
+            force: false,
+            messages: pendingMessages,
+            timeoutMs: this.autoSyncTimeoutMs,
+          })
+        }
+      })())
     }
+    await Promise.allSettled(flushes)
     this.states.clear()
   }
 
@@ -524,6 +540,7 @@ export class SessionSyncManager {
     let state = this.states.get(key)
     if (state === undefined) {
       state = {
+        threadId,
         timer: undefined,
         inFlight: undefined,
         pending: false,

--- a/nowledge-mem-amp-plugin/src/sync.ts
+++ b/nowledge-mem-amp-plugin/src/sync.ts
@@ -594,15 +594,6 @@ function hasUserAndAssistant(messages: readonly ThreadMessage[]): boolean {
 }
 
 /**
- * Merges a newly converted incremental batch onto the acknowledged local
- * snapshot. Existing external ids keep their position and are replaced when
- * the host rewrites a message in place.
- *
- * @param existing - Previously acknowledged local snapshot.
- * @param incoming - Newly converted incremental messages.
- * @returns The merged snapshot in stable order.
- */
-/**
  * Fingerprints a converted thread message without volatile timestamps.
  *
  * Amp fills missing SDK timestamps at convert time, so including `timestamp`
@@ -621,6 +612,15 @@ function threadMessageFingerprint(message: ThreadMessage): string {
   })
 }
 
+/**
+ * Merges a newly converted incremental batch onto the acknowledged local
+ * snapshot. Existing external ids keep their position and are replaced when
+ * the host rewrites a message in place.
+ *
+ * @param existing - Previously acknowledged local snapshot.
+ * @param incoming - Newly converted incremental messages.
+ * @returns The merged snapshot in stable order.
+ */
 function mergeThreadMessages(
   existing: readonly ThreadMessage[] | undefined,
   incoming: readonly ThreadMessage[],

--- a/nowledge-mem-amp-plugin/src/sync.ts
+++ b/nowledge-mem-amp-plugin/src/sync.ts
@@ -2,8 +2,8 @@
  * Session-capture orchestration.
  *
  * Owns the lifecycle of turning an Amp thread into a persisted Nowledge Mem
- * thread: reading the transcript, converting it, posting it (create-then-append
- * for idempotency), and deduplicating across rapid turn boundaries.
+ * thread: reading the transcript, converting it, posting an incremental
+ * checkpointed suffix, and isolating cursor state by destination lane.
  *
  * The manager depends on an injected {@link NmemHttp}, a thread-message reader,
  * a source-app tag, a project path, and timer functions. None of those are
@@ -11,9 +11,20 @@
  * Mem instance.
  */
 
-import type { NmemHttp } from "./http"
-import { captureSignature, normalizeMessages, toThreadMessages } from "./messages"
+import type { HttpResponse, NmemHttp } from "./http"
+import { normalizeMessages, toThreadMessages } from "./messages"
 import type { ThreadMessage } from "./messages"
+import {
+  appendAcknowledgedRemoteCount,
+  createAcknowledgedRemoteCount,
+  isCheckpointConflictResponse,
+  isCheckpointedAppendAck,
+  isThreadAlreadyExistsResponse,
+  recreateMissingThread,
+  selectAcknowledgedDelta,
+  sessionSyncLaneKey,
+  type AcknowledgedCursor,
+} from "./session-delta"
 import type { ThreadID } from "./types"
 
 /** Injectable `setTimeout`. */
@@ -25,6 +36,9 @@ export type TimerHandle = ReturnType<typeof setTimeout>
 
 /** Reasons a capture run can be triggered. */
 export type CaptureReason = "agent_end" | "manual_tool"
+
+/** Existing timeout for explicit manual thread saves. */
+export const MANUAL_SYNC_TIMEOUT_MS = 120_000
 
 /** Injectable ports required to build a session sync manager. */
 export interface SyncPorts {
@@ -48,11 +62,21 @@ export interface SessionSyncManagerOptions extends SyncPorts {
   readonly autoSyncEnabled: boolean
   /** Debounce window (milliseconds) for automatic capture. */
   readonly autoSyncDebounceMs: number
+  /** HTTP timeout (milliseconds) for automatic capture. */
+  readonly autoSyncTimeoutMs: number
+  /** Resolved Mem API URL, used to isolate destination-lane cursor state. */
+  readonly apiUrl: string
+  /** Optional API key, used to isolate destination-lane cursor state. */
+  readonly apiKey: string | undefined
   /** Ambient space id, recorded on append requests when set. */
   readonly ambientSpaceId: string | undefined
+  /** Ambient AI Identity, used to isolate destination-lane cursor state. */
+  readonly ambientAgentId: string | undefined
+  /** Optional host-agent alias, used to isolate destination-lane cursor state. */
+  readonly ambientHostAgentId: string | undefined
 }
 
-/** Per-thread state used for debounce, in-flight coalescing, and dedup. */
+/** Per-thread state used for debounce, in-flight coalescing, and checkpoints. */
 interface SyncState {
   /** Pending debounce timer handle, if a sync is scheduled. */
   timer: TimerHandle | undefined
@@ -62,8 +86,12 @@ interface SyncState {
   pending: boolean
   /** Messages supplied by pending automatic captures, if any. */
   pendingMessages: readonly unknown[] | undefined
-  /** Signature of the last successfully captured transcript. */
-  lastSignature: string | undefined
+  /** Accumulated automatic-turn snapshot used to select suffixes. */
+  localSnapshot: ThreadMessage[] | undefined
+  /** Whether the remote thread is known to exist. */
+  created: boolean
+  /** Last cursor acknowledged by an explicit persist response. */
+  acknowledged: AcknowledgedCursor | undefined
   /** Serialized manual-capture queue for this thread. */
   manualQueue: Promise<CaptureResult> | undefined
 }
@@ -78,6 +106,10 @@ export interface CaptureResult {
   readonly reason?: string
   /** Error message, when the capture failed. */
   readonly error?: string
+  /** Persist action that succeeded, when applicable. */
+  readonly action?: "created" | "appended" | "reconciled"
+  /** Whether the persist reset the local checkpoint. */
+  readonly checkpointReset?: boolean
   /** Persisted thread id. */
   readonly threadId: string
   /** Number of messages persisted in this run. */
@@ -95,8 +127,8 @@ function skipped(reason: string, threadId: string): CaptureResult {
  * Orchestrates capture of a single Amp thread into Nowledge Mem.
  *
  * One instance serves all threads for a plugin run. Per-thread state is kept in
- * a map keyed by thread id. Call {@link dispose} on plugin teardown to clear any
- * pending debounce timers.
+ * a map keyed by destination lane. Call {@link dispose} on plugin teardown to
+ * clear any pending debounce timers.
  */
 export class SessionSyncManager {
   private readonly ports: SyncPorts
@@ -104,8 +136,13 @@ export class SessionSyncManager {
   private readonly projectPath: string
   private readonly autoSyncEnabled: boolean
   private readonly autoSyncDebounceMs: number
+  private readonly autoSyncTimeoutMs: number
+  private readonly apiUrl: string
+  private readonly apiKey: string | undefined
   private readonly ambientSpaceId: string | undefined
-  private readonly states = new Map<ThreadID, SyncState>()
+  private readonly ambientAgentId: string | undefined
+  private readonly ambientHostAgentId: string | undefined
+  private readonly states = new Map<string, SyncState>()
   private disposed = false
 
   /**
@@ -117,7 +154,12 @@ export class SessionSyncManager {
     this.projectPath = options.projectPath
     this.autoSyncEnabled = options.autoSyncEnabled
     this.autoSyncDebounceMs = options.autoSyncDebounceMs
+    this.autoSyncTimeoutMs = options.autoSyncTimeoutMs
+    this.apiUrl = options.apiUrl
+    this.apiKey = options.apiKey
     this.ambientSpaceId = options.ambientSpaceId
+    this.ambientAgentId = options.ambientAgentId
+    this.ambientHostAgentId = options.ambientHostAgentId
   }
 
   /**
@@ -147,7 +189,7 @@ export class SessionSyncManager {
 
   /**
    * Runs an immediate capture, ignoring the debounce window and forcing a
-   * re-upload even when the signature matches the last run.
+   * full-snapshot persist even when the current suffix is empty.
    *
    * Participates in the per-thread in-flight guard so a manual capture and a
    * scheduled automatic capture for the same thread never run concurrently.
@@ -179,7 +221,7 @@ export class SessionSyncManager {
           /* c8 ignore next */
           if (state.inFlight === previous) state.inFlight = undefined
         }
-        return this.captureThread(threadId, { force: true })
+        return this.captureThread(threadId, { force: true, timeoutMs: MANUAL_SYNC_TIMEOUT_MS })
       })
     const guarded = run.finally(() => {
       // Defensive identity guard prevents stale promises clearing a newer queue.
@@ -230,7 +272,11 @@ export class SessionSyncManager {
       state.pendingMessages = mergeMessageBatches(state.pendingMessages, messages)
       return
     }
-    const run = this.captureThread(threadId, { force: false, messages })
+    const run = this.captureThread(threadId, {
+      force: false,
+      messages,
+      timeoutMs: this.autoSyncTimeoutMs,
+    })
       .catch(() => undefined)
     let guarded: Promise<CaptureResult | undefined>
     guarded = run.finally(() => {
@@ -251,59 +297,113 @@ export class SessionSyncManager {
   }
 
   /**
-   * Captures a thread, applying signature-based dedup unless `force` is set.
+   * Captures a thread, applying checkpointed suffix upload unless `force` is set.
+   *
+   * Automatic `agent.end` batches are merged into a local snapshot so the
+   * checkpoint cursor can see the complete prefix. Manual saves read the full
+   * SDK transcript. Failed incremental persists fall back to that full snapshot
+   * once so a dropped turn can be recovered.
    *
    * @param threadId - The thread to capture.
-   * @param options - Capture options controlling the force flag and an optional
+   * @param options - Capture options controlling force, timeout, and an optional
    * host-supplied incremental message batch.
    * @returns The capture result.
    */
   private async captureThread(
     threadId: ThreadID,
-    options: { force: boolean; messages?: readonly unknown[] },
+    options: { force: boolean; timeoutMs: number; messages?: readonly unknown[] },
+  ): Promise<CaptureResult> {
+    const incremental = options.messages !== undefined && !options.force
+    const rawMessages = options.messages ?? await this.ports.readThreadMessages(threadId)
+    const result = await this.persistSnapshot(threadId, rawMessages, {
+      force: options.force,
+      incremental,
+      timeoutMs: options.timeoutMs,
+    })
+    if (result.error === undefined || !incremental) {
+      return result
+    }
+    const fullMessages = await this.ports.readThreadMessages(threadId)
+    return this.persistSnapshot(threadId, fullMessages, {
+      force: true,
+      incremental: false,
+      timeoutMs: options.timeoutMs,
+    })
+  }
+
+  /**
+   * Converts, filters, and persists a raw snapshot or incremental batch.
+   *
+   * @param threadId - The thread to capture.
+   * @param rawMessages - Raw SDK messages.
+   * @param options - Persist options.
+   * @returns The capture result.
+   */
+  private async persistSnapshot(
+    threadId: ThreadID,
+    rawMessages: readonly unknown[],
+    options: { force: boolean; incremental: boolean; timeoutMs: number },
   ): Promise<CaptureResult> {
     const stableThreadId = this.stableThreadId(threadId)
-
-    const rawMessages = options.messages ?? await this.ports.readThreadMessages(threadId)
     const sdkMessages = normalizeMessages(rawMessages)
     if (sdkMessages.length === 0) {
       return skipped("no_messages", stableThreadId)
     }
 
-    const threadMessages = toThreadMessages(sdkMessages, { sourceApp: this.sourceApp })
-    if (threadMessages.length === 0) {
+    const incoming = toThreadMessages(sdkMessages, { sourceApp: this.sourceApp })
+    if (incoming.length === 0) {
       return skipped("no_extractable_messages", stableThreadId)
     }
+
+    const state = this.stateFor(threadId)
+    const threadMessages = options.incremental
+      ? mergeThreadMessages(state.localSnapshot, incoming)
+      : incoming
     if (!hasUserAndAssistant(threadMessages)) {
       return skipped("incomplete_turn", stableThreadId)
     }
 
-    const signature = captureSignature(threadMessages)
-    const state = this.stateFor(threadId)
-    if (!options.force && state.lastSignature === signature) {
-      return skipped("already_synced", stableThreadId)
-    }
-
-    const result = await this.persistThread(stableThreadId, threadMessages)
+    const result = await this.persistThread(stableThreadId, threadMessages, {
+      force: options.force,
+      timeoutMs: options.timeoutMs,
+      state,
+    })
     if (result.error === undefined) {
-      state.lastSignature = signature
+      state.localSnapshot = threadMessages
     }
     return result
   }
 
   /**
-   * Persists thread messages via create-then-append for idempotency.
+   * Persists thread messages via create-then-checkpointed-append.
+   *
+   * The local cursor advances only after an explicit create or checkpoint
+   * acknowledgement. Same-length replacements reset to a full replay; HTTP 400
+   * `Thread not found` recreates the complete snapshot.
    *
    * @param stableThreadId - The lowercased, source-prefixed thread id.
    * @param threadMessages - The converted thread messages to persist.
+   * @param options - Persist options including the per-lane state and timeout.
    * @returns The capture result.
    */
   private async persistThread(
     stableThreadId: string,
     threadMessages: readonly ThreadMessage[],
+    options: { force: boolean; timeoutMs: number; state: SyncState },
   ): Promise<CaptureResult> {
     const title = deriveTitle(threadMessages)
-    const body = {
+    const state = options.state
+    const delta = selectAcknowledgedDelta(
+      threadMessages,
+      options.force ? undefined : state.acknowledged,
+      (message) => message.metadata.external_id,
+      threadMessageFingerprint,
+    )
+    if (delta.messages.length === 0) {
+      return skipped("already_synced", stableThreadId)
+    }
+
+    const createBody = {
       thread_id: stableThreadId,
       title,
       messages: threadMessages,
@@ -312,26 +412,57 @@ export class SessionSyncManager {
       workspace: this.projectPath,
     }
 
-    let response = await this.ports.nmemApi("/threads", body)
+    let response: HttpResponse = state.created
+      ? { ok: false, status: 409, data: { detail: "thread already created locally" } }
+      : await this.ports.nmemApi("/threads", createBody, options.timeoutMs)
+    let action: "created" | "appended" | "reconciled" = state.created ? "appended" : "created"
+    let checkpointed = false
+    let persistedMessages = delta.messages.length
 
-    const conflictText = JSON.stringify(response.data)?.toLowerCase() ?? ""
-    const threadAlreadyExists =
-      response.status === 409
-      || (response.status === 422
-        && (conflictText.includes("already exists") || conflictText.includes("thread exists")))
+    if (!response.ok && isThreadAlreadyExistsResponse(response.status, response.data)) {
+      state.created = true
+      response = await this.ports.nmemApi(
+        `/threads/${encodeURIComponent(stableThreadId)}/append`,
+        {
+          messages: delta.messages,
+          deduplicate: true,
+          idempotency_key: `${this.sourceApp}:live:${stableThreadId}:${delta.start}-${delta.end}:${delta.next.prefixFingerprint}`,
+          ...(state.acknowledged !== undefined && !delta.reset
+            ? { expected_message_count: state.acknowledged.remoteCount }
+            : {}),
+          ...(this.ambientSpaceId !== undefined ? { space_id: this.ambientSpaceId } : {}),
+        },
+        options.timeoutMs,
+      )
+      checkpointed = state.acknowledged !== undefined && !delta.reset
+      action = "appended"
+    }
 
-    // Only fall back to append when the thread already exists. The current
-    // server uses 422 for this condition while older deployments use 409.
-    // Other errors (auth, server, permission) should surface the original
-    // failure rather than doubling API calls with a doomed append.
-    if (!response.ok && threadAlreadyExists) {
-      const appendBody = {
-        messages: threadMessages,
-        deduplicate: true,
-        idempotency_key: `${this.sourceApp}:live:${stableThreadId}`,
-        ...(this.ambientSpaceId !== undefined ? { space_id: this.ambientSpaceId } : {}),
-      }
-      response = await this.ports.nmemApi(`/threads/${encodeURIComponent(stableThreadId)}/append`, appendBody)
+    if (!response.ok && checkpointed && isCheckpointConflictResponse(response.data)) {
+      response = await this.ports.nmemApi(
+        `/threads/${encodeURIComponent(stableThreadId)}/append`,
+        {
+          messages: threadMessages,
+          deduplicate: true,
+          idempotency_key: `${this.sourceApp}:reconcile:${stableThreadId}:${delta.next.prefixFingerprint}`,
+          ...(this.ambientSpaceId !== undefined ? { space_id: this.ambientSpaceId } : {}),
+        },
+        options.timeoutMs,
+      )
+      checkpointed = false
+      persistedMessages = threadMessages.length
+      action = "reconciled"
+    }
+
+    const recovered = await recreateMissingThread(response, async () => {
+      state.created = false
+      return this.ports.nmemApi("/threads", createBody, options.timeoutMs)
+    })
+    if (recovered.recreated) {
+      response = recovered.response
+      action = "created"
+      checkpointed = false
+      persistedMessages = threadMessages.length
     }
 
     if (!response.ok) {
@@ -343,32 +474,66 @@ export class SessionSyncManager {
       }
     }
 
+    const remoteCount = action === "created"
+      ? createAcknowledgedRemoteCount(response.data, stableThreadId)
+      : appendAcknowledgedRemoteCount(response.data)
+    if (remoteCount === undefined) {
+      return {
+        error: "Thread save did not include an explicit persistence acknowledgement; cursor was preserved",
+        threadId: stableThreadId,
+        messagesSaved: 0,
+        title,
+      }
+    }
+    if (checkpointed && !isCheckpointedAppendAck(response.data)) {
+      return {
+        error: "Thread append was not acknowledged as checkpointed; cursor was preserved",
+        threadId: stableThreadId,
+        messagesSaved: 0,
+        title,
+      }
+    }
+
+    state.created = true
+    state.acknowledged = { ...delta.next, remoteCount }
     return {
       success: true,
+      action,
+      checkpointReset: delta.reset,
       threadId: stableThreadId,
-      messagesSaved: threadMessages.length,
+      messagesSaved: persistedMessages,
       title,
     }
   }
 
   /**
-   * Returns the per-thread state, creating it on first access.
+   * Returns the per-lane state, creating it on first access.
    *
    * @param threadId - The thread id.
-   * @returns The mutable state record for the thread.
+   * @returns The mutable state record for the destination lane.
    */
   private stateFor(threadId: ThreadID): SyncState {
-    let state = this.states.get(threadId)
+    const key = sessionSyncLaneKey(
+      String(threadId),
+      this.apiUrl,
+      this.apiKey,
+      this.ambientSpaceId,
+      this.ambientAgentId,
+      this.ambientHostAgentId,
+    )
+    let state = this.states.get(key)
     if (state === undefined) {
       state = {
         timer: undefined,
         inFlight: undefined,
         pending: false,
         pendingMessages: undefined,
-        lastSignature: undefined,
+        localSnapshot: undefined,
+        created: false,
+        acknowledged: undefined,
         manualQueue: undefined,
       }
-      this.states.set(threadId, state)
+      this.states.set(key, state)
     }
     return state
   }
@@ -426,6 +591,53 @@ function hasUserAndAssistant(messages: readonly ThreadMessage[]): boolean {
     else hasAssistant = true
   }
   return hasUser && hasAssistant
+}
+
+/**
+ * Merges a newly converted incremental batch onto the acknowledged local
+ * snapshot. Existing external ids keep their position and are replaced when
+ * the host rewrites a message in place.
+ *
+ * @param existing - Previously acknowledged local snapshot.
+ * @param incoming - Newly converted incremental messages.
+ * @returns The merged snapshot in stable order.
+ */
+/**
+ * Fingerprints a converted thread message without volatile timestamps.
+ *
+ * Amp fills missing SDK timestamps at convert time, so including `timestamp`
+ * would treat every recapture of the same turn as a prefix replacement.
+ *
+ * @param message - Converted thread message.
+ * @returns A stable content-bound fingerprint.
+ */
+function threadMessageFingerprint(message: ThreadMessage): string {
+  return JSON.stringify({
+    role: message.role,
+    content: message.content,
+    external_id: message.metadata.external_id,
+    agent: message.metadata.agent,
+    model: message.metadata.model,
+  })
+}
+
+function mergeThreadMessages(
+  existing: readonly ThreadMessage[] | undefined,
+  incoming: readonly ThreadMessage[],
+): ThreadMessage[] {
+  if (existing === undefined || existing.length === 0) return [...incoming]
+  const merged = [...existing]
+  const indexById = new Map(merged.map((message, index) => [message.metadata.external_id, index]))
+  for (const message of incoming) {
+    const index = indexById.get(message.metadata.external_id)
+    if (index === undefined) {
+      indexById.set(message.metadata.external_id, merged.length)
+      merged.push(message)
+    } else {
+      merged[index] = message
+    }
+  }
+  return merged
 }
 
 /**

--- a/nowledge-mem-amp-plugin/tests/cli.test.ts
+++ b/nowledge-mem-amp-plugin/tests/cli.test.ts
@@ -15,6 +15,7 @@ const BASE_CONFIG: ResolvedConfig = {
   autoSyncDebounceMs: 1500,
   bootstrapEnabled: true,
   debugLogging: false,
+  threadSyncTimeoutMs: 120_000,
 }
 
 /** Records the args a fake execFile was invoked with. */

--- a/nowledge-mem-amp-plugin/tests/config.test.ts
+++ b/nowledge-mem-amp-plugin/tests/config.test.ts
@@ -33,6 +33,7 @@ describe("resolveConfig", () => {
       autoSyncDebounceMs: 1500,
       bootstrapEnabled: true,
       debugLogging: false,
+      threadSyncTimeoutMs: 120_000,
     })
   })
 
@@ -158,5 +159,30 @@ describe("resolveConfig", () => {
   it.each(["1", "true", "on", "yes", "ON", "True"])("enables debug logging for NMEM_AMP_DEBUG=%s", (value) => {
     const config = resolveConfig({ NMEM_AMP_DEBUG: value }, sharedConfig({}))
     expect(config.debugLogging).toBe(true)
+  })
+
+  it("defaults automatic thread sync to two minutes", () => {
+    const config = resolveConfig(EMPTY_ENV, sharedConfig({}))
+    expect(config.threadSyncTimeoutMs).toBe(120_000)
+  })
+
+  it("honors a valid NMEM_SYNC_TIMEOUT_MS value", () => {
+    const config = resolveConfig({ NMEM_SYNC_TIMEOUT_MS: "5000" }, sharedConfig({}))
+    expect(config.threadSyncTimeoutMs).toBe(5_000)
+  })
+
+  it.each(["", "   ", "abc", "0", "-10", "1500.5"])("falls back to two minutes for invalid NMEM_SYNC_TIMEOUT_MS=%s", (value) => {
+    const config = resolveConfig({ NMEM_SYNC_TIMEOUT_MS: value }, sharedConfig({}))
+    expect(config.threadSyncTimeoutMs).toBe(120_000)
+  })
+
+  it("clamps NMEM_SYNC_TIMEOUT_MS below one second up to one second", () => {
+    const config = resolveConfig({ NMEM_SYNC_TIMEOUT_MS: "250" }, sharedConfig({}))
+    expect(config.threadSyncTimeoutMs).toBe(1_000)
+  })
+
+  it("clamps NMEM_SYNC_TIMEOUT_MS above 30 minutes down to 30 minutes", () => {
+    const config = resolveConfig({ NMEM_SYNC_TIMEOUT_MS: "9999999" }, sharedConfig({}))
+    expect(config.threadSyncTimeoutMs).toBe(30 * 60_000)
   })
 })

--- a/nowledge-mem-amp-plugin/tests/http.test.ts
+++ b/nowledge-mem-amp-plugin/tests/http.test.ts
@@ -21,6 +21,7 @@ const NO_AUTH_CONFIG: ResolvedConfig = {
   autoSyncDebounceMs: 1500,
   bootstrapEnabled: true,
   debugLogging: false,
+  threadSyncTimeoutMs: 120_000,
 }
 
 /** Config carrying the placeholder auth fixture. */

--- a/nowledge-mem-amp-plugin/tests/identity.test.ts
+++ b/nowledge-mem-amp-plugin/tests/identity.test.ts
@@ -15,6 +15,7 @@ function config(partial: Partial<ResolvedConfig> = {}): ResolvedConfig {
     autoSyncDebounceMs: 1500,
     bootstrapEnabled: true,
     debugLogging: false,
+    threadSyncTimeoutMs: 120_000,
     ...partial,
   }
 }

--- a/nowledge-mem-amp-plugin/tests/index.test.ts
+++ b/nowledge-mem-amp-plugin/tests/index.test.ts
@@ -17,7 +17,7 @@ vi.mock("node:child_process", () => ({ execFile: execFileMock }))
 
 interface FakeAmp {
   readonly events: Map<string, (...args: readonly unknown[]) => unknown>
-  readonly disposers: Array<() => void>
+  readonly disposers: Array<() => void | Promise<void>>
   readonly tools: string[]
   readonly toolDefinitions: Array<{
     readonly name: string
@@ -55,12 +55,12 @@ interface FakeAmp {
   }) => void
   readonly registerCommand: (id: string, definition: object, execute: (ctx: unknown) => Promise<void>) => void
   readonly on: (eventName: string, handler: (...args: readonly unknown[]) => unknown) => void
-  readonly onDispose: (handler: () => void) => void
+  readonly onDispose: (handler: () => void | Promise<void>) => void
 }
 
 function createFakeAmp(): FakeAmp {
   const events = new Map<string, (...args: readonly unknown[]) => unknown>()
-  const disposers: Array<() => void> = []
+  const disposers: Array<() => void | Promise<void>> = []
   const tools: string[] = []
   const toolDefinitions: FakeAmp["toolDefinitions"] = []
   const commands: string[] = []
@@ -155,7 +155,7 @@ describe("Amp plugin entrypoint", () => {
         { role: "assistant", id: "a2", content: [{ type: "text", text: "done" }] },
       ],
     })
-    amp.disposers[0]!()
+    await amp.disposers[0]!()
     expect(amp.logger.log).not.toHaveBeenCalled()
   })
 
@@ -163,13 +163,13 @@ describe("Amp plugin entrypoint", () => {
     const amp = createFakeAmp()
     const mod = await import("../src/index")
     mod.default(amp as unknown as Parameters<typeof mod.default>[0])
-    amp.disposers[0]!()
+    await amp.disposers[0]!()
     expect(amp.logger.log).not.toHaveBeenCalled()
 
     const debugAmp = createFakeAmp()
     vi.stubEnv("NMEM_AMP_DEBUG", "1")
     mod.default(debugAmp as unknown as Parameters<typeof mod.default>[0])
-    debugAmp.disposers[0]!()
+    await debugAmp.disposers[0]!()
 
     expect(debugAmp.logger.log).toHaveBeenCalledTimes(2)
     expect(vi.mocked(debugAmp.logger.log).mock.calls[0]![0]).toMatch(/^amp connector loaded: \d+ bytes/)

--- a/nowledge-mem-amp-plugin/tests/session-delta.test.ts
+++ b/nowledge-mem-amp-plugin/tests/session-delta.test.ts
@@ -73,11 +73,23 @@ describe("selectAcknowledgedDelta", () => {
 })
 
 describe("sessionSyncLaneKey", () => {
-  it("isolates cursor state by the complete destination lane", () => {
-    const first = sessionSyncLaneKey("thread", "https://mem", "key", "space-a", "agent", "host")
-    const second = sessionSyncLaneKey("thread", "https://mem", "key", "space-b", "agent", "host")
-    expect(first).not.toBe(second)
-    expect(first).toBe(sessionSyncLaneKey("thread", "https://mem", "key", "space-a", "agent", "host"))
+  const base = ["thread", "https://mem", "key", "space-a", "agent", "host"] as const
+
+  it("isolates cursor state by each destination-lane dimension", () => {
+    const first = sessionSyncLaneKey(...base)
+    expect(first).toBe(sessionSyncLaneKey(...base))
+    expect(first).not.toBe(sessionSyncLaneKey("other-thread", "https://mem", "key", "space-a", "agent", "host"))
+    expect(first).not.toBe(sessionSyncLaneKey("thread", "https://other", "key", "space-a", "agent", "host"))
+    expect(first).not.toBe(sessionSyncLaneKey("thread", "https://mem", "other-key", "space-a", "agent", "host"))
+    expect(first).not.toBe(sessionSyncLaneKey("thread", "https://mem", "key", "space-b", "agent", "host"))
+    expect(first).not.toBe(sessionSyncLaneKey("thread", "https://mem", "key", "space-a", "other-agent", "host"))
+    expect(first).not.toBe(sessionSyncLaneKey("thread", "https://mem", "key", "space-a", "agent", "other-host"))
+  })
+
+  it("does not collide all-undefined optional fields with all-empty-string fields", () => {
+    expect(
+      sessionSyncLaneKey("thread", "https://mem", undefined, undefined, undefined, undefined),
+    ).not.toBe(sessionSyncLaneKey("thread", "https://mem", "", "", "", ""))
   })
 })
 

--- a/nowledge-mem-amp-plugin/tests/session-delta.test.ts
+++ b/nowledge-mem-amp-plugin/tests/session-delta.test.ts
@@ -104,10 +104,24 @@ describe("acknowledgement helpers", () => {
     expect(isCheckpointedAppendAck({ append_mode: "checkpointed" })).toBe(false)
     expect(isCheckpointedAppendAck({ success: false, append_mode: "checkpointed" })).toBe(false)
     expect(isCheckpointedAppendAck({ success: true })).toBe(false)
+    expect(isCheckpointedAppendAck({
+      success: true,
+      append_mode: "checkpointed",
+      messages_added: -1,
+      total_messages: 3,
+    })).toBe(false)
+    expect(isCheckpointedAppendAck({
+      success: true,
+      append_mode: "checkpointed",
+      messages_added: 1,
+      total_messages: -1,
+    })).toBe(false)
   })
 
   it("validates create and append acknowledgements", () => {
     expect(appendAcknowledgedRemoteCount({ success: true, messages_added: 1, total_messages: 3 })).toBe(3)
+    expect(appendAcknowledgedRemoteCount({ success: true, messages_added: -1, total_messages: 3 })).toBeUndefined()
+    expect(appendAcknowledgedRemoteCount({ success: true, messages_added: 1, total_messages: -1 })).toBeUndefined()
     expect(appendAcknowledgedRemoteCount({})).toBeUndefined()
     expect(createAcknowledgedRemoteCount({ thread: { thread_id: "amp-x", message_count: 5 } }, "amp-x")).toBe(5)
     expect(createAcknowledgedRemoteCount({ thread: { thread_id: "amp-x" }, messages: [{}, {}] }, "amp-x")).toBe(2)
@@ -123,6 +137,7 @@ describe("acknowledgement helpers", () => {
     expect(isThreadNotFoundResponse(400, { error_code: "thread_not_found" })).toBe(true)
     expect(isThreadNotFoundResponse(404, { detail: "missing" })).toBe(true)
     expect(isThreadNotFoundResponse(500, { detail: "other" })).toBe(false)
+    expect(isThreadNotFoundResponse(500, { detail: "upstream thread not found" })).toBe(false)
     expect(isThreadAlreadyExistsResponse(409, {})).toBe(true)
     expect(isThreadAlreadyExistsResponse(422, { detail: "Thread amp-x already exists in space default" })).toBe(true)
     expect(isThreadAlreadyExistsResponse(422, { detail: "unrelated" })).toBe(false)

--- a/nowledge-mem-amp-plugin/tests/session-delta.test.ts
+++ b/nowledge-mem-amp-plugin/tests/session-delta.test.ts
@@ -1,0 +1,159 @@
+import { describe, expect, it } from "vitest"
+
+import {
+  appendAcknowledgedRemoteCount,
+  createAcknowledgedRemoteCount,
+  isCheckpointConflictResponse,
+  isCheckpointedAppendAck,
+  isThreadAlreadyExistsResponse,
+  isThreadNotFoundResponse,
+  recreateMissingThread,
+  selectAcknowledgedDelta,
+  sessionSyncLaneKey,
+  stableMessageFingerprint,
+} from "../src/session-delta"
+
+const id = (message: { readonly id: string }) => message.id
+
+describe("selectAcknowledgedDelta", () => {
+  it("selects only the unacknowledged suffix", () => {
+    const messages = [{ id: "a" }, { id: "b" }, { id: "c" }]
+    const cursor = selectAcknowledgedDelta(messages.slice(0, 2), undefined, id).next
+    const delta = selectAcknowledgedDelta(messages, cursor, id)
+    expect(delta.messages).toEqual([{ id: "c" }])
+    expect(delta.next.count).toBe(3)
+    expect(delta.next.lastExternalId).toBe("c")
+    expect(delta.reset).toBe(false)
+  })
+
+  it("resets when a compacted branch no longer contains the anchor", () => {
+    const messages = [{ id: "new-a" }, { id: "new-b" }]
+    const cursor = selectAcknowledgedDelta([{ id: "old-a" }], undefined, id).next
+    const delta = selectAcknowledgedDelta(messages, cursor, id)
+    expect(delta.messages).toEqual(messages)
+    expect(delta.start).toBe(0)
+    expect(delta.reset).toBe(true)
+  })
+
+  it("returns no work for an exact replay", () => {
+    const messages = [{ id: "a" }, { id: "b" }]
+    const cursor = selectAcknowledgedDelta(messages, undefined, id).next
+    const delta = selectAcknowledgedDelta(messages, cursor, id)
+    expect(delta.messages).toEqual([])
+    expect(delta.next).toEqual(cursor)
+  })
+
+  it("resets when an earlier message changes but the final anchor is unchanged", () => {
+    const original = [{ id: "a", content: "old" }, { id: "b", content: "same" }]
+    const cursor = selectAcknowledgedDelta(original, undefined, id).next
+    const changed = [{ id: "a", content: "new" }, { id: "b", content: "same" }]
+    const delta = selectAcknowledgedDelta(changed, cursor, id)
+    expect(delta.reset).toBe(true)
+    expect(delta.messages).toEqual(changed)
+  })
+
+  it("omits lastExternalId for an empty snapshot", () => {
+    const delta = selectAcknowledgedDelta([], undefined, id)
+    expect(delta.messages).toEqual([])
+    expect(delta.next.lastExternalId).toBeUndefined()
+    expect(delta.next.count).toBe(0)
+  })
+
+  it("resets when the cursor count is out of range", () => {
+    const messages = [{ id: "a" }]
+    const delta = selectAcknowledgedDelta(messages, {
+      count: 4,
+      remoteCount: 4,
+      lastExternalId: "missing",
+      prefixFingerprint: "nope",
+    }, id)
+    expect(delta.reset).toBe(true)
+    expect(delta.start).toBe(0)
+  })
+})
+
+describe("sessionSyncLaneKey", () => {
+  it("isolates cursor state by the complete destination lane", () => {
+    const first = sessionSyncLaneKey("thread", "https://mem", "key", "space-a", "agent", "host")
+    const second = sessionSyncLaneKey("thread", "https://mem", "key", "space-b", "agent", "host")
+    expect(first).not.toBe(second)
+    expect(first).toBe(sessionSyncLaneKey("thread", "https://mem", "key", "space-a", "agent", "host"))
+  })
+})
+
+describe("acknowledgement helpers", () => {
+  it("requires an explicit checkpoint acknowledgement", () => {
+    expect(isCheckpointedAppendAck({
+      success: true,
+      append_mode: "checkpointed",
+      messages_added: 1,
+      total_messages: 3,
+    })).toBe(true)
+    expect(isCheckpointedAppendAck({ append_mode: "checkpointed" })).toBe(false)
+    expect(isCheckpointedAppendAck({ success: false, append_mode: "checkpointed" })).toBe(false)
+    expect(isCheckpointedAppendAck({ success: true })).toBe(false)
+  })
+
+  it("validates create and append acknowledgements", () => {
+    expect(appendAcknowledgedRemoteCount({ success: true, messages_added: 1, total_messages: 3 })).toBe(3)
+    expect(appendAcknowledgedRemoteCount({})).toBeUndefined()
+    expect(createAcknowledgedRemoteCount({ thread: { thread_id: "amp-x", message_count: 5 } }, "amp-x")).toBe(5)
+    expect(createAcknowledgedRemoteCount({ thread: { thread_id: "amp-x" }, messages: [{}, {}] }, "amp-x")).toBe(2)
+    expect(createAcknowledgedRemoteCount({ thread: { thread_id: "amp-x" }, messages: "nope" }, "amp-x")).toBeUndefined()
+    expect(createAcknowledgedRemoteCount({ thread: { thread_id: "other", message_count: 5 } }, "amp-x")).toBeUndefined()
+    expect(createAcknowledgedRemoteCount({ thread: {} }, "amp-x")).toBeUndefined()
+    expect(createAcknowledgedRemoteCount(null, "amp-x")).toBeUndefined()
+    expect(createAcknowledgedRemoteCount({ success: true }, "amp-x")).toBeUndefined()
+  })
+
+  it("recognizes missing-thread, already-exists, and checkpoint-conflict responses", () => {
+    expect(isThreadNotFoundResponse(400, { detail: "Thread not found: amp-x" })).toBe(true)
+    expect(isThreadNotFoundResponse(400, { error_code: "thread_not_found" })).toBe(true)
+    expect(isThreadNotFoundResponse(404, { detail: "missing" })).toBe(true)
+    expect(isThreadNotFoundResponse(500, { detail: "other" })).toBe(false)
+    expect(isThreadAlreadyExistsResponse(409, {})).toBe(true)
+    expect(isThreadAlreadyExistsResponse(422, { detail: "Thread amp-x already exists in space default" })).toBe(true)
+    expect(isThreadAlreadyExistsResponse(422, { detail: "unrelated" })).toBe(false)
+    expect(isThreadAlreadyExistsResponse(422, { error: { message: "Thread exists in space default." } })).toBe(true)
+    expect(isCheckpointConflictResponse({ error_code: "checkpoint_conflict" })).toBe(true)
+    expect(isCheckpointConflictResponse({ error_code: "other" })).toBe(false)
+  })
+
+  it("preserves the reconciled remote count for the next suffix", () => {
+    const first = [{ id: "a" }, { id: "b" }]
+    const initial = selectAcknowledgedDelta(first, undefined, id).next
+    const reconciled = { ...initial, remoteCount: 5 }
+    const next = selectAcknowledgedDelta([...first, { id: "c" }], reconciled, id)
+    expect(next.messages).toEqual([{ id: "c" }])
+    expect(next.next.remoteCount).toBe(5)
+  })
+
+  it("recreates the complete thread after a missing-thread response", async () => {
+    const recovered = await recreateMissingThread(
+      { ok: false, status: 400, data: { detail: "Thread not found: amp-x" } },
+      async () => ({ ok: true, status: 201, data: { thread_id: "amp-x" } }),
+    )
+    expect(recovered.recreated).toBe(true)
+    expect(recovered.response.ok).toBe(true)
+  })
+
+  it("leaves a successful or unrelated failure unchanged", async () => {
+    const ok = await recreateMissingThread(
+      { ok: true, status: 200, data: {} },
+      async () => ({ ok: false, status: 500, data: {} }),
+    )
+    expect(ok.recreated).toBe(false)
+    expect(ok.response.ok).toBe(true)
+
+    const other = await recreateMissingThread(
+      { ok: false, status: 500, data: { detail: "boom" } },
+      async () => ({ ok: true, status: 201, data: {} }),
+    )
+    expect(other.recreated).toBe(false)
+    expect(other.response.status).toBe(500)
+  })
+
+  it("fingerprints messages as stable JSON", () => {
+    expect(stableMessageFingerprint({ id: "a" })).toBe(JSON.stringify({ id: "a" }))
+  })
+})

--- a/nowledge-mem-amp-plugin/tests/sync.test.ts
+++ b/nowledge-mem-amp-plugin/tests/sync.test.ts
@@ -530,9 +530,10 @@ describe("SessionSyncManager.scheduleSync", () => {
 })
 
 describe("SessionSyncManager.dispose", () => {
-  it("clears pending timers and prevents scheduling after dispose", () => {
+  it("flushes pending messages, clears their timer, and prevents later scheduling", async () => {
     let setCount = 0
     let clearedCount = 0
+    const nmemApi = fakeNmemApi({ "/threads": () => createAck() })
     const manager = new SessionSyncManager(
       managerOptions({
         autoSyncEnabled: true,
@@ -543,32 +544,41 @@ describe("SessionSyncManager.dispose", () => {
         clearTimer: () => {
           clearedCount += 1
         },
-        nmemApi: fakeNmemApi({ "/threads": () => createAck() }),
+        nmemApi,
       }),
     )
-    manager.scheduleSync(THREAD_ID)
+    manager.scheduleSync(THREAD_ID, FULL_TRANSCRIPT)
     expect(setCount).toBe(1)
-    manager.dispose()
+    await manager.dispose()
     expect(clearedCount).toBe(1)
+    expect(nmemApi.calls).toEqual(["/threads"])
     manager.scheduleSync(THREAD_ID)
     expect(setCount).toBe(1)
   })
 
-  it("does not reschedule pending work after dispose", async () => {
+  it("waits for in-flight work before flushing the queued suffix", async () => {
     const timers = fakeTimers()
     let resolveRequest: ((response: HttpResponse) => void) | undefined
     const nmemApi = fakeNmemApi({
       "/threads": () => new Promise<HttpResponse>((resolve) => { resolveRequest = resolve }),
+      "/threads/amp-t-abc123/append": () => appendAck(2, 4, true),
     })
     const manager = new SessionSyncManager(managerOptions({ nmemApi, ...timers }))
-    manager.scheduleSync(THREAD_ID)
+    manager.scheduleSync(THREAD_ID, FULL_TRANSCRIPT)
     timers.fireAll()
     await flushMicrotasks()
-    manager.scheduleSync(THREAD_ID)
-    manager.dispose()
+    manager.scheduleSync(THREAD_ID, FOLLOW_UP_TRANSCRIPT)
+    const disposing = manager.dispose()
+    expect(nmemApi.calls).toEqual(["/threads"])
     resolveRequest?.(createAck())
-    await flushMicrotasks()
+    await disposing
     expect(timers.handles).toHaveLength(0)
+    expect(nmemApi.calls).toEqual(["/threads", "/threads/amp-t-abc123/append"])
+    const body = nmemApi.bodies[1] as { readonly messages: Array<{ readonly metadata: { readonly external_id: string } }> }
+    expect(body.messages.map((message) => message.metadata.external_id)).toEqual([
+      "amp-msg-u2",
+      "amp-msg-a2",
+    ])
   })
 
   it("serializes concurrent manual captures", async () => {
@@ -617,9 +627,10 @@ describe("SessionSyncManager.dispose", () => {
     timers.fireAll()
     await vi.waitFor(() => expect(nmemApi.calls).toHaveLength(1))
     const manual = manager.syncNow(THREAD_ID)
-    manager.dispose()
+    const disposing = manager.dispose()
     pending.shift()?.(createAck())
     const result = await manual
+    await disposing
     expect(result.reason).toBe("disposed")
   })
 

--- a/nowledge-mem-amp-plugin/tests/sync.test.ts
+++ b/nowledge-mem-amp-plugin/tests/sync.test.ts
@@ -846,7 +846,7 @@ describe("SessionSyncManager incremental checkpoint contract", () => {
     expect(nmemApi.timeouts).toEqual([12_000, MANUAL_SYNC_TIMEOUT_MS])
   })
 
-  it("isolates checkpoint state across destination spaces", async () => {
+  it("holds independent checkpoint state across two manager instances", async () => {
     const firstApi = fakeNmemApi({ "/threads": () => createAck() })
     const secondApi = fakeNmemApi({ "/threads": () => createAck() })
     const first = new SessionSyncManager(managerOptions({ nmemApi: firstApi, ambientSpaceId: "space-a" }))

--- a/nowledge-mem-amp-plugin/tests/sync.test.ts
+++ b/nowledge-mem-amp-plugin/tests/sync.test.ts
@@ -820,29 +820,45 @@ describe("SessionSyncManager incremental checkpoint contract", () => {
     expect(appendBody.messages.map((message) => message.content)).toEqual(["rewritten hello", "hi back"])
   })
 
-  it("does not immediately retry or read the full transcript when an incremental persist fails", async () => {
+  it("retries a failed incremental suffix without rereading the full transcript", async () => {
     const timers = fakeTimers()
     const readThreadMessages = vi.fn(async () => FULL_TRANSCRIPT)
-    let attempts = 0
+    let appendAttempts = 0
     const nmemApi = fakeNmemApi({
-      "/threads": () => {
-        attempts += 1
-        return attempts === 1
+      "/threads": () => createAck(),
+      "/threads/amp-t-abc123/append": () => {
+        appendAttempts += 1
+        return appendAttempts === 1
           ? { ok: false, status: 500, data: { error: "boom" } }
-          : createAck(STABLE_THREAD_ID, 4)
+          : appendAck(2, 4, true)
       },
     })
     const manager = new SessionSyncManager(managerOptions({ nmemApi, readThreadMessages, ...timers }))
-    manager.scheduleSync(THREAD_ID, FULL_TRANSCRIPT)
-    await fireUntil(timers, nmemApi, 1)
-    expect(readThreadMessages).not.toHaveBeenCalled()
-    expect(nmemApi.calls).toEqual(["/threads"])
+    await manager.syncNow(THREAD_ID)
+    expect(readThreadMessages).toHaveBeenCalledTimes(1)
 
     manager.scheduleSync(THREAD_ID, FOLLOW_UP_TRANSCRIPT)
     await fireUntil(timers, nmemApi, 2)
-    expect(readThreadMessages).not.toHaveBeenCalled()
-    expect(nmemApi.calls).toEqual(["/threads", "/threads"])
-    expect((nmemApi.bodies[1] as { messages: unknown[] }).messages).toHaveLength(4)
+    expect(readThreadMessages).toHaveBeenCalledTimes(1)
+    expect(nmemApi.calls).toEqual(["/threads", "/threads/amp-t-abc123/append"])
+
+    manager.scheduleSync(THREAD_ID, FOLLOW_UP_TRANSCRIPT)
+    await fireUntil(timers, nmemApi, 3)
+    expect(readThreadMessages).toHaveBeenCalledTimes(1)
+    expect(nmemApi.calls).toEqual([
+      "/threads",
+      "/threads/amp-t-abc123/append",
+      "/threads/amp-t-abc123/append",
+    ])
+    const appendBodies = nmemApi.bodies.slice(1) as Array<{
+      messages: Array<{ content: string }>
+      expected_message_count: number
+    }>
+    expect(appendBodies.map((body) => body.messages.map((message) => message.content))).toEqual([
+      ["second turn", "second answer"],
+      ["second turn", "second answer"],
+    ])
+    expect(appendBodies.map((body) => body.expected_message_count)).toEqual([2, 2])
   })
 
   it("holds an unanswered user tail until a later assistant completes it", async () => {

--- a/nowledge-mem-amp-plugin/tests/sync.test.ts
+++ b/nowledge-mem-amp-plugin/tests/sync.test.ts
@@ -1,9 +1,32 @@
 import { describe, expect, it, vi } from "vitest"
 
-import { SessionSyncManager } from "../src/sync"
+import { MANUAL_SYNC_TIMEOUT_MS, SessionSyncManager } from "../src/sync"
 import type { CaptureResult, SessionSyncManagerOptions } from "../src/sync"
 import type { HttpResponse } from "../src/http"
 import type { ThreadID } from "../src/types"
+
+const STABLE_THREAD_ID = "amp-t-abc123"
+
+function createAck(threadId = STABLE_THREAD_ID, messageCount = 2): HttpResponse {
+  return {
+    ok: true,
+    status: 200,
+    data: { thread: { thread_id: threadId, message_count: messageCount } },
+  }
+}
+
+function appendAck(messagesAdded: number, totalMessages: number, checkpointed = false): HttpResponse {
+  return {
+    ok: true,
+    status: 200,
+    data: {
+      success: true,
+      messages_added: messagesAdded,
+      total_messages: totalMessages,
+      ...(checkpointed ? { append_mode: "checkpointed" } : {}),
+    },
+  }
+}
 
 /** A thread id in the SDK's branded `T-${string}` shape. */
 const THREAD_ID = "T-abc123" as ThreadID
@@ -32,18 +55,25 @@ const INCOMPLETE_TRANSCRIPT = [{ role: "user", id: "u1", parts: [{ type: "text",
 /** Builds a fake nmemApi that responds per-path. Handlers may be async. */
 function fakeNmemApi(
   handlers: Record<string, (() => HttpResponse) | (() => Promise<HttpResponse>)>,
-): SessionSyncManagerOptions["nmemApi"] & { calls: string[]; bodies: unknown[] } {
+): SessionSyncManagerOptions["nmemApi"] & { calls: string[]; bodies: unknown[]; timeouts: Array<number | undefined> } {
   const calls: string[] = []
   const bodies: unknown[] = []
-  const fn = ((path: string, body: unknown) => {
+  const timeouts: Array<number | undefined> = []
+  const fn = ((path: string, body: unknown, timeoutMs?: number) => {
     calls.push(path)
     bodies.push(body)
+    timeouts.push(timeoutMs)
     const handler = handlers[path] ?? handlers["default"]
-    if (handler === undefined) return Promise.resolve({ ok: false, status: 500, data: { error: "no handler" } })
+    if (handler === undefined) {
+      if (path.includes("/append")) return Promise.resolve(appendAck(2, 4, true))
+      if (path === "/threads") return Promise.resolve(createAck())
+      return Promise.resolve({ ok: false, status: 500, data: { error: "no handler" } })
+    }
     return Promise.resolve(handler())
-  }) as unknown as SessionSyncManagerOptions["nmemApi"] & { calls: string[]; bodies: unknown[] }
+  }) as unknown as SessionSyncManagerOptions["nmemApi"] & { calls: string[]; bodies: unknown[]; timeouts: Array<number | undefined> }
   fn.calls = calls
   fn.bodies = bodies
+  fn.timeouts = timeouts
   return fn
 }
 
@@ -51,7 +81,7 @@ function fakeNmemApi(
 function managerOptions(overrides: Partial<SessionSyncManagerOptions> = {}): SessionSyncManagerOptions {
   const timers = fakeTimers()
   return {
-    nmemApi: fakeNmemApi({ "/threads": () => ({ ok: true, status: 200, data: { id: "T-new" } }) }),
+    nmemApi: fakeNmemApi({ "/threads": () => createAck() }),
     readThreadMessages: async () => FULL_TRANSCRIPT,
     setTimer: timers.setTimer,
     clearTimer: timers.clearTimer,
@@ -59,7 +89,12 @@ function managerOptions(overrides: Partial<SessionSyncManagerOptions> = {}): Ses
     projectPath: "/proj",
     autoSyncEnabled: true,
     autoSyncDebounceMs: 1500,
+    autoSyncTimeoutMs: 45_000,
+    apiUrl: "http://127.0.0.1:14242",
+    apiKey: undefined,
     ambientSpaceId: undefined,
+    ambientAgentId: undefined,
+    ambientHostAgentId: undefined,
     ...overrides,
   }
 }
@@ -98,7 +133,7 @@ function fakeTimers(): {
 
 describe("SessionSyncManager.syncNow", () => {
   it("creates a thread on a fresh transcript", async () => {
-    const nmemApi = fakeNmemApi({ "/threads": () => ({ ok: true, status: 200, data: { id: "T-new" } }) })
+    const nmemApi = fakeNmemApi({ "/threads": () => createAck() })
     const manager = new SessionSyncManager(managerOptions({ nmemApi }))
     const result = await manager.syncNow(THREAD_ID)
 
@@ -117,7 +152,7 @@ describe("SessionSyncManager.syncNow", () => {
   ])("falls back to append when create returns the existing-thread response %i", async (status, data) => {
     const nmemApi = fakeNmemApi({
       "/threads": () => ({ ok: false, status, data }),
-      "/threads/amp-t-abc123/append": () => ({ ok: true, status: 200, data: { appended: true } }),
+      "/threads/amp-t-abc123/append": () => appendAck(2, 2),
     })
     const manager = new SessionSyncManager(managerOptions({ nmemApi, ambientSpaceId: "Research" }))
     const result = await manager.syncNow(THREAD_ID)
@@ -132,7 +167,7 @@ describe("SessionSyncManager.syncNow", () => {
   ])("preserves an unrelated 422 create failure", async (data) => {
     const nmemApi = fakeNmemApi({
       "/threads": () => ({ ok: false, status: 422, data }),
-      "/threads/amp-t-abc123/append": () => ({ ok: true, status: 200, data: { appended: true } }),
+      "/threads/amp-t-abc123/append": () => appendAck(2, 2),
     })
     const manager = new SessionSyncManager(managerOptions({ nmemApi }))
     const result = await manager.syncNow(THREAD_ID)
@@ -145,7 +180,7 @@ describe("SessionSyncManager.syncNow", () => {
   it("preserves the original create failure when it is not a conflict", async () => {
     const nmemApi = fakeNmemApi({
       "/threads": () => ({ ok: false, status: 500, data: { error: "boom" } }),
-      "/threads/amp-t-abc123/append": () => ({ ok: true, status: 200, data: { appended: true } }),
+      "/threads/amp-t-abc123/append": () => appendAck(2, 2),
     })
     const manager = new SessionSyncManager(managerOptions({ nmemApi }))
     const result = await manager.syncNow(THREAD_ID)
@@ -158,7 +193,7 @@ describe("SessionSyncManager.syncNow", () => {
   it("appends without a space_id when no ambient space is set", async () => {
     const nmemApi = fakeNmemApi({
       "/threads": () => ({ ok: false, status: 409, data: {} }),
-      "/threads/amp-t-abc123/append": () => ({ ok: true, status: 200, data: {} }),
+      "/threads/amp-t-abc123/append": () => appendAck(2, 2),
     })
     const manager = new SessionSyncManager(managerOptions({ nmemApi }))
     const result = await manager.syncNow(THREAD_ID)
@@ -170,7 +205,7 @@ describe("SessionSyncManager.syncNow", () => {
     let capturedBody: unknown
     const nmemApi = fakeNmemApi({
       "/threads": () => ({ ok: false, status: 409, data: {} }),
-      "/threads/amp-t-abc123/append": () => ({ ok: true, status: 200, data: {} }),
+      "/threads/amp-t-abc123/append": () => appendAck(2, 2),
     })
     // Wrap to capture the body argument.
     const wrapped: SessionSyncManagerOptions["nmemApi"] = ((path: string, body: unknown) => {
@@ -183,8 +218,8 @@ describe("SessionSyncManager.syncNow", () => {
     expect(capturedBody).toMatchObject({
       space_id: "Research",
       deduplicate: true,
-      idempotency_key: "amp:live:amp-t-abc123",
     })
+    expect((capturedBody as { idempotency_key: string }).idempotency_key).toMatch(/^amp:live:amp-t-abc123:0-2:/)
   })
 
   it("returns an append error result when create conflicts and append fails", async () => {
@@ -200,7 +235,7 @@ describe("SessionSyncManager.syncNow", () => {
   })
 
   it("skips with no_messages when the transcript is empty", async () => {
-    const nmemApi = fakeNmemApi({ "/threads": () => ({ ok: true, status: 200, data: {} }) })
+    const nmemApi = fakeNmemApi({ "/threads": () => (createAck()) })
     const manager = new SessionSyncManager(managerOptions({ nmemApi, readThreadMessages: async () => [] }))
     const result = await manager.syncNow(THREAD_ID)
     expect(result.skipped).toBe(true)
@@ -209,7 +244,7 @@ describe("SessionSyncManager.syncNow", () => {
   })
 
   it("skips with no_extractable_messages when messages lack ids", async () => {
-    const nmemApi = fakeNmemApi({ "/threads": () => ({ ok: true, status: 200, data: {} }) })
+    const nmemApi = fakeNmemApi({ "/threads": () => (createAck()) })
     const manager = new SessionSyncManager(
       managerOptions({ nmemApi, readThreadMessages: async () => [{ role: "user", parts: [{ type: "text", text: "x" }] }] }),
     )
@@ -219,7 +254,7 @@ describe("SessionSyncManager.syncNow", () => {
   })
 
   it("skips with incomplete_turn when only one role is present", async () => {
-    const nmemApi = fakeNmemApi({ "/threads": () => ({ ok: true, status: 200, data: {} }) })
+    const nmemApi = fakeNmemApi({ "/threads": () => (createAck()) })
     const manager = new SessionSyncManager(managerOptions({ nmemApi, readThreadMessages: async () => INCOMPLETE_TRANSCRIPT }))
     const result = await manager.syncNow(THREAD_ID)
     expect(result.skipped).toBe(true)
@@ -227,11 +262,15 @@ describe("SessionSyncManager.syncNow", () => {
   })
 
   it("forces re-upload on syncNow even when the signature matches a prior run", async () => {
-    const nmemApi = fakeNmemApi({ "/threads": () => ({ ok: true, status: 200, data: {} }) })
+    const nmemApi = fakeNmemApi({
+      "/threads": () => createAck(),
+      "/threads/amp-t-abc123/append": () => appendAck(2, 2),
+    })
     const manager = new SessionSyncManager(managerOptions({ nmemApi }))
     await manager.syncNow(THREAD_ID)
     await manager.syncNow(THREAD_ID)
-    expect(nmemApi.calls).toHaveLength(2)
+    expect(nmemApi.calls).toEqual(["/threads", "/threads/amp-t-abc123/append"])
+    expect(nmemApi.timeouts).toEqual([MANUAL_SYNC_TIMEOUT_MS, MANUAL_SYNC_TIMEOUT_MS])
   })
 
   it("serializes overlapping manual captures and reruns the forced save", async () => {
@@ -245,7 +284,7 @@ describe("SessionSyncManager.syncNow", () => {
         callCount += 1
         return callCount === 1
           ? await firstInFlight
-          : { ok: true, status: 200, data: {} }
+          : createAck()
       },
     })
     const manager = new SessionSyncManager(managerOptions({ nmemApi }))
@@ -255,15 +294,15 @@ describe("SessionSyncManager.syncNow", () => {
     await flushMicrotasks()
     expect(nmemApi.calls).toEqual(["/threads"])
 
-    resolveFirst!({ ok: true, status: 200, data: {} })
+    resolveFirst!(createAck())
     await Promise.all([firstSync, secondSync])
 
-    expect(nmemApi.calls).toEqual(["/threads", "/threads"])
+    expect(nmemApi.calls).toEqual(["/threads", "/threads/amp-t-abc123/append"])
   })
 
   it("derives the title from the first user message, truncated to 120 chars", async () => {
     const longContent = "x".repeat(200)
-    const nmemApi = fakeNmemApi({ "/threads": () => ({ ok: true, status: 200, data: {} }) })
+    const nmemApi = fakeNmemApi({ "/threads": () => (createAck()) })
     const manager = new SessionSyncManager(
       managerOptions({
         nmemApi,
@@ -280,7 +319,7 @@ describe("SessionSyncManager.syncNow", () => {
   it("uses the first user message even when the assistant turn comes first", async () => {
     // Assistant-first ordering still has both roles, so it is not incomplete,
     // and the title still comes from the (second) user turn.
-    const nmemApi = fakeNmemApi({ "/threads": () => ({ ok: true, status: 200, data: {} }) })
+    const nmemApi = fakeNmemApi({ "/threads": () => (createAck()) })
     const manager = new SessionSyncManager(
       managerOptions({
         nmemApi,
@@ -298,7 +337,7 @@ describe("SessionSyncManager.syncNow", () => {
     // No user turn means deriveTitle cannot find a user message, so it falls
     // back to messages[0]. The transcript is still incomplete_turn and skipped,
     // so assert the skip path explicitly.
-    const nmemApi = fakeNmemApi({ "/threads": () => ({ ok: true, status: 200, data: {} }) })
+    const nmemApi = fakeNmemApi({ "/threads": () => (createAck()) })
     const manager = new SessionSyncManager(
       managerOptions({
         nmemApi,
@@ -317,7 +356,7 @@ describe("SessionSyncManager.syncNow", () => {
 describe("SessionSyncManager.scheduleSync", () => {
   it("does nothing when auto-sync is disabled", async () => {
     const timers = fakeTimers()
-    const nmemApi = fakeNmemApi({ "/threads": () => ({ ok: true, status: 200, data: {} }) })
+    const nmemApi = fakeNmemApi({ "/threads": () => (createAck()) })
     const manager = new SessionSyncManager(managerOptions({ nmemApi, autoSyncEnabled: false, ...timers }))
     manager.scheduleSync(THREAD_ID)
     expect(timers.handles).toHaveLength(0)
@@ -326,7 +365,7 @@ describe("SessionSyncManager.scheduleSync", () => {
 
   it("schedules a capture that persists the thread", async () => {
     const timers = fakeTimers()
-    const nmemApi = fakeNmemApi({ "/threads": () => ({ ok: true, status: 200, data: {} }) })
+    const nmemApi = fakeNmemApi({ "/threads": () => (createAck()) })
     const manager = new SessionSyncManager(managerOptions({ nmemApi, ...timers }))
     manager.scheduleSync(THREAD_ID)
     expect(nmemApi.calls).toEqual([])
@@ -337,7 +376,7 @@ describe("SessionSyncManager.scheduleSync", () => {
 
   it("persists the incremental agent.end messages without reading the thread", async () => {
     const timers = fakeTimers()
-    const nmemApi = fakeNmemApi({ "/threads": () => ({ ok: true, status: 200, data: {} }) })
+    const nmemApi = fakeNmemApi({ "/threads": () => (createAck()) })
     const readThreadMessages = vi.fn(async () => FULL_TRANSCRIPT)
     const manager = new SessionSyncManager(managerOptions({ nmemApi, readThreadMessages, ...timers }))
 
@@ -349,9 +388,24 @@ describe("SessionSyncManager.scheduleSync", () => {
     expect(readThreadMessages).not.toHaveBeenCalled()
   })
 
+  it("keeps host messages without ids when merging debounce batches", async () => {
+    const timers = fakeTimers()
+    const nmemApi = fakeNmemApi({ "/threads": () => createAck() })
+    const manager = new SessionSyncManager(managerOptions({ nmemApi, ...timers }))
+    const first = { role: "user", parts: [{ type: "text", text: "no-id-one" }] }
+    const second = { role: "assistant", id: { nested: true }, parts: [{ type: "text", text: "no-id-two" }] }
+    manager.scheduleSync(THREAD_ID, [first])
+    manager.scheduleSync(THREAD_ID, [])
+    manager.scheduleSync(THREAD_ID, [first, second])
+    timers.fireAll()
+    await flushMicrotasks()
+    // Messages without usable ids are kept for debounce de-dupe but dropped at convert time.
+    expect(nmemApi.calls).toEqual([])
+  })
+
   it("merges incremental messages scheduled inside the debounce window", async () => {
     const timers = fakeTimers()
-    const nmemApi = fakeNmemApi({ "/threads": () => ({ ok: true, status: 200, data: {} }) })
+    const nmemApi = fakeNmemApi({ "/threads": () => (createAck()) })
     const readThreadMessages = vi.fn(async () => FULL_TRANSCRIPT)
     const manager = new SessionSyncManager(managerOptions({ nmemApi, readThreadMessages, ...timers }))
 
@@ -372,7 +426,7 @@ describe("SessionSyncManager.scheduleSync", () => {
 
   it("skips an unchanged transcript on a second non-forced schedule", async () => {
     const timers = fakeTimers()
-    const nmemApi = fakeNmemApi({ "/threads": () => ({ ok: true, status: 200, data: {} }) })
+    const nmemApi = fakeNmemApi({ "/threads": () => (createAck()) })
     const manager = new SessionSyncManager(managerOptions({ nmemApi, ...timers }))
     manager.scheduleSync(THREAD_ID)
     timers.fireAll()
@@ -380,13 +434,13 @@ describe("SessionSyncManager.scheduleSync", () => {
     manager.scheduleSync(THREAD_ID)
     timers.fireAll()
     await flushMicrotasks()
-    // First schedule persists; second is deduped by signature.
+    // First schedule persists; second is an empty acknowledged delta.
     expect(nmemApi.calls).toHaveLength(1)
   })
 
   it("coalesces repeated schedules inside the debounce window", async () => {
     const timers = fakeTimers()
-    const nmemApi = fakeNmemApi({ "/threads": () => ({ ok: true, status: 200, data: {} }) })
+    const nmemApi = fakeNmemApi({ "/threads": () => (createAck()) })
     const manager = new SessionSyncManager(managerOptions({ nmemApi, ...timers }))
 
     manager.scheduleSync(THREAD_ID)
@@ -421,14 +475,14 @@ describe("SessionSyncManager.scheduleSync", () => {
     expect(nmemApi.calls).toEqual(["/threads"])
 
     // Allow the first to complete; the pending flag schedules one more capture.
-    resolveFirst!({ ok: true, status: 200, data: {} })
+    resolveFirst!(createAck())
     await firstSync
     await flushMicrotasks()
     expect(timers.handles).toHaveLength(1)
     timers.fireAll()
     await flushMicrotasks()
 
-    // Dedup prevents further persistence of the same signature.
+    // An empty acknowledged delta prevents a second persist of the same snapshot.
     expect(nmemApi.calls).toEqual(["/threads"])
   })
 
@@ -439,10 +493,8 @@ describe("SessionSyncManager.scheduleSync", () => {
     })
     let callCount = 0
     const nmemApi = fakeNmemApi({
-      "/threads": async () => {
-        callCount += 1
-        return callCount === 1 ? await firstInFlight : { ok: true, status: 200, data: {} }
-      },
+      "/threads": async () => await firstInFlight,
+      "/threads/amp-t-abc123/append": () => appendAck(4, 6, true),
     })
     const timers = fakeTimers()
     const manager = new SessionSyncManager(managerOptions({ nmemApi, ...timers }))
@@ -462,7 +514,7 @@ describe("SessionSyncManager.scheduleSync", () => {
     await flushMicrotasks()
     expect(nmemApi.calls).toEqual(["/threads"])
 
-    resolveFirst!({ ok: true, status: 200, data: {} })
+    resolveFirst!(createAck())
     await vi.waitFor(() => expect(timers.handles).toHaveLength(1))
     timers.fireAll()
     await vi.waitFor(() => expect(nmemApi.bodies).toHaveLength(2))
@@ -491,7 +543,7 @@ describe("SessionSyncManager.dispose", () => {
         clearTimer: () => {
           clearedCount += 1
         },
-        nmemApi: fakeNmemApi({ "/threads": () => ({ ok: true, status: 200, data: {} }) }),
+        nmemApi: fakeNmemApi({ "/threads": () => createAck() }),
       }),
     )
     manager.scheduleSync(THREAD_ID)
@@ -514,7 +566,7 @@ describe("SessionSyncManager.dispose", () => {
     await flushMicrotasks()
     manager.scheduleSync(THREAD_ID)
     manager.dispose()
-    resolveRequest?.({ ok: true, status: 200, data: {} })
+    resolveRequest?.(createAck())
     await flushMicrotasks()
     expect(timers.handles).toHaveLength(0)
   })
@@ -522,36 +574,36 @@ describe("SessionSyncManager.dispose", () => {
   it("serializes concurrent manual captures", async () => {
     const pending: Array<(response: HttpResponse) => void> = []
     const nmemApi = fakeNmemApi({
-      "/threads": () => new Promise<HttpResponse>((resolve) => pending.push(resolve)),
+      default: () => new Promise<HttpResponse>((resolve) => pending.push(resolve)),
     })
     const manager = new SessionSyncManager(managerOptions({ nmemApi }))
     const first = manager.syncNow(THREAD_ID)
     await vi.waitFor(() => expect(nmemApi.calls).toHaveLength(1))
     const second = manager.syncNow(THREAD_ID)
-    pending.shift()?.({ ok: true, status: 200, data: {} })
+    pending.shift()?.(createAck())
     await first
     await vi.waitFor(() => expect(pending).toHaveLength(1))
-    pending.shift()?.({ ok: true, status: 200, data: {} })
+    pending.shift()?.(appendAck(2, 2))
     await second
-    expect(nmemApi.calls).toHaveLength(2)
+    expect(nmemApi.calls).toEqual(["/threads", "/threads/amp-t-abc123/append"])
   })
 
   it("waits for an automatic capture before a manual capture", async () => {
     const timers = fakeTimers()
     const pending: Array<(response: HttpResponse) => void> = []
     const nmemApi = fakeNmemApi({
-      "/threads": () => new Promise<HttpResponse>((resolve) => pending.push(resolve)),
+      default: () => new Promise<HttpResponse>((resolve) => pending.push(resolve)),
     })
     const manager = new SessionSyncManager(managerOptions({ nmemApi, ...timers }))
     manager.scheduleSync(THREAD_ID)
     timers.fireAll()
     await vi.waitFor(() => expect(nmemApi.calls).toHaveLength(1))
     const manual = manager.syncNow(THREAD_ID)
-    pending.shift()?.({ ok: true, status: 200, data: {} })
+    pending.shift()?.(createAck())
     await vi.waitFor(() => expect(pending).toHaveLength(1))
-    pending.shift()?.({ ok: true, status: 200, data: {} })
+    pending.shift()?.(appendAck(2, 2))
     await manual
-    expect(nmemApi.calls).toHaveLength(2)
+    expect(nmemApi.calls).toEqual(["/threads", "/threads/amp-t-abc123/append"])
   })
 
   it("returns disposed while waiting when teardown occurs", async () => {
@@ -566,7 +618,7 @@ describe("SessionSyncManager.dispose", () => {
     await vi.waitFor(() => expect(nmemApi.calls).toHaveLength(1))
     const manual = manager.syncNow(THREAD_ID)
     manager.dispose()
-    pending.shift()?.({ ok: true, status: 200, data: {} })
+    pending.shift()?.(createAck())
     const result = await manual
     expect(result.reason).toBe("disposed")
   })
@@ -579,6 +631,233 @@ describe("SessionSyncManager.dispose", () => {
     expect(result.reason).toBe("disposed")
   })
 })
+
+
+
+describe("SessionSyncManager incremental checkpoint contract", () => {
+  async function fireUntil(
+    timers: ReturnType<typeof fakeTimers>,
+    nmemApi: { readonly calls: string[] },
+    count: number,
+  ): Promise<void> {
+    timers.fireAll()
+    await vi.waitFor(() => expect(nmemApi.calls).toHaveLength(count))
+    await flushMicrotasks()
+    await flushMicrotasks()
+  }
+
+  it("appends only the unacknowledged suffix with a checkpointed request", async () => {
+    const timers = fakeTimers()
+    const nmemApi = fakeNmemApi({
+      "/threads": () => createAck(),
+      "/threads/amp-t-abc123/append": () => appendAck(2, 4, true),
+    })
+    const manager = new SessionSyncManager(managerOptions({
+      nmemApi,
+      readThreadMessages: async () => FULL_TRANSCRIPT,
+      ...timers,
+    }))
+
+    await manager.syncNow(THREAD_ID)
+    manager.scheduleSync(THREAD_ID, FOLLOW_UP_TRANSCRIPT)
+    await fireUntil(timers, nmemApi, 2)
+
+    expect(nmemApi.calls).toEqual(["/threads", "/threads/amp-t-abc123/append"])
+    expect(nmemApi.timeouts[0]).toBe(MANUAL_SYNC_TIMEOUT_MS)
+    expect(nmemApi.timeouts[1]).toBe(45_000)
+    const appendBody = nmemApi.bodies[1] as {
+      readonly messages: Array<{ readonly metadata: { readonly external_id: string } }>
+      readonly expected_message_count: number
+      readonly idempotency_key: string
+    }
+    expect(appendBody.messages.map((message) => message.metadata.external_id)).toEqual([
+      "amp-msg-u2",
+      "amp-msg-a2",
+    ])
+    expect(appendBody.expected_message_count).toBe(2)
+    expect(appendBody.idempotency_key).toMatch(/^amp:live:amp-t-abc123:2-4:/)
+  })
+
+  it("preserves the cursor when the create response lacks an explicit ack", async () => {
+    const nmemApi = fakeNmemApi({
+      "/threads": () => ({ ok: true, status: 200, data: { id: "T-new" } }),
+    })
+    const manager = new SessionSyncManager(managerOptions({ nmemApi }))
+    const result = await manager.syncNow(THREAD_ID)
+    expect(result.error).toContain("explicit persistence acknowledgement")
+    await manager.syncNow(THREAD_ID)
+    expect(nmemApi.calls).toEqual(["/threads", "/threads"])
+  })
+
+  it("preserves the cursor when a checkpointed append is not acknowledged as checkpointed", async () => {
+    const timers = fakeTimers()
+    const nmemApi = fakeNmemApi({
+      "/threads": () => createAck(),
+      "/threads/amp-t-abc123/append": () => appendAck(2, 4, false),
+    })
+    const manager = new SessionSyncManager(managerOptions({
+      nmemApi,
+      readThreadMessages: async () => FULL_TRANSCRIPT,
+      ...timers,
+    }))
+    await manager.syncNow(THREAD_ID)
+    manager.scheduleSync(THREAD_ID, FOLLOW_UP_TRANSCRIPT)
+    await fireUntil(timers, nmemApi, 2)
+    manager.scheduleSync(THREAD_ID, FOLLOW_UP_TRANSCRIPT)
+    await fireUntil(timers, nmemApi, 3)
+    expect(nmemApi.calls).toEqual([
+      "/threads",
+      "/threads/amp-t-abc123/append",
+      "/threads/amp-t-abc123/append",
+    ])
+  })
+
+  it("reconciles after a checkpoint conflict", async () => {
+    const timers = fakeTimers()
+    let appendCount = 0
+    const nmemApi = fakeNmemApi({
+      "/threads": () => createAck(),
+      "/threads/amp-t-abc123/append": () => {
+        appendCount += 1
+        return appendCount === 1
+          ? { ok: false, status: 409, data: { error_code: "checkpoint_conflict" } }
+          : appendAck(0, 5)
+      },
+    })
+    const manager = new SessionSyncManager(managerOptions({
+      nmemApi,
+      readThreadMessages: async () => FULL_TRANSCRIPT,
+      ambientSpaceId: "Research",
+      ...timers,
+    }))
+    await manager.syncNow(THREAD_ID)
+    manager.scheduleSync(THREAD_ID, FOLLOW_UP_TRANSCRIPT)
+    await fireUntil(timers, nmemApi, 3)
+    expect(nmemApi.calls).toEqual([
+      "/threads",
+      "/threads/amp-t-abc123/append",
+      "/threads/amp-t-abc123/append",
+    ])
+    const reconcileBody = nmemApi.bodies[2] as { readonly idempotency_key: string; readonly messages: unknown[]; readonly space_id: string }
+    expect(reconcileBody.idempotency_key).toMatch(/^amp:reconcile:amp-t-abc123:/)
+    expect(reconcileBody.messages).toHaveLength(4)
+    expect(reconcileBody.space_id).toBe("Research")
+  })
+
+  it("reconciles a checkpoint conflict without a space_id when none is configured", async () => {
+    const timers = fakeTimers()
+    let appendCount = 0
+    const nmemApi = fakeNmemApi({
+      "/threads": () => createAck(),
+      "/threads/amp-t-abc123/append": () => {
+        appendCount += 1
+        return appendCount === 1
+          ? { ok: false, status: 409, data: { error_code: "checkpoint_conflict" } }
+          : appendAck(0, 5)
+      },
+    })
+    const manager = new SessionSyncManager(managerOptions({
+      nmemApi,
+      readThreadMessages: async () => FULL_TRANSCRIPT,
+      ...timers,
+    }))
+    await manager.syncNow(THREAD_ID)
+    manager.scheduleSync(THREAD_ID, FOLLOW_UP_TRANSCRIPT)
+    await fireUntil(timers, nmemApi, 3)
+    expect((nmemApi.bodies[2] as { space_id?: string }).space_id).toBeUndefined()
+  })
+
+  it("recreates the complete thread after HTTP 400 Thread not found", async () => {
+    const timers = fakeTimers()
+    const nmemApi = fakeNmemApi({
+      "/threads": () => createAck("amp-t-abc123", 4),
+      "/threads/amp-t-abc123/append": () => ({
+        ok: false,
+        status: 400,
+        data: { detail: "Thread not found: amp-t-abc123" },
+      }),
+    })
+    const manager = new SessionSyncManager(managerOptions({
+      nmemApi,
+      readThreadMessages: async () => FULL_TRANSCRIPT,
+      ...timers,
+    }))
+    await manager.syncNow(THREAD_ID)
+    manager.scheduleSync(THREAD_ID, FOLLOW_UP_TRANSCRIPT)
+    await fireUntil(timers, nmemApi, 3)
+    expect(nmemApi.calls).toEqual([
+      "/threads",
+      "/threads/amp-t-abc123/append",
+      "/threads",
+    ])
+  })
+
+  it("resets to a full suffix when an earlier prefix is replaced", async () => {
+    const timers = fakeTimers()
+    const nmemApi = fakeNmemApi({
+      "/threads": () => createAck(),
+      "/threads/amp-t-abc123/append": () => appendAck(2, 2),
+    })
+    const manager = new SessionSyncManager(managerOptions({
+      nmemApi,
+      readThreadMessages: async () => FULL_TRANSCRIPT,
+      ...timers,
+    }))
+    await manager.syncNow(THREAD_ID)
+
+    const rewritten = [
+      { role: "user", id: "u1", parts: [{ type: "text", text: "rewritten hello" }] },
+      { role: "assistant", id: "a1", parts: [{ type: "text", text: "hi back" }] },
+    ]
+    manager.scheduleSync(THREAD_ID, rewritten)
+    await fireUntil(timers, nmemApi, 2)
+
+    const appendBody = nmemApi.bodies[1] as {
+      readonly messages: Array<{ readonly content: string }>
+      readonly expected_message_count?: number
+    }
+    expect(appendBody.expected_message_count).toBeUndefined()
+    expect(appendBody.messages.map((message) => message.content)).toEqual(["rewritten hello", "hi back"])
+  })
+
+  it("falls back to a full transcript read when an incremental persist fails", async () => {
+    const timers = fakeTimers()
+    const readThreadMessages = vi.fn(async () => [
+      ...FULL_TRANSCRIPT,
+      ...FOLLOW_UP_TRANSCRIPT,
+    ])
+    const nmemApi = fakeNmemApi({
+      "/threads": () => ({ ok: false, status: 500, data: { error: "boom" } }),
+    })
+    const manager = new SessionSyncManager(managerOptions({ nmemApi, readThreadMessages, ...timers }))
+    manager.scheduleSync(THREAD_ID, FULL_TRANSCRIPT)
+    await fireUntil(timers, nmemApi, 2)
+    expect(readThreadMessages).toHaveBeenCalledTimes(1)
+    expect(nmemApi.calls).toEqual(["/threads", "/threads"])
+  })
+
+  it("uses the automatic timeout for scheduled captures and the existing manual timeout for syncNow", async () => {
+    const timers = fakeTimers()
+    const nmemApi = fakeNmemApi({ "/threads": () => createAck() })
+    const manager = new SessionSyncManager(managerOptions({ nmemApi, autoSyncTimeoutMs: 12_000, ...timers }))
+    manager.scheduleSync(THREAD_ID)
+    await fireUntil(timers, nmemApi, 1)
+    await manager.syncNow(THREAD_ID)
+    expect(nmemApi.timeouts).toEqual([12_000, MANUAL_SYNC_TIMEOUT_MS])
+  })
+
+  it("isolates checkpoint state across destination spaces", async () => {
+    const firstApi = fakeNmemApi({ "/threads": () => createAck() })
+    const secondApi = fakeNmemApi({ "/threads": () => createAck() })
+    const first = new SessionSyncManager(managerOptions({ nmemApi: firstApi, ambientSpaceId: "space-a" }))
+    const second = new SessionSyncManager(managerOptions({ nmemApi: secondApi, ambientSpaceId: "space-b" }))
+    await first.syncNow(THREAD_ID)
+    await second.syncNow(THREAD_ID)
+    expect(firstApi.calls).toEqual(["/threads"])
+    expect(secondApi.calls).toEqual(["/threads"])
+  })
+})
+
 
 // Ensure CaptureResult is referenced for type-only import side effects in coverage.
 export type { CaptureResult }

--- a/nowledge-mem-amp-plugin/tests/sync.test.ts
+++ b/nowledge-mem-amp-plugin/tests/sync.test.ts
@@ -820,20 +820,57 @@ describe("SessionSyncManager incremental checkpoint contract", () => {
     expect(appendBody.messages.map((message) => message.content)).toEqual(["rewritten hello", "hi back"])
   })
 
-  it("falls back to a full transcript read when an incremental persist fails", async () => {
+  it("does not immediately retry or read the full transcript when an incremental persist fails", async () => {
     const timers = fakeTimers()
-    const readThreadMessages = vi.fn(async () => [
-      ...FULL_TRANSCRIPT,
-      ...FOLLOW_UP_TRANSCRIPT,
-    ])
+    const readThreadMessages = vi.fn(async () => FULL_TRANSCRIPT)
+    let attempts = 0
     const nmemApi = fakeNmemApi({
-      "/threads": () => ({ ok: false, status: 500, data: { error: "boom" } }),
+      "/threads": () => {
+        attempts += 1
+        return attempts === 1
+          ? { ok: false, status: 500, data: { error: "boom" } }
+          : createAck(STABLE_THREAD_ID, 4)
+      },
     })
     const manager = new SessionSyncManager(managerOptions({ nmemApi, readThreadMessages, ...timers }))
     manager.scheduleSync(THREAD_ID, FULL_TRANSCRIPT)
+    await fireUntil(timers, nmemApi, 1)
+    expect(readThreadMessages).not.toHaveBeenCalled()
+    expect(nmemApi.calls).toEqual(["/threads"])
+
+    manager.scheduleSync(THREAD_ID, FOLLOW_UP_TRANSCRIPT)
     await fireUntil(timers, nmemApi, 2)
-    expect(readThreadMessages).toHaveBeenCalledTimes(1)
+    expect(readThreadMessages).not.toHaveBeenCalled()
     expect(nmemApi.calls).toEqual(["/threads", "/threads"])
+    expect((nmemApi.bodies[1] as { messages: unknown[] }).messages).toHaveLength(4)
+  })
+
+  it("holds an unanswered user tail until a later assistant completes it", async () => {
+    const timers = fakeTimers()
+    const nmemApi = fakeNmemApi({
+      "/threads": () => createAck(),
+      "/threads/amp-t-abc123/append": () => appendAck(2, 4, true),
+    })
+    const manager = new SessionSyncManager(managerOptions({ nmemApi, ...timers }))
+
+    manager.scheduleSync(THREAD_ID, [
+      ...FULL_TRANSCRIPT,
+      FOLLOW_UP_TRANSCRIPT[0],
+    ])
+    await fireUntil(timers, nmemApi, 1)
+    expect((nmemApi.bodies[0] as { messages: unknown[] }).messages).toHaveLength(2)
+
+    manager.scheduleSync(THREAD_ID, [FOLLOW_UP_TRANSCRIPT[1]])
+    await fireUntil(timers, nmemApi, 2)
+    const appendBody = nmemApi.bodies[1] as {
+      messages: Array<{ metadata: { external_id: string } }>
+      expected_message_count: number
+    }
+    expect(appendBody.messages.map((message) => message.metadata.external_id)).toEqual([
+      "amp-msg-u2",
+      "amp-msg-a2",
+    ])
+    expect(appendBody.expected_message_count).toBe(2)
   })
 
   it("uses the automatic timeout for scheduled captures and the existing manual timeout for syncNow", async () => {

--- a/tests/plugin_e2e/test_key_plugins_e2e.py
+++ b/tests/plugin_e2e/test_key_plugins_e2e.py
@@ -1755,7 +1755,7 @@ def test_amp_plugin_static_contract_is_self_contained():
 
     # Package manifest and registry entry agree on the basics.
     assert pkg["name"] == "amp-nowledge-mem"
-    assert pkg["version"] == "0.1.3"
+    assert pkg["version"] == "0.1.4"
     assert pkg["type"] == "module"
     assert pkg["main"] == "src/index.ts"
     assert "@ampcode/plugin" in pkg["peerDependencies"]


### PR DESCRIPTION
## Summary

- Capture only the unacknowledged Amp transcript suffix and advance checkpoints after explicit create or append acknowledgement.
- Preserve pending turns across failed appends, recover from checkpoint conflicts and missing threads, and isolate cursor state by destination and identity.
- Apply bounded `NMEM_SYNC_TIMEOUT_MS` handling to automatic synchronization while retaining the existing manual-save timeout.
- Update the Amp integration release metadata and documentation to version 0.1.4.

## Validation

- `npm test`: 251 passed, 2 skipped
- `npm run typecheck`
- `npm run test:coverage`
- `git diff --check`
- GitHub Actions and CodeRabbit checks pass on `64ca42ed`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added incremental session syncing that appends only new conversation content.
  - Added recovery for missing threads, checkpoint conflicts, and transcript changes.
  - Added configurable automatic sync timeouts from 1 second to 30 minutes.

- **Bug Fixes**
  - Improved isolation between destinations and identities.
  - Prevented duplicate uploads and preserved unsent changes after failures.
  - Graceful shutdown now completes active and queued captures.

- **Documentation**
  - Documented timeout configuration and updated release notes.

- **Chores**
  - Released version 0.1.4.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->