### PR TITLE
fix(alma): make session capture checkpointed and retry-safe

### DIFF
--- a/nowledge-mem-alma-plugin/CHANGELOG.md
+++ b/nowledge-mem-alma-plugin/CHANGELOG.md
@@ -14,6 +14,8 @@
   advancing the local cursor.
 - Automatic thread create/append honor `NMEM_SYNC_TIMEOUT_MS` with a 120s
   default and 1-second to 30-minute bounds.
+- Automatic capture now waits for a user+assistant pair and coalesces
+  in-flight flushes so a later turn is not dropped while a persist is running.
 
 ## 0.7.4
 

--- a/nowledge-mem-alma-plugin/CHANGELOG.md
+++ b/nowledge-mem-alma-plugin/CHANGELOG.md
@@ -1,5 +1,20 @@
 # Changelog
 
+## Unreleased
+
+### Fixed
+
+- Automatic thread capture now sends the paired Mem checkpoint contract
+  (`expected_message_count`, a content-bound idempotency key, and
+  `append_mode: "checkpointed"`) and only advances the local cursor after an
+  explicit append/create acknowledgement.
+- Same-length and earlier-prefix replacements reset to a full replay.
+- Destination-lane cursor state is isolated by API URL, credentials, and space.
+- HTTP 400 `Thread not found` recreates the complete snapshot instead of
+  advancing the local cursor.
+- Automatic thread create/append honor `NMEM_SYNC_TIMEOUT_MS` with a 120s
+  default and 1-second to 30-minute bounds.
+
 ## 0.7.4
 
 ### Fixed

--- a/nowledge-mem-alma-plugin/README.md
+++ b/nowledge-mem-alma-plugin/README.md
@@ -225,6 +225,9 @@ The plugin currently uses these defaults:
 - Recall policy: `balanced_thread_once`
 - Auto-capture on app quit: `true`
 - Max recalled memories per injection: `5`
+- Automatic thread create/append timeout: 120s (`NMEM_SYNC_TIMEOUT_MS`, clamped to 1s–30min)
+
+Set `NMEM_SYNC_TIMEOUT_MS` before launching Alma when a remote Mem instance needs a longer automatic sync window. Manual `nowledge_mem_*` tools keep the existing per-request timeouts.
 
 ## License
 

--- a/nowledge-mem-alma-plugin/main.js
+++ b/nowledge-mem-alma-plugin/main.js
@@ -425,8 +425,7 @@ export class NowledgeMemClient {
 		return (
 			err?.code === "thread_not_found" ||
 			err?.status === 404 ||
-			(err?.status === 400 && message.includes("thread not found")) ||
-			message.includes("thread not found")
+			(err?.status === 400 && message.includes("thread not found"))
 		);
 	}
 
@@ -1556,6 +1555,7 @@ export async function activate(context) {
 
 		// Ensure stable thread ID (survives plugin restarts and LRU eviction)
 		if (!buf.nowledgeThreadId) buf.nowledgeThreadId = stableThreadId(threadId);
+		const flushThreadId = buf.nowledgeThreadId;
 
 		try {
 			// Resolve title right before saving (Alma generates titles asynchronously)
@@ -1569,7 +1569,7 @@ export async function activate(context) {
 			const { delta, expectedMessageCount, idempotencyKey } = planAutomaticFlush({
 				messages: snapshot,
 				cursor: buf.acknowledged,
-				threadId: buf.nowledgeThreadId,
+				threadId: flushThreadId,
 			});
 			if (delta.messages.length === 0) return;
 
@@ -1579,13 +1579,13 @@ export async function activate(context) {
 					.slice(-8)
 					.map((msg) => `[${msg.role}] ${escapeForInline(msg.content, 280)}`)
 					.join("\n");
-				logger.info?.(`nowledge-mem: creating thread ${buf.nowledgeThreadId} for ${threadId} (${msgsToSend.length} msgs, title="${buf.title}")`);
+				logger.info?.(`nowledge-mem: creating thread ${flushThreadId} for ${threadId} (${msgsToSend.length} msgs, title="${buf.title}")`);
 				const created = await flushClient.createThread(
 					buf.title,
 					escapeForInline(summary, 1200),
 					msgsToSend,
 					"alma",
-					buf.nowledgeThreadId,
+					flushThreadId,
 					{ timeout: flushClient._threadSyncTimeoutMs },
 				);
 				return {
@@ -1596,15 +1596,15 @@ export async function activate(context) {
 
 			let result;
 			try {
-				logger.info?.(`nowledge-mem: appending ${delta.messages.length} msgs to ${buf.nowledgeThreadId}`);
-				result = await flushClient.appendThread(buf.nowledgeThreadId, delta.messages, {
+				logger.info?.(`nowledge-mem: appending ${delta.messages.length} msgs to ${flushThreadId}`);
+				result = await flushClient.appendThread(flushThreadId, delta.messages, {
 					idempotencyKey,
 					expectedMessageCount,
 				});
 			} catch (appendErr) {
 				if (flushClient.isCheckpointConflictError(appendErr)) {
-					logger.info?.(`nowledge-mem: reconciling checkpoint conflict for ${buf.nowledgeThreadId}`);
-					result = await flushClient.appendThread(buf.nowledgeThreadId, snapshot.slice(0, delta.end), {
+					logger.info?.(`nowledge-mem: reconciling checkpoint conflict for ${flushThreadId}`);
+					result = await flushClient.appendThread(flushThreadId, snapshot.slice(0, delta.end), {
 						idempotencyKey: `${idempotencyKey}:reconcile`,
 					});
 				} else if (flushClient.isThreadNotFoundError(appendErr)) {

--- a/nowledge-mem-alma-plugin/main.js
+++ b/nowledge-mem-alma-plugin/main.js
@@ -2,6 +2,14 @@ import { spawnSync } from "node:child_process";
 import { createHash } from "node:crypto";
 import { readFileSync, statSync } from "node:fs";
 import { homedir } from "node:os";
+import {
+	isCheckpointConflictResponse,
+	isCheckpointedAppendAck,
+	isThreadAppendAck,
+	planAutomaticFlush,
+	sessionSyncLaneKey,
+} from "./session-delta.js";
+import { resolveThreadSyncTimeoutMs } from "./thread-sync-timeout.js";
 
 function clamp(value, min, max) {
 	return Math.min(max, Math.max(min, value));
@@ -141,6 +149,13 @@ export class NowledgeMemClient {
 		this._apiUrl = (credentials.apiUrl || "").trim() || "http://127.0.0.1:14242";
 		this._apiKey = (credentials.apiKey || "").trim();
 		this._spaceRef = normalizeSpaceRef(credentials.space || "");
+		this._threadSyncTimeoutMs = Number.isInteger(credentials.threadSyncTimeoutMs)
+			? credentials.threadSyncTimeoutMs
+			: 120_000;
+	}
+
+	cursorKey(threadId) {
+		return sessionSyncLaneKey(threadId, this._apiUrl, this._apiKey, this._spaceRef);
 	}
 
 	// --- HTTP transport (async, non-blocking) ---
@@ -191,8 +206,11 @@ export class NowledgeMemClient {
 			});
 			if (!resp.ok) {
 				const text = await resp.text().catch(() => "");
+				let parsed = {};
+				try { parsed = text ? JSON.parse(text) : {}; } catch { parsed = {}; }
 				const err = new Error(`HTTP ${resp.status}: ${text.slice(0, 200)}`);
 				err.status = resp.status;
+				err.code = typeof parsed?.error_code === "string" ? parsed.error_code : undefined;
 				throw err;
 			}
 			const ct = resp.headers.get("content-type") || "";
@@ -349,27 +367,57 @@ export class NowledgeMemClient {
 			const titleHash = createHash("md5").update(title || "").digest("hex").slice(0, 6);
 			body.thread_id = `alma-${ts}-${titleHash}`;
 		}
-		const data = await this._fetch("POST", "/threads", { body, timeout: 30_000 });
+		const data = await this._fetch("POST", "/threads", { body, timeout: this._threadSyncTimeoutMs });
 		const threadData = data.thread ?? {};
+		const remoteCount = Number.isInteger(threadData.message_count)
+			? threadData.message_count
+			: Array.isArray(data.messages) ? data.messages.length : undefined;
 		return {
 			success: true,
 			id: threadData.thread_id ?? body.thread_id,
 			title: threadData.title ?? title,
 			messages: (data.messages ?? []).length,
+			total_messages: remoteCount,
 		};
 	}
 
-	async appendThread(threadId, messages) {
+	async appendThread(threadId, messages, { idempotencyKey, expectedMessageCount } = {}) {
+		const checkpointed = Number.isInteger(expectedMessageCount);
 		const data = await this._fetch("POST", `/threads/${encodeURIComponent(threadId)}/append`, {
-			body: { messages, deduplicate: true },
-			timeout: 30_000,
+			body: {
+				messages,
+				deduplicate: true,
+				...(idempotencyKey ? { idempotency_key: String(idempotencyKey) } : {}),
+				...(checkpointed ? { expected_message_count: expectedMessageCount } : {}),
+			},
+			timeout: this._threadSyncTimeoutMs,
 		});
+		if (!isThreadAppendAck(data)) {
+			throw new Error("Thread append did not include an explicit persistence acknowledgement");
+		}
+		if (checkpointed && !isCheckpointedAppendAck(data)) {
+			throw new Error("Thread append was not acknowledged as checkpointed");
+		}
 		return {
-			success: data.success ?? true,
+			success: true,
 			id: threadId,
-			messages_added: data.messages_added ?? 0,
-			total_messages: data.total_messages ?? 0,
+			messages_added: data.messages_added,
+			total_messages: data.total_messages,
 		};
+	}
+
+	isThreadNotFoundError(err) {
+		const message = (err instanceof Error ? err.message : String(err)).toLowerCase();
+		return (
+			err?.code === "thread_not_found" ||
+			err?.status === 404 ||
+			(err?.status === 400 && message.includes("thread not found")) ||
+			message.includes("thread not found")
+		);
+	}
+
+	isCheckpointConflictError(err) {
+		return err?.code === "checkpoint_conflict" || isCheckpointConflictResponse({ error_code: err?.code });
 	}
 
 	async deleteThread(id, cascade = false) {
@@ -584,10 +632,13 @@ export async function activate(context) {
 	let apiUrl = getSetting(context.settings, "nowledgeMem.apiUrl", "") || "";
 	let apiKey = getSetting(context.settings, "nowledgeMem.apiKey", "") || "";
 	let ambientSpace = resolveAmbientSpace(context.settings, logger);
+	const threadSyncTimeoutMs = resolveThreadSyncTimeoutMs(process.env.NMEM_SYNC_TIMEOUT_MS);
+	let resetDestinationCursors = () => {};
 	let client = new NowledgeMemClient(logger, {
 		apiUrl,
 		apiKey,
 		space: ambientSpace.space,
+		threadSyncTimeoutMs,
 	});
 	const recalledThreads = new Set();
 
@@ -624,7 +675,11 @@ export async function activate(context) {
 						apiUrl,
 						apiKey,
 						space: ambientSpace.space,
+						threadSyncTimeoutMs,
 					});
+					if (typeof resetDestinationCursors === "function") {
+						resetDestinationCursors();
+					}
 					const remoteMode = apiUrl && apiUrl !== "http://127.0.0.1:14242";
 					logger.info?.(
 						`nowledge-mem: settings updated, mode=${remoteMode ? `remote → ${apiUrl}` : "local"}, space=${ambientSpace.space || "Default"}`,
@@ -1407,10 +1462,30 @@ export async function activate(context) {
 	// and timing may cause it to miss the latest message.
 	//
 	// Buffer schema: { title, messages: [{role,content}], savedCount: number,
-	//   nowledgeThreadId: string|null, flushing: boolean, timer: number|null }
+	//   acknowledged: {count, remoteCount, lastExternalId?, prefixFingerprint}|null,
+	//   destinationKey: string, nowledgeThreadId: string|null,
+	//   flushing: boolean, timer: number|null }
 	const MAX_THREAD_BUFFERS = 20;
 	const threadBuffers = new Map();
 	let activeThreadId = null;
+
+	const destinationLane = () =>
+		sessionSyncLaneKey("", client._apiUrl, client._apiKey, client._spaceRef);
+
+	const attachDestination = (buf) => {
+		const dest = destinationLane();
+		if (buf.destinationKey !== dest) {
+			buf.destinationKey = dest;
+			buf.savedCount = 0;
+			buf.acknowledged = null;
+			buf.nowledgeThreadId = null;
+		}
+		return buf;
+	};
+
+	resetDestinationCursors = () => {
+		for (const buf of threadBuffers.values()) attachDestination(buf);
+	};
 
 	/** Resolve the best possible thread title via Alma APIs, falling back to first user message. */
 	const resolveTitle = async (threadId, buf) => {
@@ -1451,8 +1526,9 @@ export async function activate(context) {
 	/** Flush a thread buffer to Nowledge Mem if it has new messages. */
 	const flushThread = async (threadId) => {
 		const buf = threadBuffers.get(threadId);
-		if (!buf || buf.messages.length < 2) return;
-		if (buf.messages.length <= buf.savedCount) return;
+		if (!buf) return;
+		attachDestination(buf);
+		if (buf.messages.length < 2) return;
 		if (buf.flushing) return; // guard against concurrent flush
 		buf.flushing = true;
 
@@ -1467,45 +1543,66 @@ export async function activate(context) {
 			const resolved = await resolveTitle(threadId, buf);
 			if (resolved) buf.title = escapeForInline(resolved, 120);
 
-			// Snapshot message count before async work. New messages may arrive
-			// via willSend/didReceive during the awaits; snapshotting prevents
-			// counting those as already saved.
-			const snapshotCount = buf.messages.length;
+			// Snapshot messages before async work. New turns may arrive via
+			// willSend/didReceive during the awaits; only this prefix is sent
+			// and the cursor advances only after an explicit ack.
+			const snapshot = buf.messages.slice();
+			const { delta, expectedMessageCount, idempotencyKey } = planAutomaticFlush({
+				messages: snapshot,
+				cursor: buf.acknowledged,
+				threadId: buf.nowledgeThreadId,
+			});
+			if (delta.messages.length === 0) return;
 
-			if (buf.savedCount > 0) {
-				// Already synced before in this session: append new messages
-				const newMessages = buf.messages.slice(buf.savedCount, snapshotCount);
-				logger.info?.(`nowledge-mem: appending ${newMessages.length} msgs to ${buf.nowledgeThreadId}`);
-				await client.appendThread(buf.nowledgeThreadId, newMessages);
-			} else {
-				// First flush for this buffer: try append (thread may exist from prior session), fall back to create
-				const msgsToSend = buf.messages.slice(0, snapshotCount);
-				try {
-					logger.info?.(`nowledge-mem: appending ${msgsToSend.length} msgs to ${buf.nowledgeThreadId} (reconnect)`);
-					await client.appendThread(buf.nowledgeThreadId, msgsToSend);
-				} catch (appendErr) {
-					// Only fall back to create when the thread genuinely doesn't exist (404).
-					// Rethrow transient errors (5xx, timeouts) so the outer catch handles them.
-					const isNotFound =
-						appendErr?.status === 404 ||
-						/not.found/i.test(appendErr instanceof Error ? appendErr.message : "");
-					if (!isNotFound) throw appendErr;
-					logger.debug?.(`nowledge-mem: thread not found, creating ${buf.nowledgeThreadId}`);
-					const summary = msgsToSend
-						.slice(-8)
-						.map((msg) => `[${msg.role}] ${escapeForInline(msg.content, 280)}`)
-						.join("\n");
-					logger.info?.(`nowledge-mem: creating thread ${buf.nowledgeThreadId} for ${threadId} (${msgsToSend.length} msgs, title="${buf.title}")`);
-					await client.createThread(
-						buf.title,
-						escapeForInline(summary, 1200),
-						msgsToSend,
-						"alma",
-						buf.nowledgeThreadId,
-					);
+			const persistCreate = async () => {
+				const msgsToSend = snapshot.slice(0, delta.end);
+				const summary = msgsToSend
+					.slice(-8)
+					.map((msg) => `[${msg.role}] ${escapeForInline(msg.content, 280)}`)
+					.join("\n");
+				logger.info?.(`nowledge-mem: creating thread ${buf.nowledgeThreadId} for ${threadId} (${msgsToSend.length} msgs, title="${buf.title}")`);
+				const created = await client.createThread(
+					buf.title,
+					escapeForInline(summary, 1200),
+					msgsToSend,
+					"alma",
+					buf.nowledgeThreadId,
+				);
+				return {
+					messages_added: msgsToSend.length,
+					total_messages: Number.isInteger(created.total_messages)
+						? created.total_messages
+						: msgsToSend.length,
+				};
+			};
+
+			let result;
+			try {
+				logger.info?.(`nowledge-mem: appending ${delta.messages.length} msgs to ${buf.nowledgeThreadId}`);
+				result = await client.appendThread(buf.nowledgeThreadId, delta.messages, {
+					idempotencyKey,
+					expectedMessageCount,
+				});
+			} catch (appendErr) {
+				if (client.isCheckpointConflictError(appendErr)) {
+					logger.info?.(`nowledge-mem: reconciling checkpoint conflict for ${buf.nowledgeThreadId}`);
+					result = await client.appendThread(buf.nowledgeThreadId, snapshot.slice(0, delta.end), {
+						idempotencyKey: `${idempotencyKey}:reconcile`,
+					});
+				} else if (client.isThreadNotFoundError(appendErr)) {
+					result = await persistCreate();
+				} else {
+					throw appendErr;
 				}
 			}
-			buf.savedCount = snapshotCount;
+
+			buf.acknowledged = {
+				...delta.next,
+				remoteCount: Number.isInteger(result.total_messages)
+					? result.total_messages
+					: delta.next.remoteCount,
+			};
+			buf.savedCount = delta.next.count;
 			logger.info?.(`nowledge-mem: thread synced (${threadId}, ${buf.messages.length} msgs)`);
 		} catch (err) {
 			logger.error?.(`nowledge-mem: thread sync failed: ${err instanceof Error ? err.message : String(err)}`);
@@ -1541,12 +1638,14 @@ export async function activate(context) {
 				title: escapeForInline(`Alma Thread ${new Date().toISOString().slice(0, 10)}`, 120),
 				messages: [],
 				savedCount: 0,
+				acknowledged: null,
+				destinationKey: destinationLane(),
 				nowledgeThreadId: null,
 				flushing: false,
 				timer: null,
 			});
 		}
-		return threadBuffers.get(threadId);
+		return attachDestination(threadBuffers.get(threadId));
 	};
 
 	// --- Hook: willSend (recall injection + capture user message) ---

--- a/nowledge-mem-alma-plugin/main.js
+++ b/nowledge-mem-alma-plugin/main.js
@@ -3,6 +3,9 @@ import { createHash } from "node:crypto";
 import { readFileSync, statSync } from "node:fs";
 import { homedir } from "node:os";
 import {
+	beginInFlightFlush,
+	finishInFlightFlush,
+	hasUserAndAssistant,
 	isCheckpointConflictResponse,
 	isCheckpointedAppendAck,
 	isThreadAppendAck,
@@ -1464,7 +1467,7 @@ export async function activate(context) {
 	// Buffer schema: { title, messages: [{role,content}], savedCount: number,
 	//   acknowledged: {count, remoteCount, lastExternalId?, prefixFingerprint}|null,
 	//   destinationKey: string, nowledgeThreadId: string|null,
-	//   flushing: boolean, timer: number|null }
+	//   flushing: boolean, pending: boolean, inFlight: Promise|undefined, timer: number|null }
 	const MAX_THREAD_BUFFERS = 20;
 	const threadBuffers = new Map();
 	let activeThreadId = null;
@@ -1528,10 +1531,12 @@ export async function activate(context) {
 		const buf = threadBuffers.get(threadId);
 		if (!buf) return;
 		attachDestination(buf);
-		if (buf.messages.length < 2) return;
-		if (buf.flushing) return; // guard against concurrent flush
-		buf.flushing = true;
+		if (!hasUserAndAssistant(buf.messages)) return;
+		if (beginInFlightFlush(buf) === "wait") {
+			return buf.inFlight;
+		}
 
+		const run = (async () => {
 		// Cancel this buffer's idle timer
 		if (buf.timer) { clearTimeout(buf.timer); buf.timer = null; }
 
@@ -1607,8 +1612,16 @@ export async function activate(context) {
 		} catch (err) {
 			logger.error?.(`nowledge-mem: thread sync failed: ${err instanceof Error ? err.message : String(err)}`);
 		} finally {
-			buf.flushing = false;
+			if (finishInFlightFlush(buf) === "rerun") {
+				buf.inFlight = flushThread(threadId);
+				await buf.inFlight;
+			} else if (buf.inFlight === run) {
+				buf.inFlight = undefined;
+			}
 		}
+		})();
+		buf.inFlight = run;
+		await run;
 	};
 
 	const resetIdleTimer = (threadId) => {
@@ -1628,7 +1641,7 @@ export async function activate(context) {
 				const oldest = threadBuffers.keys().next().value;
 				const evicted = threadBuffers.get(oldest);
 				// Best-effort flush before eviction (fire-and-forget)
-				if (evicted && evicted.messages.length > evicted.savedCount && evicted.messages.length >= 2) {
+				if (evicted && evicted.messages.length > evicted.savedCount && hasUserAndAssistant(evicted.messages)) {
 					flushThread(oldest).catch(() => {});
 				}
 				if (evicted?.timer) clearTimeout(evicted.timer);
@@ -1642,6 +1655,8 @@ export async function activate(context) {
 				destinationKey: destinationLane(),
 				nowledgeThreadId: null,
 				flushing: false,
+				pending: false,
+				inFlight: undefined,
 				timer: null,
 			});
 		}
@@ -1738,8 +1753,10 @@ export async function activate(context) {
 			const flushPromises = [];
 			for (const [tid, buf] of threadBuffers) {
 				if (buf.timer) { clearTimeout(buf.timer); buf.timer = null; }
-				if (buf.messages.length >= 2 && buf.messages.length > buf.savedCount) {
+				if (hasUserAndAssistant(buf.messages) && buf.messages.length > buf.savedCount) {
 					flushPromises.push(flushThread(tid));
+				} else if (buf.inFlight) {
+					flushPromises.push(buf.inFlight);
 				}
 			}
 			await Promise.allSettled(flushPromises);
@@ -1779,12 +1796,15 @@ export async function activate(context) {
 			// This covers plugin disable/reload paths where quit hooks may not fire.
 			const flushPromises = [];
 			for (const [threadId, buf] of threadBuffers) {
-				if (autoCapture && buf.messages.length > buf.savedCount && !buf.flushing) {
+				if (autoCapture && buf.messages.length > buf.savedCount) {
+					if (buf.flushing) buf.pending = true;
 					flushPromises.push(
-						flushThread(threadId).catch((err) =>
+						Promise.resolve(flushThread(threadId)).catch((err) =>
 							logger.error?.(`nowledge-mem: dispose flush failed for ${threadId}: ${err}`),
 						),
 					);
+				} else if (autoCapture && buf.inFlight) {
+					flushPromises.push(buf.inFlight);
 				}
 			}
 			if (flushPromises.length > 0) {

--- a/nowledge-mem-alma-plugin/main.js
+++ b/nowledge-mem-alma-plugin/main.js
@@ -356,7 +356,7 @@ export class NowledgeMemClient {
 		return this._fetch("GET", `/threads/${encodeURIComponent(id)}`, { params });
 	}
 
-	async createThread(title, content, messages, source = "alma", id = null) {
+	async createThread(title, content, messages, source = "alma", id = null, { timeout } = {}) {
 		const body = { title, source };
 		if (id) body.thread_id = id;
 		if (Array.isArray(messages) && messages.length > 0) {
@@ -370,16 +370,27 @@ export class NowledgeMemClient {
 			const titleHash = createHash("md5").update(title || "").digest("hex").slice(0, 6);
 			body.thread_id = `alma-${ts}-${titleHash}`;
 		}
-		const data = await this._fetch("POST", "/threads", { body, timeout: this._threadSyncTimeoutMs });
-		const threadData = data.thread ?? {};
-		const remoteCount = Number.isInteger(threadData.message_count)
-			? threadData.message_count
-			: Array.isArray(data.messages) ? data.messages.length : undefined;
+		const data = await this._fetch("POST", "/threads", {
+			body,
+			...(timeout !== undefined ? { timeout } : {}),
+		});
+		const threadData = data?.thread;
+		const threadId =
+			threadData !== null && typeof threadData === "object" && typeof threadData.thread_id === "string"
+				? threadData.thread_id.trim()
+				: "";
+		if (!threadId) {
+			throw new Error("Thread create did not include a thread identity");
+		}
+		const remoteCount = threadData.message_count;
+		if (!Number.isInteger(remoteCount) || remoteCount < 0) {
+			throw new Error("Thread create did not include an explicit total message count");
+		}
 		return {
 			success: true,
-			id: threadData.thread_id ?? body.thread_id,
+			id: threadId,
 			title: threadData.title ?? title,
-			messages: (data.messages ?? []).length,
+			messages: Array.isArray(data.messages) ? data.messages.length : 0,
 			total_messages: remoteCount,
 		};
 	}
@@ -1536,6 +1547,9 @@ export async function activate(context) {
 			return buf.inFlight;
 		}
 
+		const flushDestinationKey = buf.destinationKey;
+		const flushClient = client;
+
 		const run = (async () => {
 		// Cancel this buffer's idle timer
 		if (buf.timer) { clearTimeout(buf.timer); buf.timer = null; }
@@ -1566,39 +1580,43 @@ export async function activate(context) {
 					.map((msg) => `[${msg.role}] ${escapeForInline(msg.content, 280)}`)
 					.join("\n");
 				logger.info?.(`nowledge-mem: creating thread ${buf.nowledgeThreadId} for ${threadId} (${msgsToSend.length} msgs, title="${buf.title}")`);
-				const created = await client.createThread(
+				const created = await flushClient.createThread(
 					buf.title,
 					escapeForInline(summary, 1200),
 					msgsToSend,
 					"alma",
 					buf.nowledgeThreadId,
+					{ timeout: flushClient._threadSyncTimeoutMs },
 				);
 				return {
 					messages_added: msgsToSend.length,
-					total_messages: Number.isInteger(created.total_messages)
-						? created.total_messages
-						: msgsToSend.length,
+					total_messages: created.total_messages,
 				};
 			};
 
 			let result;
 			try {
 				logger.info?.(`nowledge-mem: appending ${delta.messages.length} msgs to ${buf.nowledgeThreadId}`);
-				result = await client.appendThread(buf.nowledgeThreadId, delta.messages, {
+				result = await flushClient.appendThread(buf.nowledgeThreadId, delta.messages, {
 					idempotencyKey,
 					expectedMessageCount,
 				});
 			} catch (appendErr) {
-				if (client.isCheckpointConflictError(appendErr)) {
+				if (flushClient.isCheckpointConflictError(appendErr)) {
 					logger.info?.(`nowledge-mem: reconciling checkpoint conflict for ${buf.nowledgeThreadId}`);
-					result = await client.appendThread(buf.nowledgeThreadId, snapshot.slice(0, delta.end), {
+					result = await flushClient.appendThread(buf.nowledgeThreadId, snapshot.slice(0, delta.end), {
 						idempotencyKey: `${idempotencyKey}:reconcile`,
 					});
-				} else if (client.isThreadNotFoundError(appendErr)) {
+				} else if (flushClient.isThreadNotFoundError(appendErr)) {
 					result = await persistCreate();
 				} else {
 					throw appendErr;
 				}
+			}
+
+			if (buf.destinationKey !== flushDestinationKey || client !== flushClient) {
+				buf.pending = true;
+				return;
 			}
 
 			buf.acknowledged = {
@@ -1611,6 +1629,9 @@ export async function activate(context) {
 			logger.info?.(`nowledge-mem: thread synced (${threadId}, ${buf.messages.length} msgs)`);
 		} catch (err) {
 			logger.error?.(`nowledge-mem: thread sync failed: ${err instanceof Error ? err.message : String(err)}`);
+			if (buf.destinationKey !== flushDestinationKey || client !== flushClient) {
+				buf.pending = true;
+			}
 		} finally {
 			if (finishInFlightFlush(buf) === "rerun") {
 				buf.inFlight = flushThread(threadId);

--- a/nowledge-mem-alma-plugin/main.js
+++ b/nowledge-mem-alma-plugin/main.js
@@ -403,6 +403,7 @@ export class NowledgeMemClient {
 				deduplicate: true,
 				...(idempotencyKey ? { idempotency_key: String(idempotencyKey) } : {}),
 				...(checkpointed ? { expected_message_count: expectedMessageCount } : {}),
+				...(checkpointed ? { append_mode: "checkpointed" } : {}),
 			},
 			timeout: this._threadSyncTimeoutMs,
 		});

--- a/nowledge-mem-alma-plugin/session-delta.js
+++ b/nowledge-mem-alma-plugin/session-delta.js
@@ -1,0 +1,123 @@
+import { createHash } from "node:crypto";
+
+export function sessionSyncLaneKey(threadId, apiUrl, apiKey, spaceId) {
+	const destination = createHash("sha256")
+		.update([String(apiUrl || ""), String(apiKey || ""), String(spaceId || "")].join("\0"))
+		.digest("hex");
+	return `${destination}\0${String(threadId || "")}`;
+}
+
+export function stableMessageFingerprint(message) {
+	return JSON.stringify({ role: message?.role, content: message?.content });
+}
+
+function prefixFingerprint(messages, end, messageFingerprint) {
+	const hash = createHash("sha256");
+	for (const message of messages.slice(0, end)) {
+		const value = messageFingerprint(message);
+		hash.update(String(Buffer.byteLength(value)));
+		hash.update(":");
+		hash.update(value);
+	}
+	return hash.digest("hex");
+}
+
+export function isThreadAppendAck(data) {
+	return (
+		data !== null &&
+		typeof data === "object" &&
+		data.success === true &&
+		Number.isInteger(data.messages_added) &&
+		Number.isInteger(data.total_messages)
+	);
+}
+
+export function isCheckpointedAppendAck(data) {
+	return isThreadAppendAck(data) && data.append_mode === "checkpointed";
+}
+
+export function isCheckpointConflictResponse(data) {
+	return data !== null && typeof data === "object" && data.error_code === "checkpoint_conflict";
+}
+
+export function isThreadNotFoundResponse(status, data) {
+	if (
+		data !== null &&
+		typeof data === "object" &&
+		data.error_code === "thread_not_found"
+	) {
+		return true;
+	}
+	if (status === 404) return true;
+	return JSON.stringify(data ?? {}).toLowerCase().includes("thread not found");
+}
+
+export function selectAcknowledgedDelta(
+	messages,
+	cursor,
+	externalId,
+	messageFingerprint = stableMessageFingerprint,
+) {
+	let start = cursor?.count ?? 0;
+	let reset = false;
+	if (start < 0 || start > messages.length) {
+		start = 0;
+		reset = true;
+	} else if (start > 0) {
+		const fingerprintTrusted = Boolean(cursor?.prefixFingerprint);
+		const externalIdTrusted = Boolean(cursor?.lastExternalId);
+		const prefix = prefixFingerprint(messages, start, messageFingerprint);
+		if (
+			(externalIdTrusted && externalId(messages[start - 1]) !== cursor.lastExternalId) ||
+			(fingerprintTrusted && prefix !== cursor.prefixFingerprint)
+		) {
+			start = 0;
+			reset = true;
+		}
+	}
+	const end = messages.length;
+	return {
+		start,
+		end,
+		messages: messages.slice(start),
+		next: {
+			count: end,
+			remoteCount: cursor?.remoteCount ?? end,
+			...(end > 0 ? { lastExternalId: externalId(messages[end - 1]) } : {}),
+			prefixFingerprint: prefixFingerprint(messages, end, messageFingerprint),
+		},
+		reset,
+	};
+}
+
+export function contentBoundIdempotencyKey(prefix, threadId, start, end, fingerprint) {
+	return `${prefix}:${threadId}:${start}-${end}:${fingerprint}`;
+}
+
+export function planAutomaticFlush({
+	messages,
+	cursor,
+	threadId,
+	externalId = (message) =>
+		typeof message?.external_id === "string" && message.external_id
+			? message.external_id
+			: stableMessageFingerprint(message),
+	prefix = "alma-thread",
+}) {
+	const delta = selectAcknowledgedDelta(messages, cursor, externalId);
+	const trusted =
+		!delta.reset &&
+		Number.isInteger(cursor?.remoteCount) &&
+		Boolean(cursor?.prefixFingerprint);
+	return {
+		delta,
+		expectedMessageCount: trusted ? cursor.remoteCount : undefined,
+		idempotencyKey: contentBoundIdempotencyKey(
+			prefix,
+			threadId,
+			delta.start,
+			delta.end,
+			delta.next.prefixFingerprint,
+		),
+	};
+}

--- a/nowledge-mem-alma-plugin/session-delta.js
+++ b/nowledge-mem-alma-plugin/session-delta.js
@@ -104,7 +104,14 @@ export function planAutomaticFlush({
 			: stableMessageFingerprint(message),
 	prefix = "alma-thread",
 }) {
-	const delta = selectAcknowledgedDelta(messages, cursor, externalId);
+	let snapshotEnd = 0;
+	for (let index = messages.length - 1; index >= 0; index -= 1) {
+		if (messages[index]?.role === "assistant") {
+			snapshotEnd = index + 1;
+			break;
+		}
+	}
+	const delta = selectAcknowledgedDelta(messages.slice(0, snapshotEnd), cursor, externalId);
 	const trusted =
 		!delta.reset &&
 		Number.isInteger(cursor?.remoteCount) &&

--- a/nowledge-mem-alma-plugin/session-delta.js
+++ b/nowledge-mem-alma-plugin/session-delta.js
@@ -28,7 +28,9 @@ export function isThreadAppendAck(data) {
 		typeof data === "object" &&
 		data.success === true &&
 		Number.isInteger(data.messages_added) &&
-		Number.isInteger(data.total_messages)
+		data.messages_added >= 0 &&
+		Number.isInteger(data.total_messages) &&
+		data.total_messages >= 0
 	);
 }
 
@@ -49,7 +51,7 @@ export function isThreadNotFoundResponse(status, data) {
 		return true;
 	}
 	if (status === 404) return true;
-	return JSON.stringify(data ?? {}).toLowerCase().includes("thread not found");
+	return status === 400 && JSON.stringify(data ?? {}).toLowerCase().includes("thread not found");
 }
 
 export function selectAcknowledgedDelta(

--- a/nowledge-mem-alma-plugin/session-delta.js
+++ b/nowledge-mem-alma-plugin/session-delta.js
@@ -121,3 +121,37 @@ export function planAutomaticFlush({
 		),
 	};
 }
+
+export function hasUserAndAssistant(messages) {
+	if (!Array.isArray(messages) || messages.length < 2) return false;
+	let hasUser = false;
+	let hasAssistant = false;
+	for (const message of messages) {
+		if (message?.role === "user") hasUser = true;
+		else if (message?.role === "assistant") hasAssistant = true;
+		if (hasUser && hasAssistant) return true;
+	}
+	return false;
+}
+
+/**
+ * In-flight coalescing for per-thread automatic flush.
+ * A second flush requested while one is running is remembered and replayed
+ * after the in-flight persist finishes, so later turns are not dropped.
+ */
+export function beginInFlightFlush(state) {
+	if (state.flushing) {
+		state.pending = true;
+		return "wait";
+	}
+	state.flushing = true;
+	state.pending = false;
+	return "run";
+}
+
+export function finishInFlightFlush(state) {
+	state.flushing = false;
+	if (!state.pending) return "done";
+	state.pending = false;
+	return "rerun";
+}

--- a/nowledge-mem-alma-plugin/tests/session-delta.test.mjs
+++ b/nowledge-mem-alma-plugin/tests/session-delta.test.mjs
@@ -111,6 +111,7 @@ test("planAutomaticFlush omits expected_message_count until a trusted fingerprin
 		cursor: { ...initial.delta.next, remoteCount: 2 },
 		threadId: "alma-x",
 	});
+	assert.equal(completed.expectedMessageCount, 2);
 	assert.deepEqual(completed.delta.messages, [
 		{ role: "user", content: "next" },
 		{ role: "assistant", content: "done" },

--- a/nowledge-mem-alma-plugin/tests/session-delta.test.mjs
+++ b/nowledge-mem-alma-plugin/tests/session-delta.test.mjs
@@ -2,7 +2,10 @@ import assert from "node:assert/strict";
 import test from "node:test";
 
 import {
+	beginInFlightFlush,
 	contentBoundIdempotencyKey,
+	finishInFlightFlush,
+	hasUserAndAssistant,
 	isCheckpointConflictResponse,
 	isCheckpointedAppendAck,
 	isThreadAppendAck,
@@ -103,4 +106,35 @@ test("resolveThreadSyncTimeoutMs honors 120s default and 1s-30min bounds", () =>
 	assert.equal(resolveThreadSyncTimeoutMs("250"), 1_000);
 	assert.equal(resolveThreadSyncTimeoutMs("9999999"), 30 * 60_000);
 	assert.equal(resolveThreadSyncTimeoutMs("abc"), 120_000);
+});
+
+test("hasUserAndAssistant requires both roles, not just two messages", () => {
+	assert.equal(hasUserAndAssistant([{ role: "user", content: "a" }]), false);
+	assert.equal(
+		hasUserAndAssistant([
+			{ role: "user", content: "a" },
+			{ role: "user", content: "b" },
+		]),
+		false,
+	);
+	assert.equal(
+		hasUserAndAssistant([
+			{ role: "user", content: "a" },
+			{ role: "assistant", content: "b" },
+		]),
+		true,
+	);
+});
+
+test("in-flight flush coalesces a second request instead of dropping it", () => {
+	const state = { flushing: false, pending: false };
+	assert.equal(beginInFlightFlush(state), "run");
+	assert.equal(state.flushing, true);
+	assert.equal(beginInFlightFlush(state), "wait");
+	assert.equal(state.pending, true);
+	assert.equal(finishInFlightFlush(state), "rerun");
+	assert.equal(state.flushing, false);
+	assert.equal(state.pending, false);
+	assert.equal(beginInFlightFlush(state), "run");
+	assert.equal(finishInFlightFlush(state), "done");
 });

--- a/nowledge-mem-alma-plugin/tests/session-delta.test.mjs
+++ b/nowledge-mem-alma-plugin/tests/session-delta.test.mjs
@@ -1,0 +1,106 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+	contentBoundIdempotencyKey,
+	isCheckpointConflictResponse,
+	isCheckpointedAppendAck,
+	isThreadAppendAck,
+	isThreadNotFoundResponse,
+	planAutomaticFlush,
+	selectAcknowledgedDelta,
+	sessionSyncLaneKey,
+} from "../session-delta.js";
+import { resolveThreadSyncTimeoutMs } from "../thread-sync-timeout.js";
+
+const id = (message) => message.id;
+
+test("sessionSyncLaneKey isolates api url, key, and space", () => {
+	const first = sessionSyncLaneKey("thread", "https://mem", "key", "space-a");
+	const second = sessionSyncLaneKey("thread", "https://mem", "key", "space-b");
+	assert.notEqual(first, second);
+	assert.notEqual(
+		sessionSyncLaneKey("thread", "https://mem", "key-a", "space"),
+		sessionSyncLaneKey("thread", "https://mem", "key-b", "space"),
+	);
+	assert.equal(sessionSyncLaneKey("thread", "https://mem", "key", "space-a"), first);
+});
+
+test("selectAcknowledgedDelta appends only the unacknowledged suffix", () => {
+	const first = [{ id: "a" }, { id: "b" }];
+	const cursor = selectAcknowledgedDelta(first, undefined, id).next;
+	const delta = selectAcknowledgedDelta([...first, { id: "c" }], cursor, id);
+	assert.deepEqual(delta.messages, [{ id: "c" }]);
+	assert.equal(delta.reset, false);
+});
+
+test("selectAcknowledgedDelta resets same-length prefix replacements", () => {
+	const original = [
+		{ id: "a", content: "old" },
+		{ id: "b", content: "same" },
+	];
+	const cursor = selectAcknowledgedDelta(original, undefined, id).next;
+	const changed = [
+		{ id: "a", content: "new" },
+		{ id: "b", content: "same" },
+	];
+	const delta = selectAcknowledgedDelta(changed, cursor, id);
+	assert.equal(delta.reset, true);
+	assert.deepEqual(delta.messages, changed);
+});
+
+test("count-only cursors without fingerprints still slice the tail", () => {
+	const messages = [{ id: "a" }, { id: "b" }, { id: "c" }];
+	const delta = selectAcknowledgedDelta(messages, { count: 2, remoteCount: 2 }, id);
+	assert.deepEqual(delta.messages, [{ id: "c" }]);
+	assert.equal(delta.reset, false);
+});
+
+test("acknowledgement helpers require explicit checkpointed acks", () => {
+	assert.equal(
+		isCheckpointedAppendAck({
+			success: true,
+			append_mode: "checkpointed",
+			messages_added: 1,
+			total_messages: 3,
+		}),
+		true,
+	);
+	assert.equal(isThreadAppendAck({ success: true, messages_added: 1, total_messages: 3 }), true);
+	assert.equal(isCheckpointedAppendAck({ success: true, messages_added: 1, total_messages: 3 }), false);
+	assert.equal(isCheckpointConflictResponse({ error_code: "checkpoint_conflict" }), true);
+	assert.equal(isThreadNotFoundResponse(400, { detail: "Thread not found: alma-x" }), true);
+	assert.equal(isThreadNotFoundResponse(400, { error_code: "thread_not_found" }), true);
+	assert.equal(isThreadNotFoundResponse(500, { detail: "other" }), false);
+	assert.match(
+		contentBoundIdempotencyKey("alma-thread", "t", 2, 4, "abc"),
+		/^alma-thread:t:2-4:abc$/,
+	);
+});
+
+test("planAutomaticFlush omits expected_message_count until a trusted fingerprint exists", () => {
+	const first = [
+		{ role: "user", content: "hi" },
+		{ role: "assistant", content: "hello" },
+	];
+	const initial = planAutomaticFlush({ messages: first, cursor: null, threadId: "alma-x" });
+	assert.equal(initial.expectedMessageCount, undefined);
+	assert.equal(initial.delta.start, 0);
+	assert.match(initial.idempotencyKey, /^alma-thread:alma-x:0-2:/);
+
+	const trusted = planAutomaticFlush({
+		messages: [...first, { role: "user", content: "next" }],
+		cursor: { ...initial.delta.next, remoteCount: 2 },
+		threadId: "alma-x",
+	});
+	assert.equal(trusted.expectedMessageCount, 2);
+	assert.deepEqual(trusted.delta.messages, [{ role: "user", content: "next" }]);
+});
+
+test("resolveThreadSyncTimeoutMs honors 120s default and 1s-30min bounds", () => {
+	assert.equal(resolveThreadSyncTimeoutMs(undefined), 120_000);
+	assert.equal(resolveThreadSyncTimeoutMs("5000"), 5_000);
+	assert.equal(resolveThreadSyncTimeoutMs("250"), 1_000);
+	assert.equal(resolveThreadSyncTimeoutMs("9999999"), 30 * 60_000);
+	assert.equal(resolveThreadSyncTimeoutMs("abc"), 120_000);
+});

--- a/nowledge-mem-alma-plugin/tests/session-delta.test.mjs
+++ b/nowledge-mem-alma-plugin/tests/session-delta.test.mjs
@@ -97,7 +97,21 @@ test("planAutomaticFlush omits expected_message_count until a trusted fingerprin
 		threadId: "alma-x",
 	});
 	assert.equal(trusted.expectedMessageCount, 2);
-	assert.deepEqual(trusted.delta.messages, [{ role: "user", content: "next" }]);
+	assert.deepEqual(trusted.delta.messages, []);
+
+	const completed = planAutomaticFlush({
+		messages: [
+			...first,
+			{ role: "user", content: "next" },
+			{ role: "assistant", content: "done" },
+		],
+		cursor: { ...initial.delta.next, remoteCount: 2 },
+		threadId: "alma-x",
+	});
+	assert.deepEqual(completed.delta.messages, [
+		{ role: "user", content: "next" },
+		{ role: "assistant", content: "done" },
+	]);
 });
 
 test("resolveThreadSyncTimeoutMs honors 120s default and 1s-30min bounds", () => {

--- a/nowledge-mem-alma-plugin/tests/session-delta.test.mjs
+++ b/nowledge-mem-alma-plugin/tests/session-delta.test.mjs
@@ -70,11 +70,14 @@ test("acknowledgement helpers require explicit checkpointed acks", () => {
 		true,
 	);
 	assert.equal(isThreadAppendAck({ success: true, messages_added: 1, total_messages: 3 }), true);
+	assert.equal(isThreadAppendAck({ success: true, messages_added: -1, total_messages: 3 }), false);
+	assert.equal(isThreadAppendAck({ success: true, messages_added: 1, total_messages: -1 }), false);
 	assert.equal(isCheckpointedAppendAck({ success: true, messages_added: 1, total_messages: 3 }), false);
 	assert.equal(isCheckpointConflictResponse({ error_code: "checkpoint_conflict" }), true);
 	assert.equal(isThreadNotFoundResponse(400, { detail: "Thread not found: alma-x" }), true);
 	assert.equal(isThreadNotFoundResponse(400, { error_code: "thread_not_found" }), true);
 	assert.equal(isThreadNotFoundResponse(500, { detail: "other" }), false);
+	assert.equal(isThreadNotFoundResponse(500, { detail: "upstream thread not found" }), false);
 	assert.match(
 		contentBoundIdempotencyKey("alma-thread", "t", 2, 4, "abc"),
 		/^alma-thread:t:2-4:abc$/,

--- a/nowledge-mem-alma-plugin/tests/thread-sync.test.mjs
+++ b/nowledge-mem-alma-plugin/tests/thread-sync.test.mjs
@@ -1,0 +1,116 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { NowledgeMemClient } from "../main.js";
+
+const logger = { info() {}, warn() {}, debug() {}, error() {} };
+
+function jsonResponse(status, data) {
+	return {
+		ok: status >= 200 && status < 300,
+		status,
+		headers: { get: () => "application/json" },
+		json: async () => data,
+		text: async () => JSON.stringify(data),
+	};
+}
+
+test("appendThread sends checkpoint fields and requires a checkpointed ack", async () => {
+	const bodies = [];
+	const previous = globalThis.fetch;
+	globalThis.fetch = async (_url, init) => {
+		bodies.push(JSON.parse(init.body));
+		return jsonResponse(200, {
+			success: true,
+			append_mode: "checkpointed",
+			messages_added: 1,
+			total_messages: 3,
+		});
+	};
+	try {
+		const client = new NowledgeMemClient(logger, { threadSyncTimeoutMs: 5_000 });
+		const result = await client.appendThread(
+			"alma-x",
+			[{ role: "user", content: "next" }],
+			{ idempotencyKey: "alma-thread:alma-x:2-3:abc", expectedMessageCount: 2 },
+		);
+		assert.equal(result.total_messages, 3);
+		assert.equal(bodies[0].expected_message_count, 2);
+		assert.equal(bodies[0].idempotency_key, "alma-thread:alma-x:2-3:abc");
+		assert.equal(bodies[0].deduplicate, true);
+	} finally {
+		globalThis.fetch = previous;
+	}
+});
+
+test("appendThread does not treat a success-only body as an ack", async () => {
+	const previous = globalThis.fetch;
+	globalThis.fetch = async () => jsonResponse(200, { success: true });
+	try {
+		const client = new NowledgeMemClient(logger, {});
+		await assert.rejects(
+			() => client.appendThread("alma-x", [{ role: "user", content: "hi" }]),
+			/explicit persistence acknowledgement/,
+		);
+	} finally {
+		globalThis.fetch = previous;
+	}
+});
+
+test("appendThread rejects a non-checkpointed ack when a checkpoint was required", async () => {
+	const previous = globalThis.fetch;
+	globalThis.fetch = async () =>
+		jsonResponse(200, { success: true, messages_added: 1, total_messages: 2 });
+	try {
+		const client = new NowledgeMemClient(logger, {});
+		await assert.rejects(
+			() =>
+				client.appendThread("alma-x", [{ role: "user", content: "hi" }], {
+					expectedMessageCount: 1,
+				}),
+			/not acknowledged as checkpointed/,
+		);
+	} finally {
+		globalThis.fetch = previous;
+	}
+});
+
+test("create and append use the configured thread-sync timeout, not the 15s default", async () => {
+	const timeouts = [];
+	const previous = globalThis.fetch;
+	globalThis.fetch = async (_url, init) => {
+		timeouts.push(init.signal);
+		return jsonResponse(200, {
+			success: true,
+			append_mode: "checkpointed",
+			messages_added: 1,
+			total_messages: 1,
+			thread: { thread_id: "alma-x", message_count: 1 },
+			messages: [{ role: "user", content: "hi" }],
+		});
+	};
+	try {
+		const client = new NowledgeMemClient(logger, { threadSyncTimeoutMs: 90_000 });
+		assert.equal(client._threadSyncTimeoutMs, 90_000);
+		await client.createThread("t", "", [{ role: "user", content: "hi" }], "alma", "alma-x");
+		await client.appendThread("alma-x", [{ role: "assistant", content: "ok" }], {
+			expectedMessageCount: 1,
+		});
+		assert.equal(timeouts.length, 2);
+	} finally {
+		globalThis.fetch = previous;
+	}
+});
+
+test("isThreadNotFoundError treats HTTP 400 Thread not found as recreate", () => {
+	const client = new NowledgeMemClient(logger, {});
+	const err = new Error("HTTP 400: Thread not found: alma-x");
+	err.status = 400;
+	assert.equal(client.isThreadNotFoundError(err), true);
+	const coded = new Error("missing");
+	coded.code = "thread_not_found";
+	assert.equal(client.isThreadNotFoundError(coded), true);
+	const other = new Error("HTTP 500: boom");
+	other.status = 500;
+	assert.equal(client.isThreadNotFoundError(other), false);
+});

--- a/nowledge-mem-alma-plugin/tests/thread-sync.test.mjs
+++ b/nowledge-mem-alma-plugin/tests/thread-sync.test.mjs
@@ -321,6 +321,51 @@ test("flush discards a stale ack after the destination changes and reruns", asyn
 	}
 });
 
+test("automatic flush leaves a user-only tail buffered until its assistant arrives", async () => {
+	const previous = globalThis.fetch;
+	const appends = [];
+	globalThis.fetch = async (url, init) => {
+		if (String(url).includes("/append")) {
+			const body = JSON.parse(init.body);
+			appends.push(body.messages);
+			return jsonResponse(200, {
+				success: true,
+				append_mode: "checkpointed",
+				messages_added: body.messages.length,
+				total_messages: appends.flat().length,
+			});
+		}
+		return jsonResponse(200, {});
+	};
+	const harness = makePluginHarness();
+	const plugin = await activate(harness.context);
+	try {
+		await captureUserAndAssistant(harness.events);
+		await harness.events.get("chat.message.willSend")({
+			threadId: "thread-1",
+			content: "pending question",
+		});
+		await harness.events.get("app.willQuit")({}, { cancel: false });
+		assert.deepEqual(appends, [[
+			{ role: "user", content: "hello from alma" },
+			{ role: "assistant", content: "hi from mem" },
+		]]);
+
+		harness.events.get("chat.message.didReceive")({
+			threadId: "thread-1",
+			response: { content: "pending answer" },
+		});
+		await harness.events.get("app.willQuit")({}, { cancel: false });
+		assert.deepEqual(appends[1], [
+			{ role: "user", content: "pending question" },
+			{ role: "assistant", content: "pending answer" },
+		]);
+	} finally {
+		globalThis.fetch = previous;
+		await plugin.dispose();
+	}
+});
+
 test("isThreadNotFoundError treats HTTP 400 Thread not found as recreate", () => {
 	const client = new NowledgeMemClient(logger, {});
 	const err = new Error("HTTP 400: Thread not found: alma-x");

--- a/nowledge-mem-alma-plugin/tests/thread-sync.test.mjs
+++ b/nowledge-mem-alma-plugin/tests/thread-sync.test.mjs
@@ -321,6 +321,56 @@ test("flush discards a stale ack after the destination changes and reruns", asyn
 	}
 });
 
+test("in-flight flush keeps its stable thread id after a destination reset", async () => {
+	const previous = globalThis.fetch;
+	const harness = makePluginHarness();
+	let releaseTitle;
+	let titleCalls = 0;
+	const titleStarted = new Promise((resolve) => {
+		harness.context.chat = {
+			getThread() {
+				titleCalls += 1;
+				if (titleCalls > 1) return Promise.resolve({ title: "Resolved title" });
+				resolve();
+				return new Promise((finish) => {
+					releaseTitle = finish;
+				});
+			},
+		};
+	});
+	const calls = [];
+	globalThis.fetch = async (url, init) => {
+		const href = String(url);
+		const body = init?.body ? JSON.parse(init.body) : undefined;
+		calls.push({ href, body });
+		if (href.includes("/append")) {
+			return jsonResponse(404, { detail: "Thread not found" });
+		}
+		return jsonResponse(200, {
+			thread: { thread_id: body.thread_id, message_count: body.messages.length },
+		});
+	};
+	const plugin = await activate(harness.context);
+	try {
+		await captureUserAndAssistant(harness.events);
+		const flushing = harness.events.get("app.willQuit")({}, { cancel: false });
+		await titleStarted;
+		harness.changeSettings({ "nowledgeMem.apiUrl": "http://mem-b:14242" });
+		releaseTitle({ title: "Resolved title" });
+		await flushing;
+
+		const oldAppend = calls.find((call) => call.href.includes("127.0.0.1") && call.href.includes("/append"));
+		const oldCreate = calls.find((call) => call.href === "http://127.0.0.1:14242/threads");
+		assert.ok(oldAppend);
+		assert.ok(oldCreate);
+		assert.doesNotMatch(oldAppend.href, /\/threads\/null\/append/);
+		assert.match(oldAppend.href, new RegExp(`/threads/${oldCreate.body.thread_id}/append$`));
+	} finally {
+		globalThis.fetch = previous;
+		await plugin.dispose();
+	}
+});
+
 test("automatic flush leaves a user-only tail buffered until its assistant arrives", async () => {
 	const previous = globalThis.fetch;
 	const appends = [];
@@ -377,4 +427,7 @@ test("isThreadNotFoundError treats HTTP 400 Thread not found as recreate", () =>
 	const other = new Error("HTTP 500: boom");
 	other.status = 500;
 	assert.equal(client.isThreadNotFoundError(other), false);
+	const upstream = new Error("HTTP 500: upstream thread not found");
+	upstream.status = 500;
+	assert.equal(client.isThreadNotFoundError(upstream), false);
 });

--- a/nowledge-mem-alma-plugin/tests/thread-sync.test.mjs
+++ b/nowledge-mem-alma-plugin/tests/thread-sync.test.mjs
@@ -1,7 +1,7 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 
-import { NowledgeMemClient } from "../main.js";
+import { activate, NowledgeMemClient } from "../main.js";
 
 const logger = { info() {}, warn() {}, debug() {}, error() {} };
 
@@ -75,30 +75,249 @@ test("appendThread rejects a non-checkpointed ack when a checkpoint was required
 	}
 });
 
-test("create and append use the configured thread-sync timeout, not the 15s default", async () => {
-	const timeouts = [];
+function captureFetchTimeouts(client) {
+	const calls = [];
+	const original = client._fetch.bind(client);
+	client._fetch = async (method, path, options = {}) => {
+		calls.push({ method, path, timeout: options.timeout });
+		return original(method, path, options);
+	};
+	return calls;
+}
+
+test("manual createThread keeps the 15s request timeout", async () => {
 	const previous = globalThis.fetch;
-	globalThis.fetch = async (_url, init) => {
-		timeouts.push(init.signal);
-		return jsonResponse(200, {
-			success: true,
-			append_mode: "checkpointed",
-			messages_added: 1,
-			total_messages: 1,
+	globalThis.fetch = async () =>
+		jsonResponse(200, {
 			thread: { thread_id: "alma-x", message_count: 1 },
 			messages: [{ role: "user", content: "hi" }],
 		});
-	};
 	try {
 		const client = new NowledgeMemClient(logger, { threadSyncTimeoutMs: 90_000 });
-		assert.equal(client._threadSyncTimeoutMs, 90_000);
+		const calls = captureFetchTimeouts(client);
 		await client.createThread("t", "", [{ role: "user", content: "hi" }], "alma", "alma-x");
+		assert.equal(calls.length, 1);
+		assert.equal(calls[0].path, "/threads");
+		assert.equal(calls[0].timeout, undefined);
+	} finally {
+		globalThis.fetch = previous;
+	}
+});
+
+test("automatic createThread path can pass the configured sync timeout", async () => {
+	const previous = globalThis.fetch;
+	globalThis.fetch = async () =>
+		jsonResponse(200, {
+			thread: { thread_id: "alma-x", message_count: 1 },
+			messages: [{ role: "user", content: "hi" }],
+		});
+	try {
+		const client = new NowledgeMemClient(logger, { threadSyncTimeoutMs: 90_000 });
+		const calls = captureFetchTimeouts(client);
+		await client.createThread(
+			"t",
+			"",
+			[{ role: "user", content: "hi" }],
+			"alma",
+			"alma-x",
+			{ timeout: client._threadSyncTimeoutMs },
+		);
+		assert.equal(calls[0].timeout, 90_000);
+	} finally {
+		globalThis.fetch = previous;
+	}
+});
+
+test("appendThread still uses the configured thread-sync timeout", async () => {
+	const previous = globalThis.fetch;
+	globalThis.fetch = async () =>
+		jsonResponse(200, {
+			success: true,
+			append_mode: "checkpointed",
+			messages_added: 1,
+			total_messages: 2,
+		});
+	try {
+		const client = new NowledgeMemClient(logger, { threadSyncTimeoutMs: 90_000 });
+		const calls = captureFetchTimeouts(client);
 		await client.appendThread("alma-x", [{ role: "assistant", content: "ok" }], {
 			expectedMessageCount: 1,
 		});
-		assert.equal(timeouts.length, 2);
+		assert.equal(calls[0].timeout, 90_000);
 	} finally {
 		globalThis.fetch = previous;
+	}
+});
+
+test("createThread requires a thread identity and a non-negative total message count", async () => {
+	const previous = globalThis.fetch;
+	try {
+		const client = new NowledgeMemClient(logger, {});
+		globalThis.fetch = async () => jsonResponse(200, {});
+		await assert.rejects(
+			() => client.createThread("t", "hi", [], "alma", "alma-x"),
+			/thread identity/,
+		);
+		globalThis.fetch = async () =>
+			jsonResponse(200, { thread: { thread_id: "alma-x" }, messages: [{ role: "user", content: "hi" }] });
+		await assert.rejects(
+			() => client.createThread("t", "hi", [], "alma", "alma-x"),
+			/explicit total message count/,
+		);
+		globalThis.fetch = async () =>
+			jsonResponse(200, { thread: { thread_id: "alma-x", message_count: -1 } });
+		await assert.rejects(
+			() => client.createThread("t", "hi", [], "alma", "alma-x"),
+			/explicit total message count/,
+		);
+		globalThis.fetch = async () =>
+			jsonResponse(200, { thread: { thread_id: "alma-x", message_count: 2 } });
+		const created = await client.createThread(
+			"t",
+			"",
+			[{ role: "user", content: "a" }, { role: "assistant", content: "b" }],
+			"alma",
+			"alma-x",
+		);
+		assert.equal(created.id, "alma-x");
+		assert.equal(created.total_messages, 2);
+	} finally {
+		globalThis.fetch = previous;
+	}
+});
+
+function makePluginHarness(initialSettings = {}) {
+	const store = {
+		"nowledgeMem.recallPolicy": "off",
+		"nowledgeMem.autoCapture": true,
+		"nowledgeMem.autoRecall": false,
+		...initialSettings,
+	};
+	const listeners = [];
+	const tools = new Map();
+	const events = new Map();
+	return {
+		tools,
+		events,
+		changeSettings(patch) {
+			Object.assign(store, patch);
+			for (const fn of listeners) fn();
+		},
+		context: {
+			logger,
+			settings: {
+				get(key) {
+					return store[key];
+				},
+				onDidChange(fn) {
+					listeners.push(fn);
+					return { dispose() {} };
+				},
+			},
+			tools: {
+				register(name, tool) {
+					if (typeof name === "string") tools.set(name, tool);
+					return { dispose() {} };
+				},
+			},
+			events: {
+				on(name, handler) {
+					events.set(name, handler);
+					return { dispose() {} };
+				},
+			},
+		},
+	};
+}
+
+async function captureUserAndAssistant(events, threadId = "thread-1") {
+	await events.get("chat.message.willSend")({ threadId, content: "hello from alma" });
+	events.get("chat.message.didReceive")({
+		threadId,
+		response: { content: "hi from mem" },
+	});
+}
+
+test("manual thread_create tool keeps the 15s timeout while automatic flush uses NMEM_SYNC_TIMEOUT_MS", async () => {
+	const previousFetch = globalThis.fetch;
+	const previousEnv = process.env.NMEM_SYNC_TIMEOUT_MS;
+	const originalFetch = NowledgeMemClient.prototype._fetch;
+	const calls = [];
+	NowledgeMemClient.prototype._fetch = async function (method, path, options = {}) {
+		calls.push({ method, path, timeout: options.timeout, apiUrl: this._apiUrl });
+		if (String(path).includes("/append")) {
+			const err = new Error("HTTP 404: Thread not found");
+			err.status = 404;
+			throw err;
+		}
+		if (method === "POST" && path === "/threads") {
+			return {
+				thread: {
+					thread_id: options.body?.thread_id || "alma-x",
+					message_count: Array.isArray(options.body?.messages) ? options.body.messages.length : 1,
+				},
+			};
+		}
+		return {};
+	};
+	process.env.NMEM_SYNC_TIMEOUT_MS = "90000";
+	const harness = makePluginHarness();
+	const plugin = await activate(harness.context);
+	try {
+		await captureUserAndAssistant(harness.events);
+		await harness.events.get("app.willQuit")({}, { cancel: false });
+		const autoCreate = calls.find((call) => call.method === "POST" && call.path === "/threads");
+		assert.equal(autoCreate?.timeout, 90_000);
+
+		calls.length = 0;
+		const tool = harness.tools.get("nowledge_mem_thread_create");
+		const result = await tool.execute({ title: "manual", content: "hello" });
+		assert.equal(result.ok, true);
+		assert.equal(calls[0].path, "/threads");
+		assert.equal(calls[0].timeout, undefined);
+	} finally {
+		NowledgeMemClient.prototype._fetch = originalFetch;
+		globalThis.fetch = previousFetch;
+		if (previousEnv === undefined) delete process.env.NMEM_SYNC_TIMEOUT_MS;
+		else process.env.NMEM_SYNC_TIMEOUT_MS = previousEnv;
+		await plugin.dispose();
+	}
+});
+
+test("flush discards a stale ack after the destination changes and reruns", async () => {
+	const previous = globalThis.fetch;
+	const posts = [];
+	const harness = makePluginHarness();
+	globalThis.fetch = async (url, init) => {
+		const href = String(url);
+		const body = init?.body ? JSON.parse(init.body) : undefined;
+		posts.push({ href, body });
+		if (href.includes("/append") && posts.filter((post) => post.href.includes("127.0.0.1")).length === 1) {
+			harness.changeSettings({ "nowledgeMem.apiUrl": "http://mem-b:14242" });
+		}
+		if (href.includes("/append")) {
+			return jsonResponse(200, {
+				success: true,
+				append_mode: "checkpointed",
+				messages_added: 2,
+				total_messages: 2,
+			});
+		}
+		return jsonResponse(200, {
+			thread: { thread_id: body?.thread_id || "alma-x", message_count: 2 },
+		});
+	};
+	const plugin = await activate(harness.context);
+	try {
+		await captureUserAndAssistant(harness.events);
+		await harness.events.get("app.willQuit")({}, { cancel: false });
+		const appends = posts.filter((post) => post.href.includes("/append"));
+		assert.equal(appends.length, 2);
+		assert.match(appends[0].href, /127\.0\.0\.1/);
+		assert.match(appends[1].href, /mem-b:14242/);
+	} finally {
+		globalThis.fetch = previous;
+		await plugin.dispose();
 	}
 });
 

--- a/nowledge-mem-alma-plugin/tests/thread-sync.test.mjs
+++ b/nowledge-mem-alma-plugin/tests/thread-sync.test.mjs
@@ -36,6 +36,7 @@ test("appendThread sends checkpoint fields and requires a checkpointed ack", asy
 		);
 		assert.equal(result.total_messages, 3);
 		assert.equal(bodies[0].expected_message_count, 2);
+		assert.equal(bodies[0].append_mode, "checkpointed");
 		assert.equal(bodies[0].idempotency_key, "alma-thread:alma-x:2-3:abc");
 		assert.equal(bodies[0].deduplicate, true);
 	} finally {

--- a/nowledge-mem-alma-plugin/thread-sync-timeout.js
+++ b/nowledge-mem-alma-plugin/thread-sync-timeout.js
@@ -1,0 +1,11 @@
+const DEFAULT_THREAD_SYNC_TIMEOUT_MS = 120_000;
+const MIN_THREAD_SYNC_TIMEOUT_MS = 1_000;
+const MAX_THREAD_SYNC_TIMEOUT_MS = 30 * 60_000;
+
+export function resolveThreadSyncTimeoutMs(raw) {
+	const parsed = Number(raw);
+	if (!String(raw ?? "").trim() || !Number.isSafeInteger(parsed) || parsed <= 0) {
+		return DEFAULT_THREAD_SYNC_TIMEOUT_MS;
+	}
+	return Math.min(MAX_THREAD_SYNC_TIMEOUT_MS, Math.max(MIN_THREAD_SYNC_TIMEOUT_MS, parsed));
+}


### PR DESCRIPTION
## Summary

- Capture acknowledged Alma transcript suffixes, coalesce in-flight flushes, and defer incomplete user-only turns until an assistant response arrives.
- Validate create and append acknowledgements, recover from conflicts and missing threads, and retain a stable thread and destination for each in-flight request.
- Discard stale acknowledgements after a destination change and rerun synchronization against the current destination.
- Apply bounded `NMEM_SYNC_TIMEOUT_MS` handling to automatic synchronization while keeping manual thread creation at its existing timeout.

## Validation

- `npm test`: 30 passed
- Targeted Biome check for the modified session-delta test
- `node --check main.js`
- `node --check session-delta.js`
- `git diff --check`
- CodeRabbit passes on `7b56dd68` with no unresolved review threads.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved session synchronization reliability with checkpoint tracking, conflict recovery, and thread recreation after missing-thread errors.
  - Prevented duplicate or stale updates during concurrent saves, destination changes, and application shutdown.
  - Captured complete user-and-assistant exchanges while buffering incomplete turns safely.
  - Added bounded synchronization timeouts and clearer handling of server acknowledgements.

- **Documentation**
  - Documented the `app.willQuit` shutdown flush hook.
  - Documented the configurable 120-second synchronization timeout and its supported range.

- **Tests**
  - Expanded coverage for synchronization, recovery, timeout, shutdown, and destination-change scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->