### PR TITLE
fix(openclaw): make session capture checkpointed and retry-safe

### DIFF
--- a/nowledge-mem-openclaw-plugin/CHANGELOG.md
+++ b/nowledge-mem-openclaw-plugin/CHANGELOG.md
@@ -4,6 +4,20 @@ All notable changes to the Nowledge Mem OpenClaw plugin will be documented in th
 
 ## Unreleased
 
+### Fixed
+
+- Automatic thread capture now sends the paired Mem checkpoint contract
+  (`expected_message_count`, a content-bound idempotency key, and
+  `append_mode: "checkpointed"`) and only advances the local cursor after an
+  explicit append/create acknowledgement.
+- Same-length and earlier-prefix replacements reset to a full replay. OpenClaw
+  compaction shrinks still reset the local cursor without replaying the
+  compacted summary.
+- Destination-lane cursor state is isolated by API URL, credentials, and space.
+- Thread create/append honor `NMEM_SYNC_TIMEOUT_MS` with a 120s default and
+  1-second to 30-minute bounds.
+
+
 ## [0.8.31] - 2026-07-12
 
 ### Improved

--- a/nowledge-mem-openclaw-plugin/CHANGELOG.md
+++ b/nowledge-mem-openclaw-plugin/CHANGELOG.md
@@ -16,6 +16,8 @@ All notable changes to the Nowledge Mem OpenClaw plugin will be documented in th
 - Destination-lane cursor state is isolated by API URL, credentials, and space.
 - Thread create/append honor `NMEM_SYNC_TIMEOUT_MS` with a 120s default and
   1-second to 30-minute bounds.
+- Automatic capture now skips persist until a user+assistant pair exists,
+  so a user-only reset checkpoint is not stored as a complete thread.
 
 
 ## [0.8.31] - 2026-07-12

--- a/nowledge-mem-openclaw-plugin/README.md
+++ b/nowledge-mem-openclaw-plugin/README.md
@@ -220,7 +220,7 @@ flowchart TD
 
 **Key points:**
 - Thread capture is unconditional: every conversation is saved and searchable via `nowledge_mem_thread_search`
-- Thread sync is incremental: the plugin preserves the real transcript but appends only the unsynced tail instead of replaying the whole session
+- Thread sync is incremental: the plugin preserves the real transcript, appends only the unsynced tail, and requires Mem's checkpointed acknowledgement before the local cursor advances
 - LLM distillation only runs at `agent_end`, not during compaction/reset checkpoints
 - Distilled memories carry `sourceThreadId`, linking them back to the source conversation
 - Cooldown (`digestMinInterval`, default 300s) prevents burst distillation
@@ -498,6 +498,7 @@ NMEM_CORPUS_MAX_RESULTS=5
 NMEM_CORPUS_MIN_SCORE=0
 NMEM_API_URL=https://...
 NMEM_API_KEY=your-key
+NMEM_SYNC_TIMEOUT_MS=120000
 ```
 
 ### Priority

--- a/nowledge-mem-openclaw-plugin/src/client.js
+++ b/nowledge-mem-openclaw-plugin/src/client.js
@@ -1,4 +1,10 @@
 import { buildNmemSpawnEnv } from "./spawn-env.js";
+import {
+	isCheckpointConflictResponse,
+	isCheckpointedAppendAck,
+	isThreadAppendAck,
+	sessionSyncLaneKey,
+} from "./session-delta.js";
 
 /**
  * Patch a single markdown section in a Working Memory document.
@@ -94,6 +100,26 @@ export class NowledgeMemClient {
 				? credentials.spaceId
 				: "";
 		this._spaceRef = String(resolvedSpace ?? "").trim();
+		this._threadSyncTimeoutMs = Number.isInteger(credentials.threadSyncTimeoutMs)
+			? credentials.threadSyncTimeoutMs
+			: 120_000;
+	}
+
+	getSpaceRef() {
+		return this._spaceRef;
+	}
+
+	getThreadSyncTimeoutMs() {
+		return this._threadSyncTimeoutMs;
+	}
+
+	cursorKey(threadId) {
+		return sessionSyncLaneKey(
+			threadId,
+			this._apiUrl,
+			this._apiKey,
+			this._spaceRef,
+		);
 	}
 
 	// ── API helpers (fallback path and direct operations) ─────────────────────
@@ -162,7 +188,11 @@ export class NowledgeMemClient {
 							: typeof data?.raw === "string"
 								? data.raw
 								: `HTTP ${response.status}`;
-				throw new Error(detail);
+				const error = new Error(detail);
+				error.status = response.status;
+				error.code =
+					typeof data?.error_code === "string" ? data.error_code : undefined;
+				throw error;
 			}
 			return data;
 		} finally {
@@ -602,6 +632,7 @@ export class NowledgeMemClient {
 				source: String(source),
 				messages,
 			},
+			this._threadSyncTimeoutMs,
 		);
 
 		return String(
@@ -614,6 +645,7 @@ export class NowledgeMemClient {
 		messages,
 		deduplicate = true,
 		idempotencyKey,
+		expectedMessageCount,
 	}) {
 		const normalizedThreadId = String(threadId || "").trim();
 		if (!normalizedThreadId) {
@@ -623,6 +655,7 @@ export class NowledgeMemClient {
 			return { messagesAdded: 0, totalMessages: 0 };
 		}
 
+		const checkpointed = Number.isInteger(expectedMessageCount);
 		const data = await this.apiJson(
 			"POST",
 			`/threads/${encodeURIComponent(normalizedThreadId)}/append`,
@@ -632,11 +665,25 @@ export class NowledgeMemClient {
 				...(idempotencyKey
 					? { idempotency_key: String(idempotencyKey) }
 					: {}),
+				...(checkpointed
+					? { expected_message_count: expectedMessageCount }
+					: {}),
 			},
+			this._threadSyncTimeoutMs,
 		);
+		if (!isThreadAppendAck(data)) {
+			throw new Error(
+				"Thread append did not include an explicit persistence acknowledgement",
+			);
+		}
+		if (checkpointed && !isCheckpointedAppendAck(data)) {
+			throw new Error(
+				"Thread append was not acknowledged as checkpointed",
+			);
+		}
 		return {
-			messagesAdded: Number(data.messages_added ?? 0),
-			totalMessages: Number(data.total_messages ?? 0),
+			messagesAdded: data.messages_added,
+			totalMessages: data.total_messages,
 		};
 	}
 
@@ -679,9 +726,17 @@ export class NowledgeMemClient {
 			err instanceof Error ? err.message : String(err)
 		).toLowerCase();
 		return (
+			err?.code === "thread_not_found" ||
 			message.includes("thread not found") ||
 			message.includes("404") ||
 			message.includes("not found")
+		);
+	}
+
+	isCheckpointConflictError(err) {
+		return (
+			err?.code === "checkpoint_conflict" ||
+			isCheckpointConflictResponse({ error_code: err?.code })
 		);
 	}
 

--- a/nowledge-mem-openclaw-plugin/src/client.js
+++ b/nowledge-mem-openclaw-plugin/src/client.js
@@ -732,9 +732,8 @@ export class NowledgeMemClient {
 		).toLowerCase();
 		return (
 			err?.code === "thread_not_found" ||
-			message.includes("thread not found") ||
-			message.includes("404") ||
-			message.includes("not found")
+			err?.status === 404 ||
+			(err?.status === 400 && message.includes("thread not found"))
 		);
 	}
 

--- a/nowledge-mem-openclaw-plugin/src/client.js
+++ b/nowledge-mem-openclaw-plugin/src/client.js
@@ -4,6 +4,7 @@ import {
 	isCheckpointedAppendAck,
 	isThreadAppendAck,
 	sessionSyncLaneKey,
+	threadCreateAck,
 } from "./session-delta.js";
 
 /**
@@ -635,9 +636,13 @@ export class NowledgeMemClient {
 			this._threadSyncTimeoutMs,
 		);
 
-		return String(
-			data.id ?? data.thread?.thread_id ?? data.thread_id ?? "created",
-		);
+		const ack = threadCreateAck(data, threadId);
+		if (!ack) {
+			throw new Error(
+				"Thread create did not include an explicit persistence acknowledgement",
+			);
+		}
+		return ack;
 	}
 
 	async appendThread({

--- a/nowledge-mem-openclaw-plugin/src/client.js
+++ b/nowledge-mem-openclaw-plugin/src/client.js
@@ -616,6 +616,10 @@ export class NowledgeMemClient {
 	}
 
 	async createThread({ threadId, title, messages, source = "openclaw" }) {
+		const normalizedThreadId = String(threadId || "").trim();
+		if (!normalizedThreadId) {
+			throw new Error("createThread requires threadId");
+		}
 		const normalizedTitle = String(title || "").trim();
 		if (!normalizedTitle) {
 			throw new Error("createThread requires a non-empty title");
@@ -628,7 +632,7 @@ export class NowledgeMemClient {
 			"POST",
 			"/threads",
 			{
-				...(threadId ? { thread_id: String(threadId) } : {}),
+				thread_id: normalizedThreadId,
 				title: normalizedTitle,
 				source: String(source),
 				messages,
@@ -636,7 +640,7 @@ export class NowledgeMemClient {
 			this._threadSyncTimeoutMs,
 		);
 
-		const ack = threadCreateAck(data, threadId);
+		const ack = threadCreateAck(data, normalizedThreadId);
 		if (!ack) {
 			throw new Error(
 				"Thread create did not include an explicit persistence acknowledgement",

--- a/nowledge-mem-openclaw-plugin/src/hooks/capture.js
+++ b/nowledge-mem-openclaw-plugin/src/hooks/capture.js
@@ -4,8 +4,8 @@ import { buildStableThreadId } from "./thread-identity.js";
 import {
 	contentBoundIdempotencyKey,
 	hasUserAndAssistant,
+	prefixFingerprint,
 	selectSnapshotDelta,
-	stableMessageFingerprint,
 } from "../session-delta.js";
 export {
 	_resetConversationRoots,
@@ -518,7 +518,15 @@ export async function appendOrCreateThread({
 
 	let cursor = _getCursor(client, threadId);
 	if (cursor === undefined) {
-		const remoteCount = await client.getThreadMessageCount(threadId);
+		let remoteCount = null;
+		try {
+			remoteCount = await client.getThreadMessageCount(threadId);
+		} catch (err) {
+			const message = err instanceof Error ? err.message : String(err);
+			logger.warn(
+				`capture: remote message count failed for ${threadId}: ${message}`,
+			);
+		}
 		if (remoteCount !== null && Number.isFinite(remoteCount) && remoteCount >= 0) {
 			cursor = {
 				count: Math.trunc(remoteCount),
@@ -542,7 +550,7 @@ export async function appendOrCreateThread({
 			...(allMessages.length > 0
 				? { lastExternalId: messageExternalId(allMessages[allMessages.length - 1]) }
 				: {}),
-			prefixFingerprint: stableMessageFingerprint(allMessages[allMessages.length - 1] || {}),
+			prefixFingerprint: prefixFingerprint(allMessages, allMessages.length),
 		};
 		return persistMessages({
 			client,

--- a/nowledge-mem-openclaw-plugin/src/hooks/capture.js
+++ b/nowledge-mem-openclaw-plugin/src/hooks/capture.js
@@ -3,6 +3,7 @@ import { readFile } from "node:fs/promises";
 import { buildStableThreadId } from "./thread-identity.js";
 import {
 	contentBoundIdempotencyKey,
+	hasUserAndAssistant,
 	selectSnapshotDelta,
 	stableMessageFingerprint,
 } from "../session-delta.js";
@@ -485,6 +486,7 @@ export async function appendOrCreateThread({
 		.map((message) => normalizeRoleMessage(message, maxMessageChars))
 		.filter(Boolean);
 	if (normalized.length === 0) return;
+	if (!hasUserAndAssistant(normalized)) return;
 	const title = buildThreadTitle(ctx, normalized);
 
 	const buildMessages = (resolvedMessageMode) =>

--- a/nowledge-mem-openclaw-plugin/src/hooks/capture.js
+++ b/nowledge-mem-openclaw-plugin/src/hooks/capture.js
@@ -486,11 +486,28 @@ export async function appendOrCreateThread({
 		.map((message) => normalizeRoleMessage(message, maxMessageChars))
 		.filter(Boolean);
 	if (normalized.length === 0) return;
-	if (!hasUserAndAssistant(normalized)) return;
-	const title = buildThreadTitle(ctx, normalized);
+	const resolvedMessageMode =
+		messageMode === CAPTURE_MESSAGE_MODE_DELTA ||
+		(messageMode === CAPTURE_MESSAGE_MODE_AUTO &&
+			hasStableExternalHints(normalized))
+			? CAPTURE_MESSAGE_MODE_DELTA
+			: CAPTURE_MESSAGE_MODE_SNAPSHOT;
+	let captured = normalized;
+	if (resolvedMessageMode === CAPTURE_MESSAGE_MODE_SNAPSHOT) {
+		let lastAssistantIndex = -1;
+		for (let index = normalized.length - 1; index >= 0; index -= 1) {
+			if (normalized[index].role === "assistant") {
+				lastAssistantIndex = index;
+				break;
+			}
+		}
+		captured = normalized.slice(0, lastAssistantIndex + 1);
+	}
+	if (!hasUserAndAssistant(captured)) return;
+	const title = buildThreadTitle(ctx, captured);
 
 	const buildMessages = (resolvedMessageMode) =>
-		normalized.map((message, index) => ({
+		captured.map((message, index) => ({
 			role: message.role,
 			content: message.content,
 			timestamp: message.timestamp,
@@ -536,12 +553,6 @@ export async function appendOrCreateThread({
 		}
 	}
 
-	const resolvedMessageMode =
-		messageMode === CAPTURE_MESSAGE_MODE_DELTA ||
-		(messageMode === CAPTURE_MESSAGE_MODE_AUTO &&
-			hasStableExternalHints(normalized))
-			? CAPTURE_MESSAGE_MODE_DELTA
-			: CAPTURE_MESSAGE_MODE_SNAPSHOT;
 	if (resolvedMessageMode === CAPTURE_MESSAGE_MODE_DELTA) {
 		allMessages = buildMessages(CAPTURE_MESSAGE_MODE_DELTA);
 		const next = {
@@ -698,16 +709,16 @@ async function persistMessages({
 	}
 
 	try {
-		const createdId = await client.createThread({
+		const created = await client.createThread({
 			threadId,
 			title,
 			messages: allMessages,
 			source: "openclaw",
 		});
 		logger.info(
-			`capture: created thread ${createdId} with ${allMessages.length} ${label} messages (${reason || "event"})`,
+			`capture: created thread ${created.threadId} with ${created.totalMessages} persisted messages (${reason || "event"})`,
 		);
-		return acknowledge(allMessages.length, allMessages.length);
+		return acknowledge(created.totalMessages, allMessages.length);
 	} catch (err) {
 		const message = err instanceof Error ? err.message : String(err);
 		logger.warn(`capture: thread create failed for ${threadId}: ${message}`);

--- a/nowledge-mem-openclaw-plugin/src/hooks/capture.js
+++ b/nowledge-mem-openclaw-plugin/src/hooks/capture.js
@@ -546,7 +546,7 @@ export async function appendOrCreateThread({
 		}
 		if (remoteCount !== null && Number.isFinite(remoteCount) && remoteCount >= 0) {
 			cursor = {
-				count: Math.trunc(remoteCount),
+				count: 0,
 				remoteCount: Math.trunc(remoteCount),
 				prefixFingerprint: "",
 			};

--- a/nowledge-mem-openclaw-plugin/src/hooks/capture.js
+++ b/nowledge-mem-openclaw-plugin/src/hooks/capture.js
@@ -1,6 +1,11 @@
 import { createHash } from "node:crypto";
 import { readFile } from "node:fs/promises";
 import { buildStableThreadId } from "./thread-identity.js";
+import {
+	contentBoundIdempotencyKey,
+	selectSnapshotDelta,
+	stableMessageFingerprint,
+} from "../session-delta.js";
 export {
 	_resetConversationRoots,
 	buildStableThreadId,
@@ -25,7 +30,7 @@ const OPENCLAW_INTERNAL_SENDER_BLOCK_RE =
 // Evicted opportunistically when new entries are set (see _setLastCapture).
 const _lastCaptureAt = new Map();
 const _MAX_COOLDOWN_ENTRIES = 200;
-const _syncedMessageCounts = new Map();
+const _acknowledgedCursors = new Map();
 const _MAX_SYNC_CURSOR_ENTRIES = 500;
 const CAPTURE_MESSAGE_MODE_AUTO = "auto";
 const CAPTURE_MESSAGE_MODE_SNAPSHOT = "snapshot";
@@ -70,18 +75,32 @@ function _setLastCapture(threadId, now) {
 	}
 }
 
-function _setSyncedMessageCount(threadId, count) {
-	if (!threadId || !Number.isFinite(count) || count < 0) return;
-	_syncedMessageCounts.set(threadId, Math.trunc(count));
-	if (_syncedMessageCounts.size > _MAX_SYNC_CURSOR_ENTRIES) {
-		const excess = _syncedMessageCounts.size - _MAX_SYNC_CURSOR_ENTRIES;
+function _laneKey(client, threadId) {
+	return typeof client?.cursorKey === "function"
+		? client.cursorKey(threadId)
+		: String(threadId || "");
+}
+
+function _getCursor(client, threadId) {
+	return _acknowledgedCursors.get(_laneKey(client, threadId));
+}
+
+function _setAcknowledgedCursor(client, threadId, cursor) {
+	if (!threadId || !cursor) return;
+	_acknowledgedCursors.set(_laneKey(client, threadId), cursor);
+	if (_acknowledgedCursors.size > _MAX_SYNC_CURSOR_ENTRIES) {
+		const excess = _acknowledgedCursors.size - _MAX_SYNC_CURSOR_ENTRIES;
 		let removed = 0;
-		for (const key of _syncedMessageCounts.keys()) {
-			_syncedMessageCounts.delete(key);
+		for (const key of _acknowledgedCursors.keys()) {
+			_acknowledgedCursors.delete(key);
 			removed += 1;
 			if (removed >= excess) break;
 		}
 	}
+}
+
+export function _resetSyncCursors() {
+	_acknowledgedCursors.clear();
 }
 
 // ---------------------------------------------------------------------------
@@ -386,18 +405,18 @@ function buildExternalId({
 	return `oc-msg:${digest}`;
 }
 
-function buildAppendIdempotencyKey(threadId, reason, messages) {
-	const seed = {
-		threadId: String(threadId || ""),
-		reason: String(reason || "event"),
-		count: Array.isArray(messages) ? messages.length : 0,
-		externalIds: Array.isArray(messages)
-			? messages
-					.map((m) => m?.metadata?.external_id)
-					.filter((v) => typeof v === "string" && v.length > 0)
-			: [],
-	};
-	return `oc-batch:${createHash("sha1").update(JSON.stringify(seed)).digest("hex")}`;
+function messageExternalId(message) {
+	return String(message?.metadata?.external_id || "");
+}
+
+function buildContentBoundIdempotencyKey(threadId, reason, start, end, fingerprint) {
+	return contentBoundIdempotencyKey(
+		`oc:${String(reason || "event")}`,
+		threadId,
+		start,
+		end,
+		fingerprint,
+	);
 }
 
 function hasStableExternalHints(normalized) {
@@ -495,11 +514,15 @@ export async function appendOrCreateThread({
 			: CAPTURE_MESSAGE_MODE_SNAPSHOT,
 	);
 
-	let syncedCount = _syncedMessageCounts.get(threadId);
-	if (syncedCount === undefined) {
-		syncedCount = await client.getThreadMessageCount(threadId);
-		if (syncedCount !== null) {
-			_setSyncedMessageCount(threadId, syncedCount);
+	let cursor = _getCursor(client, threadId);
+	if (cursor === undefined) {
+		const remoteCount = await client.getThreadMessageCount(threadId);
+		if (remoteCount !== null && Number.isFinite(remoteCount) && remoteCount >= 0) {
+			cursor = {
+				count: Math.trunc(remoteCount),
+				remoteCount: Math.trunc(remoteCount),
+				prefixFingerprint: "",
+			};
 		}
 	}
 
@@ -511,95 +534,152 @@ export async function appendOrCreateThread({
 			: CAPTURE_MESSAGE_MODE_SNAPSHOT;
 	if (resolvedMessageMode === CAPTURE_MESSAGE_MODE_DELTA) {
 		allMessages = buildMessages(CAPTURE_MESSAGE_MODE_DELTA);
-		const idempotencyKey = buildAppendIdempotencyKey(
+		const next = {
+			count: allMessages.length,
+			remoteCount: cursor?.remoteCount ?? allMessages.length,
+			...(allMessages.length > 0
+				? { lastExternalId: messageExternalId(allMessages[allMessages.length - 1]) }
+				: {}),
+			prefixFingerprint: stableMessageFingerprint(allMessages[allMessages.length - 1] || {}),
+		};
+		return persistMessages({
+			client,
+			logger,
 			threadId,
+			title,
 			reason,
+			normalized,
 			allMessages,
-		);
-		try {
-			const appended = await client.appendThread({
-				threadId,
-				messages: allMessages,
-				deduplicate: true,
-				idempotencyKey,
-			});
-			const added = appended.messagesAdded ?? 0;
-			const total =
-				Number.isFinite(appended.totalMessages) && appended.totalMessages >= 0
-					? appended.totalMessages
-					: typeof syncedCount === "number"
-						? syncedCount + added
-						: allMessages.length;
-			_setSyncedMessageCount(threadId, total);
-			logger.info(
-				`capture: appended ${added} delta messages to ${threadId} (${reason || "event"})`,
-			);
-			return { threadId, normalized, messagesAdded: added };
-		} catch (err) {
-			if (!client.isThreadNotFoundError(err)) {
-				const message = err instanceof Error ? err.message : String(err);
-				logger.warn(
-					`capture: thread append failed for ${threadId}: ${message}`,
-				);
-				return null;
-			}
-		}
-
-		try {
-			const createdId = await client.createThread({
-				threadId,
-				title,
-				messages: allMessages,
-				source: "openclaw",
-			});
-			_setSyncedMessageCount(threadId, allMessages.length);
-			logger.info(
-				`capture: created thread ${createdId} with ${allMessages.length} delta messages (${reason || "event"})`,
-			);
-			return { threadId, normalized, messagesAdded: allMessages.length };
-		} catch (err) {
-			const message = err instanceof Error ? err.message : String(err);
-			logger.warn(`capture: thread create failed for ${threadId}: ${message}`);
-			return null;
-		}
+			toSend: allMessages,
+			start: 0,
+			end: allMessages.length,
+			next,
+			cursor,
+			reset: false,
+			label: "delta",
+		});
 	}
 
-	if (typeof syncedCount === "number" && syncedCount > allMessages.length) {
-		// OpenClaw compaction can shrink the active transcript after we already
-		// stored the pre-compaction history. Reset the local cursor to the new
-		// compacted length so future turns append only the tail after compaction.
-		_setSyncedMessageCount(threadId, allMessages.length);
+	const delta = selectSnapshotDelta(
+		allMessages,
+		cursor,
+		messageExternalId,
+	);
+	if (delta.compactionShrink) {
+		_setAcknowledgedCursor(client, threadId, delta.next);
 		return { threadId, normalized, messagesAdded: 0 };
 	}
-
-	const appendStart =
-		typeof syncedCount === "number" && syncedCount > 0
-			? Math.min(syncedCount, allMessages.length)
-			: 0;
-	const newMessages = allMessages.slice(appendStart);
-	if (newMessages.length === 0) {
+	if (delta.messages.length === 0) {
 		return { threadId, normalized, messagesAdded: 0 };
 	}
-	const idempotencyKey = buildAppendIdempotencyKey(
+	return persistMessages({
+		client,
+		logger,
+		threadId,
+		title,
+		reason,
+		normalized,
+		allMessages,
+		toSend: delta.messages,
+		start: delta.start,
+		end: delta.end,
+		next: delta.next,
+		cursor,
+		reset: delta.reset,
+		label: "snapshot",
+	});
+}
+
+async function persistMessages({
+	client,
+	logger,
+	threadId,
+	title,
+	reason,
+	normalized,
+	allMessages,
+	toSend,
+	start,
+	end,
+	next,
+	cursor,
+	reset,
+	label,
+}) {
+	const fingerprint = next.prefixFingerprint;
+	const idempotencyKey = buildContentBoundIdempotencyKey(
 		threadId,
 		reason,
-		newMessages,
+		start,
+		end,
+		fingerprint,
 	);
+	const expectedMessageCount =
+		!reset && Number.isInteger(cursor?.remoteCount) && cursor.prefixFingerprint
+			? cursor.remoteCount
+			: undefined;
+
+	const acknowledge = (remoteCount, added) => {
+		_setAcknowledgedCursor(client, threadId, {
+			...next,
+			remoteCount,
+		});
+		return { threadId, normalized, messagesAdded: added };
+	};
 
 	try {
 		const appended = await client.appendThread({
 			threadId,
-			messages: newMessages,
+			messages: toSend,
 			deduplicate: true,
 			idempotencyKey,
+			expectedMessageCount,
 		});
 		const added = appended.messagesAdded ?? 0;
-		_setSyncedMessageCount(threadId, allMessages.length);
+		const total =
+			Number.isInteger(appended.totalMessages) && appended.totalMessages >= 0
+				? appended.totalMessages
+				: toSend.length;
 		logger.info(
-			`capture: appended ${added} messages to ${threadId} (${reason || "event"})`,
+			`capture: appended ${added} ${label} messages to ${threadId} (${reason || "event"})`,
 		);
-		return { threadId, normalized, messagesAdded: added };
+		return acknowledge(total, added);
 	} catch (err) {
+		if (client.isCheckpointConflictError?.(err)) {
+			try {
+				const reconciled = await client.appendThread({
+					threadId,
+					messages: allMessages,
+					deduplicate: true,
+					idempotencyKey: buildContentBoundIdempotencyKey(
+						threadId,
+						`${reason || "event"}-reconcile`,
+						0,
+						allMessages.length,
+						fingerprint,
+					),
+				});
+				const added = reconciled.messagesAdded ?? allMessages.length;
+				const total =
+					Number.isInteger(reconciled.totalMessages) &&
+					reconciled.totalMessages >= 0
+						? reconciled.totalMessages
+						: allMessages.length;
+				logger.info(
+					`capture: reconciled ${added} messages to ${threadId} (${reason || "event"})`,
+				);
+				return acknowledge(total, added);
+			} catch (reconcileErr) {
+				const message =
+					reconcileErr instanceof Error
+						? reconcileErr.message
+						: String(reconcileErr);
+				logger.warn(
+					`capture: thread reconcile failed for ${threadId}: ${message}`,
+				);
+				return null;
+			}
+		}
 		if (!client.isThreadNotFoundError(err)) {
 			const message = err instanceof Error ? err.message : String(err);
 			logger.warn(`capture: thread append failed for ${threadId}: ${message}`);
@@ -614,11 +694,10 @@ export async function appendOrCreateThread({
 			messages: allMessages,
 			source: "openclaw",
 		});
-		_setSyncedMessageCount(threadId, allMessages.length);
 		logger.info(
-			`capture: created thread ${createdId} with ${allMessages.length} messages (${reason || "event"})`,
+			`capture: created thread ${createdId} with ${allMessages.length} ${label} messages (${reason || "event"})`,
 		);
-		return { threadId, normalized, messagesAdded: allMessages.length };
+		return acknowledge(allMessages.length, allMessages.length);
 	} catch (err) {
 		const message = err instanceof Error ? err.message : String(err);
 		logger.warn(`capture: thread create failed for ${threadId}: ${message}`);

--- a/nowledge-mem-openclaw-plugin/src/index.js
+++ b/nowledge-mem-openclaw-plugin/src/index.js
@@ -1,4 +1,5 @@
 import { NowledgeMemClient } from "./client.js";
+import { resolveThreadSyncTimeoutMs } from "./thread-sync-timeout.js";
 import { createCliRegistrar } from "./commands/cli.js";
 import {
 	createForgetCommand,
@@ -46,6 +47,7 @@ export default {
 			apiUrl: cfg.apiUrl,
 			apiKey: cfg.apiKey,
 			space: cfg.space,
+			threadSyncTimeoutMs: resolveThreadSyncTimeoutMs(process.env.NMEM_SYNC_TIMEOUT_MS),
 		});
 
 		const { memorySlot, memorySlotSelected } = resolveRegistrationMode({

--- a/nowledge-mem-openclaw-plugin/src/session-delta.js
+++ b/nowledge-mem-openclaw-plugin/src/session-delta.js
@@ -19,7 +19,11 @@ export function stableMessageFingerprint(message) {
 	});
 }
 
-function prefixFingerprint(messages, end, messageFingerprint) {
+export function prefixFingerprint(
+	messages,
+	end,
+	messageFingerprint = stableMessageFingerprint,
+) {
 	const hash = createHash("sha256");
 	for (const message of messages.slice(0, end)) {
 		const value = messageFingerprint(message);

--- a/nowledge-mem-openclaw-plugin/src/session-delta.js
+++ b/nowledge-mem-openclaw-plugin/src/session-delta.js
@@ -115,3 +115,15 @@ export function selectSnapshotDelta(
 export function contentBoundIdempotencyKey(prefix, threadId, start, end, fingerprint) {
 	return `${prefix}:${threadId}:${start}-${end}:${fingerprint}`;
 }
+
+export function hasUserAndAssistant(messages) {
+	if (!Array.isArray(messages) || messages.length < 2) return false;
+	let hasUser = false;
+	let hasAssistant = false;
+	for (const message of messages) {
+		if (message?.role === "user") hasUser = true;
+		else if (message?.role === "assistant") hasAssistant = true;
+		if (hasUser && hasAssistant) return true;
+	}
+	return false;
+}

--- a/nowledge-mem-openclaw-plugin/src/session-delta.js
+++ b/nowledge-mem-openclaw-plugin/src/session-delta.js
@@ -44,6 +44,22 @@ export function isThreadAppendAck(data) {
 	);
 }
 
+export function threadCreateAck(data, expectedThreadId) {
+	if (data === null || typeof data !== "object") return null;
+	const thread =
+		data.thread !== null && typeof data.thread === "object" ? data.thread : data;
+	const threadId = String(thread.thread_id ?? "").trim();
+	const totalMessages = thread.message_count ?? thread.total_messages;
+	if (
+		threadId !== String(expectedThreadId || "").trim() ||
+		!Number.isInteger(totalMessages) ||
+		totalMessages < 0
+	) {
+		return null;
+	}
+	return { threadId, totalMessages };
+}
+
 export function isCheckpointedAppendAck(data) {
 	return isThreadAppendAck(data) && data.append_mode === "checkpointed";
 }

--- a/nowledge-mem-openclaw-plugin/src/session-delta.js
+++ b/nowledge-mem-openclaw-plugin/src/session-delta.js
@@ -1,0 +1,117 @@
+import { createHash } from "node:crypto";
+
+export function sessionSyncLaneKey(threadId, apiUrl, apiKey, spaceId) {
+	const destination = createHash("sha256")
+		.update(
+			[String(apiUrl || ""), String(apiKey || ""), String(spaceId || "")].join(
+				"\0",
+			),
+		)
+		.digest("hex");
+	return `${destination}\0${String(threadId || "")}`;
+}
+
+export function stableMessageFingerprint(message) {
+	return JSON.stringify({
+		role: message?.role,
+		content: message?.content,
+		external_id: message?.metadata?.external_id,
+	});
+}
+
+function prefixFingerprint(messages, end, messageFingerprint) {
+	const hash = createHash("sha256");
+	for (const message of messages.slice(0, end)) {
+		const value = messageFingerprint(message);
+		hash.update(String(Buffer.byteLength(value)));
+		hash.update(":");
+		hash.update(value);
+	}
+	return hash.digest("hex");
+}
+
+export function isThreadAppendAck(data) {
+	return (
+		data !== null &&
+		typeof data === "object" &&
+		data.success === true &&
+		Number.isInteger(data.messages_added) &&
+		Number.isInteger(data.total_messages)
+	);
+}
+
+export function isCheckpointedAppendAck(data) {
+	return isThreadAppendAck(data) && data.append_mode === "checkpointed";
+}
+
+export function isCheckpointConflictResponse(data) {
+	return (
+		data !== null &&
+		typeof data === "object" &&
+		data.error_code === "checkpoint_conflict"
+	);
+}
+
+export function selectSnapshotDelta(
+	messages,
+	cursor,
+	externalId,
+	messageFingerprint = stableMessageFingerprint,
+) {
+	let start = cursor?.count ?? 0;
+	let reset = false;
+	if (start > messages.length) {
+		// OpenClaw compaction shrinks the live transcript after we already
+		// stored the pre-compaction history. Reset the local cursor to the
+		// compacted length so later turns append only the post-compaction tail.
+		const end = messages.length;
+		return {
+			start: end,
+			end,
+			messages: [],
+			next: {
+				count: end,
+				remoteCount: cursor?.remoteCount ?? end,
+				...(end > 0 ? { lastExternalId: externalId(messages[end - 1]) } : {}),
+				prefixFingerprint: prefixFingerprint(messages, end, messageFingerprint),
+			},
+			reset: false,
+			compactionShrink: true,
+		};
+	}
+	const acknowledgedPrefix =
+		start >= 0
+			? prefixFingerprint(messages, start, messageFingerprint)
+			: "";
+	const fingerprintTrusted = Boolean(cursor?.prefixFingerprint);
+	const externalIdTrusted = Boolean(cursor?.lastExternalId);
+	if (
+		start < 0 ||
+		(start > 0 &&
+			((externalIdTrusted &&
+				externalId(messages[start - 1]) !== cursor.lastExternalId) ||
+				(fingerprintTrusted &&
+					acknowledgedPrefix !== cursor.prefixFingerprint)))
+	) {
+		start = 0;
+		reset = true;
+	}
+	const end = messages.length;
+	return {
+		start,
+		end,
+		messages: messages.slice(start),
+		next: {
+			count: end,
+			remoteCount: cursor?.remoteCount ?? end,
+			...(end > 0 ? { lastExternalId: externalId(messages[end - 1]) } : {}),
+			prefixFingerprint: prefixFingerprint(messages, end, messageFingerprint),
+		},
+		reset,
+		compactionShrink: false,
+	};
+}
+
+export function contentBoundIdempotencyKey(prefix, threadId, start, end, fingerprint) {
+	return `${prefix}:${threadId}:${start}-${end}:${fingerprint}`;
+}

--- a/nowledge-mem-openclaw-plugin/src/session-delta.js
+++ b/nowledge-mem-openclaw-plugin/src/session-delta.js
@@ -40,7 +40,9 @@ export function isThreadAppendAck(data) {
 		typeof data === "object" &&
 		data.success === true &&
 		Number.isInteger(data.messages_added) &&
-		Number.isInteger(data.total_messages)
+		data.messages_added >= 0 &&
+		Number.isInteger(data.total_messages) &&
+		data.total_messages >= 0
 	);
 }
 

--- a/nowledge-mem-openclaw-plugin/src/thread-sync-timeout.js
+++ b/nowledge-mem-openclaw-plugin/src/thread-sync-timeout.js
@@ -1,0 +1,14 @@
+const DEFAULT_THREAD_SYNC_TIMEOUT_MS = 120_000;
+const MIN_THREAD_SYNC_TIMEOUT_MS = 1_000;
+const MAX_THREAD_SYNC_TIMEOUT_MS = 30 * 60_000;
+
+export function resolveThreadSyncTimeoutMs(raw) {
+	const parsed = Number(raw);
+	if (!String(raw ?? "").trim() || !Number.isSafeInteger(parsed) || parsed <= 0) {
+		return DEFAULT_THREAD_SYNC_TIMEOUT_MS;
+	}
+	return Math.min(
+		MAX_THREAD_SYNC_TIMEOUT_MS,
+		Math.max(MIN_THREAD_SYNC_TIMEOUT_MS, parsed),
+	);
+}

--- a/nowledge-mem-openclaw-plugin/tests/capture-append-mode.test.mjs
+++ b/nowledge-mem-openclaw-plugin/tests/capture-append-mode.test.mjs
@@ -112,8 +112,12 @@ class FakeThreadClient {
 
 	async createThread(request) {
 		this.createCalls.push(request);
+		if (this.createAck !== undefined) return this.createAck;
 		this.existingCount = request.messages.length;
-		return request.threadId;
+		return {
+			threadId: request.threadId,
+			totalMessages: request.messages.length,
+		};
 	}
 
 	isThreadNotFoundError(error) {
@@ -608,6 +612,69 @@ test("skips persist until a user+assistant pair exists", async () => {
 	assert.equal(result, undefined);
 	assert.equal(client.appendCalls.length, 0);
 	assert.equal(client.createCalls.length, 0);
+});
+
+test("snapshot capture leaves a trailing user turn for the next assistant", async () => {
+	_resetSyncCursors();
+	const client = new FakeThreadClient({ existingCount: 0 });
+	const ctx = {
+		sessionId: "session-trailing-user",
+		sessionKey: "agent:main:telegram:direct:trailing-user",
+	};
+	const first = await appendOrCreateThread({
+		client,
+		logger,
+		event: {
+			messages: [
+				message("user", "first"),
+				message("assistant", "answer"),
+				message("user", "wait for me"),
+			],
+		},
+		ctx,
+		reason: "before_reset",
+	});
+	assert.equal(first.messagesAdded, 2);
+	assert.deepEqual(client.appendCalls[0].messages.map((msg) => msg.content), ["first", "answer"]);
+
+	const second = await appendOrCreateThread({
+		client,
+		logger,
+		event: {
+			messages: [
+				message("user", "first"),
+				message("assistant", "answer"),
+				message("user", "wait for me"),
+				message("assistant", "now complete"),
+			],
+		},
+		ctx,
+		reason: "agent_end",
+	});
+	assert.equal(second.messagesAdded, 2);
+	assert.deepEqual(client.appendCalls[1].messages.map((msg) => msg.content), [
+		"wait for me",
+		"now complete",
+	]);
+});
+
+test("create without an explicit persistence ack does not advance the cursor", async () => {
+	_resetSyncCursors();
+	const client = new FakeThreadClient();
+	client.failAppend = "thread not found";
+	client.failAppendCode = "thread_not_found";
+	client.createAck = null;
+	const ctx = {
+		sessionId: "session-create-no-ack",
+		sessionKey: "agent:main:telegram:direct:create-no-ack",
+	};
+	const event = { messages: [message("user", "hello"), message("assistant", "hi")] };
+	const failed = await appendOrCreateThread({ client, logger, event, ctx, reason: "agent_end" });
+	assert.equal(failed, null);
+	client.failAppend = "";
+	const retried = await appendOrCreateThread({ client, logger, event, ctx, reason: "agent_end" });
+	assert.equal(retried.messagesAdded, 2);
+	assert.equal(client.appendCalls.at(-1).messages.length, 2);
 });
 
 test("capture continues when remote message count lookup fails", async () => {

--- a/nowledge-mem-openclaw-plugin/tests/capture-append-mode.test.mjs
+++ b/nowledge-mem-openclaw-plugin/tests/capture-append-mode.test.mjs
@@ -3,6 +3,7 @@ import { createHash } from "node:crypto";
 import test from "node:test";
 
 import {
+	_resetSyncCursors,
 	appendOrCreateThread,
 	buildThreadTitle,
 	normalizeRoleMessage,
@@ -86,6 +87,11 @@ class FakeThreadClient {
 
 	async appendThread(request) {
 		this.appendCalls.push(request);
+		if (this.failAppend) {
+			const error = new Error(this.failAppend);
+			if (this.failAppendCode) error.code = this.failAppendCode;
+			throw error;
+		}
 		const messagesToAdd = request.deduplicate
 			? request.messages.filter((message) => {
 					const externalId = message?.metadata?.external_id;
@@ -432,4 +438,145 @@ test("OpenClaw mirror identity wins over transcript idempotency key for stable d
 	});
 
 	assert.equal(normalized.externalHint, "turn-1:prompt");
+});
+
+
+test("snapshot capture sends a content-bound checkpoint contract after the first ack", async () => {
+	_resetSyncCursors();
+	const client = new FakeThreadClient({ existingCount: 0 });
+	const ctx = {
+		sessionId: "session-checkpoint",
+		sessionKey: "agent:main:telegram:direct:checkpoint",
+	};
+	await appendOrCreateThread({
+		client,
+		logger,
+		event: { messages: [message("user", "first"), message("assistant", "second")] },
+		ctx,
+		reason: "agent_end",
+	});
+	const second = await appendOrCreateThread({
+		client,
+		logger,
+		event: {
+			messages: [
+				message("user", "first"),
+				message("assistant", "second"),
+				message("user", "third"),
+				message("assistant", "fourth"),
+			],
+		},
+		ctx,
+		reason: "agent_end",
+	});
+	assert.equal(second.messagesAdded, 2);
+	assert.equal(client.appendCalls.length, 2);
+	assert.equal(typeof client.appendCalls[1].idempotencyKey, "string");
+	assert.match(client.appendCalls[1].idempotencyKey, /^oc:agent_end:/);
+	assert.equal(client.appendCalls[1].expectedMessageCount, 2);
+});
+
+test("snapshot capture resets a same-length prefix replacement to a full replay", async () => {
+	_resetSyncCursors();
+	const client = new FakeThreadClient({ existingCount: 0 });
+	const ctx = {
+		sessionId: "session-same-length",
+		sessionKey: "agent:main:telegram:direct:same-length",
+	};
+	await appendOrCreateThread({
+		client,
+		logger,
+		event: { messages: [message("user", "old prompt"), message("assistant", "old answer")] },
+		ctx,
+		reason: "agent_end",
+	});
+	const replaced = await appendOrCreateThread({
+		client,
+		logger,
+		event: { messages: [message("user", "new prompt"), message("assistant", "new answer")] },
+		ctx,
+		reason: "agent_end",
+	});
+	assert.equal(replaced.messagesAdded, 2);
+	assert.deepEqual(
+		client.appendCalls[1].messages.map((msg) => msg.content),
+		["new prompt", "new answer"],
+	);
+	assert.equal(client.appendCalls[1].expectedMessageCount, undefined);
+});
+
+test("destination lanes isolate cursors by api url, key, and space", async () => {
+	_resetSyncCursors();
+	class LaneClient extends FakeThreadClient {
+		constructor(lane, existingCount) {
+			super({ existingCount });
+			this.lane = lane;
+		}
+		cursorKey(threadId) {
+			return `${this.lane}\0${threadId}`;
+		}
+	}
+	const first = new LaneClient("https://mem\0key-a\0space-a", 0);
+	const second = new LaneClient("https://mem\0key-a\0space-b", 0);
+	const ctx = {
+		sessionId: "session-lane",
+		sessionKey: "agent:main:telegram:direct:lane",
+	};
+	const event = { messages: [message("user", "hello"), message("assistant", "hi")] };
+	await appendOrCreateThread({ client: first, logger, event, ctx, reason: "agent_end" });
+	await appendOrCreateThread({ client: second, logger, event, ctx, reason: "agent_end" });
+	assert.equal(first.appendCalls.length, 1);
+	assert.equal(second.appendCalls.length, 1);
+});
+
+test("failed appends do not advance the local cursor", async () => {
+	_resetSyncCursors();
+	const client = new FakeThreadClient({ existingCount: 0 });
+	const ctx = {
+		sessionId: "session-no-ack",
+		sessionKey: "agent:main:telegram:direct:no-ack",
+	};
+	await appendOrCreateThread({
+		client,
+		logger,
+		event: { messages: [message("user", "first"), message("assistant", "second")] },
+		ctx,
+		reason: "agent_end",
+	});
+	client.failAppend = "Thread append was not acknowledged as checkpointed";
+	const failed = await appendOrCreateThread({
+		client,
+		logger,
+		event: {
+			messages: [
+				message("user", "first"),
+				message("assistant", "second"),
+				message("user", "third"),
+				message("assistant", "fourth"),
+			],
+		},
+		ctx,
+		reason: "agent_end",
+	});
+	assert.equal(failed, null);
+	client.failAppend = "";
+	const retried = await appendOrCreateThread({
+		client,
+		logger,
+		event: {
+			messages: [
+				message("user", "first"),
+				message("assistant", "second"),
+				message("user", "third"),
+				message("assistant", "fourth"),
+			],
+		},
+		ctx,
+		reason: "agent_end",
+	});
+	assert.equal(retried.messagesAdded, 2);
+	assert.deepEqual(
+		client.appendCalls.at(-1).messages.map((msg) => msg.content),
+		["third", "fourth"],
+	);
 });

--- a/nowledge-mem-openclaw-plugin/tests/capture-append-mode.test.mjs
+++ b/nowledge-mem-openclaw-plugin/tests/capture-append-mode.test.mjs
@@ -162,6 +162,9 @@ test("auto capture sends textual timestamps to the thread append API", async () 
 		logger,
 		event: {
 			messages: [
+				message("user", "prompt", {
+					__openclaw: { mirrorIdentity: "turn-2:prompt" },
+				}),
 				message("assistant", "captured", {
 					timestamp: 1_751_881_234_567,
 					__openclaw: { mirrorIdentity: "turn-2:assistant" },
@@ -178,7 +181,7 @@ test("auto capture sends textual timestamps to the thread append API", async () 
 	});
 
 	assert.equal(
-		client.appendCalls[0].messages[0].timestamp,
+		client.appendCalls[0].messages.find((msg) => msg.role === "assistant").timestamp,
 		"2025-07-07T09:40:34.567Z",
 	);
 });
@@ -381,7 +384,10 @@ test("snapshot fallback external IDs preserve the legacy seed shape", async () =
 		client,
 		logger,
 		event: {
-			messages: [message("user", "legacy fallback")],
+			messages: [
+				message("user", "legacy fallback"),
+				message("assistant", "legacy reply"),
+			],
 		},
 		ctx: {
 			sessionId: "session-snapshot-fallback",
@@ -391,7 +397,7 @@ test("snapshot fallback external IDs preserve the legacy seed shape", async () =
 		reason: "after_turn",
 	});
 
-	assert.equal(result.messagesAdded, 1);
+	assert.equal(result.messagesAdded, 2);
 	assert.equal(client.appendCalls.length, 1);
 	assert.equal(
 		client.appendCalls[0].messages[0].metadata.external_id,
@@ -408,7 +414,10 @@ test("delta fallback external IDs include run id when available", async () => {
 		client,
 		logger,
 		event: {
-			messages: [message("assistant", "delta fallback")],
+			messages: [
+				message("assistant", "delta fallback"),
+				message("user", "follow-up prompt"),
+			],
 		},
 		ctx: {
 			sessionId: "session-delta-fallback",
@@ -419,7 +428,7 @@ test("delta fallback external IDs include run id when available", async () => {
 		messageMode: "delta",
 	});
 
-	assert.equal(result.messagesAdded, 1);
+	assert.equal(result.messagesAdded, 2);
 	assert.equal(client.appendCalls.length, 1);
 	assert.equal(
 		client.appendCalls[0].messages[0].metadata.external_id,
@@ -579,4 +588,24 @@ test("failed appends do not advance the local cursor", async () => {
 		client.appendCalls.at(-1).messages.map((msg) => msg.content),
 		["third", "fourth"],
 	);
+});
+
+test("skips persist until a user+assistant pair exists", async () => {
+	const client = new FakeThreadClient();
+	const result = await appendOrCreateThread({
+		client,
+		logger,
+		event: {
+			messages: [message("user", "only a prompt so far")],
+			success: true,
+		},
+		ctx: {
+			sessionId: "session-user-only",
+			sessionKey: "agent:main:telegram:direct:user-only",
+		},
+		reason: "before_reset",
+	});
+	assert.equal(result, undefined);
+	assert.equal(client.appendCalls.length, 0);
+	assert.equal(client.createCalls.length, 0);
 });

--- a/nowledge-mem-openclaw-plugin/tests/capture-append-mode.test.mjs
+++ b/nowledge-mem-openclaw-plugin/tests/capture-append-mode.test.mjs
@@ -27,6 +27,41 @@ test("thread-not-found detection does not recreate after an unrelated server fai
 	assert.equal(client.isThreadNotFoundError(upstream), false);
 });
 
+test("createThread requires and sends a normalized thread id", async () => {
+	const client = new NowledgeMemClient(logger, {});
+	const requests = [];
+	client.apiJson = async (method, path, body) => {
+		requests.push({ method, path, body });
+		return { thread_id: "oc-target", message_count: 1 };
+	};
+	const messages = [{ role: "user", content: "hello" }];
+
+	await assert.rejects(
+		client.createThread({ threadId: " ", title: "title", messages }),
+		/createThread requires threadId/,
+	);
+	assert.equal(requests.length, 0);
+
+	const ack = await client.createThread({
+		threadId: "  oc-target  ",
+		title: "title",
+		messages,
+	});
+	assert.deepEqual(ack, { threadId: "oc-target", totalMessages: 1 });
+	assert.deepEqual(requests, [
+		{
+			method: "POST",
+			path: "/threads",
+			body: {
+				thread_id: "oc-target",
+				title: "title",
+				source: "openclaw",
+				messages,
+			},
+		},
+	]);
+});
+
 function message(role, content, extra = {}) {
 	return {
 		role,
@@ -317,7 +352,7 @@ test("auto capture remains idempotent when a stable full transcript is emitted",
 	assert.equal(client.appendCalls[0].messages.length, 4);
 });
 
-test("snapshot capture still treats a shorter transcript as compaction shrink", async () => {
+test("snapshot capture does not trust a remote count as a local prefix", async () => {
 	const client = new FakeThreadClient({ existingCount: 6 });
 	const result = await appendOrCreateThread({
 		client,
@@ -335,12 +370,17 @@ test("snapshot capture still treats a shorter transcript as compaction shrink", 
 		reason: "after_compaction",
 	});
 
-	assert.equal(result.messagesAdded, 0);
-	assert.equal(client.appendCalls.length, 0);
+	assert.equal(result.messagesAdded, 2);
+	assert.equal(client.appendCalls.length, 1);
+	assert.deepEqual(
+		client.appendCalls[0].messages.map((msg) => msg.content),
+		["summarized prompt", "summarized answer"],
+	);
+	assert.equal(client.appendCalls[0].expectedMessageCount, undefined);
 	assert.equal(client.createCalls.length, 0);
 });
 
-test("auto capture requires stable identities before treating a short batch as delta", async () => {
+test("auto capture replays a short snapshot batch without stable identities", async () => {
 	const client = new FakeThreadClient({ existingCount: 6 });
 	const result = await appendOrCreateThread({
 		client,
@@ -360,12 +400,20 @@ test("auto capture requires stable identities before treating a short batch as d
 		messageMode: "auto",
 	});
 
-	assert.equal(result.messagesAdded, 0);
-	assert.equal(client.appendCalls.length, 0);
+	assert.equal(result.messagesAdded, 2);
+	assert.equal(client.appendCalls.length, 1);
+	assert.deepEqual(
+		client.appendCalls[0].messages.map((msg) => msg.content),
+		[
+			"short prompt without host identity",
+			"short answer without host identity",
+		],
+	);
+	assert.equal(client.appendCalls[0].expectedMessageCount, undefined);
 	assert.equal(client.createCalls.length, 0);
 });
 
-test("snapshot capture appends only the tail of full-transcript hook payloads", async () => {
+test("snapshot capture replays the local transcript until its prefix is acknowledged", async () => {
 	const client = new FakeThreadClient({ existingCount: 2 });
 	const result = await appendOrCreateThread({
 		client,
@@ -385,12 +433,13 @@ test("snapshot capture appends only the tail of full-transcript hook payloads", 
 		reason: "agent_end",
 	});
 
-	assert.equal(result.messagesAdded, 2);
+	assert.equal(result.messagesAdded, 4);
 	assert.equal(client.appendCalls.length, 1);
 	assert.deepEqual(
 		client.appendCalls[0].messages.map((msg) => msg.content),
-		["third", "fourth"],
+		["first", "second", "third", "fourth"],
 	);
+	assert.equal(client.appendCalls[0].expectedMessageCount, undefined);
 });
 
 test("snapshot fallback external IDs preserve the legacy seed shape", async () => {

--- a/nowledge-mem-openclaw-plugin/tests/capture-append-mode.test.mjs
+++ b/nowledge-mem-openclaw-plugin/tests/capture-append-mode.test.mjs
@@ -609,3 +609,90 @@ test("skips persist until a user+assistant pair exists", async () => {
 	assert.equal(client.appendCalls.length, 0);
 	assert.equal(client.createCalls.length, 0);
 });
+
+test("capture continues when remote message count lookup fails", async () => {
+	_resetSyncCursors();
+	const warnings = [];
+	const warnLogger = {
+		...logger,
+		warn(msg) {
+			warnings.push(msg);
+		},
+	};
+	class FailingCountClient extends FakeThreadClient {
+		async getThreadMessageCount() {
+			throw new Error("backend unavailable");
+		}
+	}
+	const client = new FailingCountClient();
+	const result = await appendOrCreateThread({
+		client,
+		logger: warnLogger,
+		event: {
+			messages: [message("user", "hello"), message("assistant", "hi")],
+		},
+		ctx: {
+			sessionId: "session-count-fail",
+			sessionKey: "agent:main:telegram:direct:count-fail",
+		},
+		reason: "agent_end",
+	});
+	assert.equal(result.messagesAdded, 2);
+	assert.equal(client.appendCalls.length, 1);
+	assert.match(warnings.join("\n"), /remote message count failed/);
+});
+
+test("delta capture cursor lets a later snapshot append only the suffix", async () => {
+	_resetSyncCursors();
+	const client = new FakeThreadClient({ existingCount: 0 });
+	const ctx = {
+		sessionId: "session-delta-then-snapshot",
+		sessionKey: "agent:main:telegram:direct:delta-then-snapshot",
+	};
+	await appendOrCreateThread({
+		client,
+		logger,
+		event: {
+			messages: [
+				message("user", "first", {
+					__openclaw: { mirrorIdentity: "turn-1:prompt" },
+				}),
+				message("assistant", "second", {
+					__openclaw: { mirrorIdentity: "turn-1:assistant" },
+				}),
+			],
+		},
+		ctx,
+		reason: "agent_end",
+		messageMode: "delta",
+	});
+	const later = await appendOrCreateThread({
+		client,
+		logger,
+		event: {
+			messages: [
+				message("user", "first", {
+					__openclaw: { mirrorIdentity: "turn-1:prompt" },
+				}),
+				message("assistant", "second", {
+					__openclaw: { mirrorIdentity: "turn-1:assistant" },
+				}),
+				message("user", "third", {
+					__openclaw: { mirrorIdentity: "turn-2:prompt" },
+				}),
+				message("assistant", "fourth", {
+					__openclaw: { mirrorIdentity: "turn-2:assistant" },
+				}),
+			],
+		},
+		ctx,
+		reason: "agent_end",
+		messageMode: "snapshot",
+	});
+	assert.equal(later.messagesAdded, 2);
+	assert.deepEqual(
+		client.appendCalls.at(-1).messages.map((msg) => msg.content),
+		["third", "fourth"],
+	);
+	assert.equal(client.appendCalls.at(-1).expectedMessageCount, 2);
+});

--- a/nowledge-mem-openclaw-plugin/tests/capture-append-mode.test.mjs
+++ b/nowledge-mem-openclaw-plugin/tests/capture-append-mode.test.mjs
@@ -8,12 +8,24 @@ import {
 	buildThreadTitle,
 	normalizeRoleMessage,
 } from "../src/hooks/capture.js";
+import { NowledgeMemClient } from "../src/client.js";
 
 const logger = {
 	info() {},
 	warn() {},
 	debug() {},
 };
+
+test("thread-not-found detection does not recreate after an unrelated server failure", () => {
+	const client = new NowledgeMemClient(logger, {});
+	const missing = new Error("Thread not found: oc-x");
+	missing.status = 400;
+	assert.equal(client.isThreadNotFoundError(missing), true);
+
+	const upstream = new Error("Upstream failed: thread not found");
+	upstream.status = 500;
+	assert.equal(client.isThreadNotFoundError(upstream), false);
+});
 
 function message(role, content, extra = {}) {
 	return {

--- a/nowledge-mem-openclaw-plugin/tests/session-delta.test.mjs
+++ b/nowledge-mem-openclaw-plugin/tests/session-delta.test.mjs
@@ -77,6 +77,8 @@ test("acknowledgement helpers require explicit checkpointed acks", () => {
 		true,
 	);
 	assert.equal(isThreadAppendAck({ success: true, messages_added: 1, total_messages: 3 }), true);
+	assert.equal(isThreadAppendAck({ success: true, messages_added: -1, total_messages: 3 }), false);
+	assert.equal(isThreadAppendAck({ success: true, messages_added: 1, total_messages: -1 }), false);
 	assert.equal(isCheckpointedAppendAck({ success: true, messages_added: 1, total_messages: 3 }), false);
 	assert.equal(isCheckpointConflictResponse({ error_code: "checkpoint_conflict" }), true);
 	assert.match(

--- a/nowledge-mem-openclaw-plugin/tests/session-delta.test.mjs
+++ b/nowledge-mem-openclaw-plugin/tests/session-delta.test.mjs
@@ -3,6 +3,7 @@ import test from "node:test";
 
 import {
 	contentBoundIdempotencyKey,
+	hasUserAndAssistant,
 	isCheckpointConflictResponse,
 	isCheckpointedAppendAck,
 	isThreadAppendAck,
@@ -87,4 +88,22 @@ test("resolveThreadSyncTimeoutMs honors 120s default and 1s-30min bounds", () =>
 	assert.equal(resolveThreadSyncTimeoutMs("250"), 1_000);
 	assert.equal(resolveThreadSyncTimeoutMs("9999999"), 30 * 60_000);
 	assert.equal(resolveThreadSyncTimeoutMs("abc"), 120_000);
+});
+
+test("hasUserAndAssistant requires both roles, not just two messages", () => {
+	assert.equal(hasUserAndAssistant([{ role: "user", content: "a" }]), false);
+	assert.equal(
+		hasUserAndAssistant([
+			{ role: "user", content: "a" },
+			{ role: "user", content: "b" },
+		]),
+		false,
+	);
+	assert.equal(
+		hasUserAndAssistant([
+			{ role: "user", content: "a" },
+			{ role: "assistant", content: "b" },
+		]),
+		true,
+	);
 });

--- a/nowledge-mem-openclaw-plugin/tests/session-delta.test.mjs
+++ b/nowledge-mem-openclaw-plugin/tests/session-delta.test.mjs
@@ -7,8 +7,10 @@ import {
 	isCheckpointConflictResponse,
 	isCheckpointedAppendAck,
 	isThreadAppendAck,
+	prefixFingerprint,
 	selectSnapshotDelta,
 	sessionSyncLaneKey,
+	stableMessageFingerprint,
 } from "../src/session-delta.js";
 import { resolveThreadSyncTimeoutMs } from "../src/thread-sync-timeout.js";
 
@@ -106,4 +108,35 @@ test("hasUserAndAssistant requires both roles, not just two messages", () => {
 		]),
 		true,
 	);
+});
+
+test("prefixFingerprint hashes the length-prefixed prefix with the default fingerprint", () => {
+	const messages = [
+		{ role: "user", content: "a", metadata: { external_id: "a" } },
+		{ role: "assistant", content: "b", metadata: { external_id: "b" } },
+	];
+	const hashed = prefixFingerprint(messages, messages.length);
+	assert.match(hashed, /^[0-9a-f]{64}$/);
+	assert.equal(
+		hashed,
+		prefixFingerprint(messages, messages.length, stableMessageFingerprint),
+	);
+	assert.notEqual(hashed, stableMessageFingerprint(messages[messages.length - 1]));
+});
+
+test("selectSnapshotDelta trusts a cursor hashed with the shared prefixFingerprint helper", () => {
+	const first = [
+		{ id: "a", role: "user", content: "a" },
+		{ id: "b", role: "assistant", content: "b" },
+	];
+	const cursor = {
+		count: first.length,
+		remoteCount: first.length,
+		lastExternalId: "b",
+		prefixFingerprint: prefixFingerprint(first, first.length),
+	};
+	const later = [...first, { id: "c", role: "user", content: "c" }];
+	const delta = selectSnapshotDelta(later, cursor, id);
+	assert.equal(delta.reset, false);
+	assert.deepEqual(delta.messages, [{ id: "c", role: "user", content: "c" }]);
 });

--- a/nowledge-mem-openclaw-plugin/tests/session-delta.test.mjs
+++ b/nowledge-mem-openclaw-plugin/tests/session-delta.test.mjs
@@ -1,0 +1,90 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+	contentBoundIdempotencyKey,
+	isCheckpointConflictResponse,
+	isCheckpointedAppendAck,
+	isThreadAppendAck,
+	selectSnapshotDelta,
+	sessionSyncLaneKey,
+} from "../src/session-delta.js";
+import { resolveThreadSyncTimeoutMs } from "../src/thread-sync-timeout.js";
+
+const id = (message) => message.id;
+
+test("sessionSyncLaneKey isolates api url, key, and space", () => {
+	const first = sessionSyncLaneKey("thread", "https://mem", "key", "space-a");
+	const second = sessionSyncLaneKey("thread", "https://mem", "key", "space-b");
+	assert.notEqual(first, second);
+	assert.notEqual(
+		sessionSyncLaneKey("thread", "https://mem", "key-a", "space"),
+		sessionSyncLaneKey("thread", "https://mem", "key-b", "space"),
+	);
+	assert.equal(
+		sessionSyncLaneKey("thread", "https://mem", "key", "space-a"),
+		first,
+	);
+});
+
+test("selectSnapshotDelta appends only the unacknowledged suffix", () => {
+	const first = [{ id: "a" }, { id: "b" }];
+	const cursor = selectSnapshotDelta(first, undefined, id).next;
+	const delta = selectSnapshotDelta([...first, { id: "c" }], cursor, id);
+	assert.deepEqual(delta.messages, [{ id: "c" }]);
+	assert.equal(delta.reset, false);
+});
+
+test("selectSnapshotDelta resets same-length prefix replacements", () => {
+	const original = [
+		{ id: "a", content: "old" },
+		{ id: "b", content: "same" },
+	];
+	const cursor = selectSnapshotDelta(original, undefined, id).next;
+	const changed = [
+		{ id: "a", content: "new" },
+		{ id: "b", content: "same" },
+	];
+	const delta = selectSnapshotDelta(changed, cursor, id);
+	assert.equal(delta.reset, true);
+	assert.deepEqual(delta.messages, changed);
+});
+
+test("selectSnapshotDelta treats a shorter transcript as OpenClaw compaction", () => {
+	const cursor = selectSnapshotDelta(
+		[{ id: "a" }, { id: "b" }, { id: "c" }],
+		undefined,
+		id,
+	).next;
+	const delta = selectSnapshotDelta([{ id: "new-a" }, { id: "new-b" }], cursor, id);
+	assert.equal(delta.compactionShrink, true);
+	assert.deepEqual(delta.messages, []);
+	assert.equal(delta.next.count, 2);
+});
+
+test("acknowledgement helpers require explicit checkpointed acks", () => {
+	assert.equal(
+		isCheckpointedAppendAck({
+			success: true,
+			append_mode: "checkpointed",
+			messages_added: 1,
+			total_messages: 3,
+		}),
+		true,
+	);
+	assert.equal(isThreadAppendAck({ success: true, messages_added: 1, total_messages: 3 }), true);
+	assert.equal(isCheckpointedAppendAck({ success: true, messages_added: 1, total_messages: 3 }), false);
+	assert.equal(isCheckpointConflictResponse({ error_code: "checkpoint_conflict" }), true);
+	assert.match(
+		contentBoundIdempotencyKey("oc:agent_end", "t", 2, 4, "abc"),
+		/^oc:agent_end:t:2-4:abc$/,
+	);
+});
+
+test("resolveThreadSyncTimeoutMs honors 120s default and 1s-30min bounds", () => {
+	assert.equal(resolveThreadSyncTimeoutMs(undefined), 120_000);
+	assert.equal(resolveThreadSyncTimeoutMs("5000"), 5_000);
+	assert.equal(resolveThreadSyncTimeoutMs("250"), 1_000);
+	assert.equal(resolveThreadSyncTimeoutMs("9999999"), 30 * 60_000);
+	assert.equal(resolveThreadSyncTimeoutMs("abc"), 120_000);
+});

--- a/nowledge-mem-openclaw-plugin/tests/session-delta.test.mjs
+++ b/nowledge-mem-openclaw-plugin/tests/session-delta.test.mjs
@@ -11,6 +11,7 @@ import {
 	selectSnapshotDelta,
 	sessionSyncLaneKey,
 	stableMessageFingerprint,
+	threadCreateAck,
 } from "../src/session-delta.js";
 import { resolveThreadSyncTimeoutMs } from "../src/thread-sync-timeout.js";
 
@@ -82,6 +83,16 @@ test("acknowledgement helpers require explicit checkpointed acks", () => {
 		contentBoundIdempotencyKey("oc:agent_end", "t", 2, 4, "abc"),
 		/^oc:agent_end:t:2-4:abc$/,
 	);
+});
+
+test("threadCreateAck requires the target id and an explicit non-negative count", () => {
+	assert.deepEqual(threadCreateAck({ thread_id: "target", message_count: 2 }, "target"), {
+		threadId: "target",
+		totalMessages: 2,
+	});
+	assert.equal(threadCreateAck({ thread_id: "other", message_count: 2 }, "target"), null);
+	assert.equal(threadCreateAck({ thread_id: "target" }, "target"), null);
+	assert.equal(threadCreateAck({ thread_id: "target", message_count: -1 }, "target"), null);
 });
 
 test("resolveThreadSyncTimeoutMs honors 120s default and 1s-30min bounds", () => {


### PR DESCRIPTION
## Summary

- Persist only acknowledged OpenClaw snapshot deltas and keep failed suffixes available for retry.
- Require complete user-and-assistant turns, validate create and append acknowledgements, and avoid trusting an unverified remote message count as a local cursor.
- Recover from unavailable remote counts, checkpoint conflicts, missing threads, and transcript replacement without leaking cursor state across destinations.
- Apply bounded `NMEM_SYNC_TIMEOUT_MS` handling to automatic thread synchronization.

## Validation

- `npm test`: 61 passed
- `npm run validate`
- Targeted Biome checks for the modified capture and client paths
- `git diff --check`
- CodeRabbit passes on `ce4a7fb3` with no unresolved review threads.