### PR TITLE
fix(opencode): isolate session checkpoints by destination lane

### DIFF
--- a/integrations.json
+++ b/integrations.json
@@ -1092,7 +1092,7 @@
       "name": "OpenCode",
       "category": "coding",
       "type": "plugin",
-      "version": "0.3.8",
+      "version": "0.3.9",
       "directory": "nowledge-mem-opencode-plugin",
       "transport": "cli+http",
       "capabilities": {

--- a/nowledge-mem-opencode-plugin/CHANGELOG.md
+++ b/nowledge-mem-opencode-plugin/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## [0.3.9] - 2026-08-19
+
+### Fixed
+
+- Automatic session checkpoints now isolate cursor state by destination
+  lane (API URL, API key, space, and AI Identity), not just the ambient
+  space id. Switching server, key, or identity no longer reuses another
+  lane's acknowledged suffix.
+
 ## [0.3.8] - 2026-08-19
 
 ### Fixed

--- a/nowledge-mem-opencode-plugin/README.md
+++ b/nowledge-mem-opencode-plugin/README.md
@@ -57,7 +57,7 @@ The plugin follows OpenCode's standard plugin update mechanism. To pin a specifi
 
 ```json
 {
-  "plugin": ["opencode-nowledge-mem@0.3.8"]
+  "plugin": ["opencode-nowledge-mem@0.3.9"]
 }
 ```
 

--- a/nowledge-mem-opencode-plugin/README.md
+++ b/nowledge-mem-opencode-plugin/README.md
@@ -173,7 +173,7 @@ The plugin's Context Bundle, Working Memory, search, save, and full-session thre
 
 When a single request names another Space, OpenCode can pass `space` or `space_id` directly to the relevant `nowledge_mem_*` tool. The ambient setting remains the default only for calls that do not provide an explicit Space.
 
-For multi-agent orchestrators, set `NMEM_AGENT_ID=<agent-slug>` per spawned OpenCode worker. Add `NMEM_SPACE` only when that run should override the AI Identity's default space. `NMEM_HOST_AGENT_ID` is for advanced external aliases. Context Bundle will use the stable identity while keeping `source_app=opencode` for provenance.
+For multi-agent orchestrators, set `NMEM_AGENT_ID=<agent-slug>` per spawned OpenCode worker. Add `NMEM_SPACE` only when that run should override the AI Identity's default space. `NMEM_HOST_AGENT_ID` is for advanced external aliases. Context Bundle will use the stable identity while keeping `source_app=opencode` for provenance. Automatic session checkpoints isolate cursor state by destination lane (API URL, API key, space, and identity) so one process cannot reuse another destination's acknowledged suffix.
 
 Shared spaces, default retrieval, and agent guidance still come from Mem's own space profile. OpenCode should pick the lane once, not invent a second plugin-local memory partition.
 

--- a/nowledge-mem-opencode-plugin/dist/index.js
+++ b/nowledge-mem-opencode-plugin/dist/index.js
@@ -1,15 +1,16 @@
-// Generated from src/index.ts. Run npm run build before publishing.
+// Generated from src/index.ts. Run bun run build before publishing.
 
-// nowledge-mem-opencode-plugin/src/index.ts
+// src/index.ts
 import { tool } from "@opencode-ai/plugin";
 import { existsSync, readFileSync } from "node:fs";
 import { homedir } from "node:os";
 import { join } from "node:path";
 
-// nowledge-mem-opencode-plugin/src/session-delta.ts
+// src/session-delta.ts
 import { createHash } from "node:crypto";
-function sessionSyncLaneKey(sessionId, spaceId) {
-  return `${spaceId ?? ""}\0${sessionId}`;
+function sessionSyncLaneKey(sessionId, apiUrl, apiKey, spaceId, agentId, hostAgentId) {
+  const destination = createHash("sha256").update([apiUrl, apiKey ?? "", spaceId ?? "", agentId ?? "", hostAgentId ?? ""].join("\0")).digest("hex");
+  return `${destination}\0${sessionId}`;
 }
 function stableMessageFingerprint(message) {
   return JSON.stringify(message);
@@ -94,7 +95,7 @@ function selectAcknowledgedDelta(messages, cursor, externalId, messageFingerprin
   };
 }
 
-// nowledge-mem-opencode-plugin/src/thread-sync-timeout.ts
+// src/thread-sync-timeout.ts
 var DEFAULT_THREAD_SYNC_TIMEOUT_MS = 12e4;
 var MIN_THREAD_SYNC_TIMEOUT_MS = 1e3;
 var MAX_THREAD_SYNC_TIMEOUT_MS = 30 * 6e4;
@@ -106,7 +107,7 @@ function resolveThreadSyncTimeoutMs(raw) {
   return Math.min(MAX_THREAD_SYNC_TIMEOUT_MS, Math.max(MIN_THREAD_SYNC_TIMEOUT_MS, parsed));
 }
 
-// nowledge-mem-opencode-plugin/src/index.ts
+// src/index.ts
 var THREAD_SYNC_TIMEOUT_MS = resolveThreadSyncTimeoutMs(process.env.NMEM_SYNC_TIMEOUT_MS);
 var BEHAVIORAL_GUIDANCE = `## Nowledge Mem
 
@@ -355,7 +356,14 @@ ${reasoning}
       (process.env.NMEM_OPENCODE_AUTO_SYNC ?? "1").trim().toLowerCase()
     );
     function syncStateFor(sessionID, spaceId = ambientSpaceId) {
-      const key = sessionSyncLaneKey(sessionID, spaceId);
+      const key = sessionSyncLaneKey(
+        sessionID,
+        apiUrl,
+        apiKey,
+        spaceId,
+        ambientAgentId,
+        ambientHostAgentId
+      );
       const existing = syncStates.get(key);
       if (existing) return existing;
       const created = {};

--- a/nowledge-mem-opencode-plugin/package.json
+++ b/nowledge-mem-opencode-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "opencode-nowledge-mem",
-  "version": "0.3.8",
+  "version": "0.3.9",
   "description": "Nowledge Mem plugin for OpenCode. Cross-tool knowledge with idle-event thread capture, Context Bundle, search, save, and handoffs.",
   "type": "module",
   "main": "dist/index.js",

--- a/nowledge-mem-opencode-plugin/src/index.ts
+++ b/nowledge-mem-opencode-plugin/src/index.ts
@@ -341,7 +341,14 @@ export default {
     )
 
     function syncStateFor(sessionID: string, spaceId = ambientSpaceId): SessionSyncState {
-      const key = sessionSyncLaneKey(sessionID, spaceId)
+      const key = sessionSyncLaneKey(
+        sessionID,
+        apiUrl,
+        apiKey,
+        spaceId,
+        ambientAgentId,
+        ambientHostAgentId,
+      )
       const existing = syncStates.get(key)
       if (existing) return existing
       const created: SessionSyncState = {}

--- a/nowledge-mem-opencode-plugin/src/session-delta.ts
+++ b/nowledge-mem-opencode-plugin/src/session-delta.ts
@@ -15,8 +15,23 @@ export type AcknowledgedDelta<T> = {
   reset: boolean
 }
 
-export function sessionSyncLaneKey(sessionId: string, spaceId?: string): string {
-  return `${spaceId ?? ""}\0${sessionId}`
+/**
+ * Builds a destination-lane key so cursor state never crosses servers, keys,
+ * spaces, or identities. Hashes the destination fields and binds the result
+ * to the host session id.
+ */
+export function sessionSyncLaneKey(
+  sessionId: string,
+  apiUrl: string,
+  apiKey: string | undefined,
+  spaceId: string | undefined,
+  agentId: string | undefined,
+  hostAgentId: string | undefined,
+): string {
+  const destination = createHash("sha256")
+    .update([apiUrl, apiKey ?? "", spaceId ?? "", agentId ?? "", hostAgentId ?? ""].join("\0"))
+    .digest("hex")
+  return `${destination}\0${sessionId}`
 }
 
 export function stableMessageFingerprint(message: unknown): string {

--- a/nowledge-mem-opencode-plugin/tests/session-delta.test.mjs
+++ b/nowledge-mem-opencode-plugin/tests/session-delta.test.mjs
@@ -123,29 +123,28 @@ test("recreates the complete Thread after a 400 missing-thread response", async 
 })
 
 test("session checkpoints are isolated by destination lane", () => {
-  const base = ["https://mem", "key", "space-a", "agent-a", undefined]
-  assert.notEqual(
-    sessionSyncLaneKey("session-1", "https://mem", "key", "space-a", undefined, undefined),
-    sessionSyncLaneKey("session-1", "https://mem", "key", "space-b", undefined, undefined),
-  )
-  assert.notEqual(
-    sessionSyncLaneKey("session-1", "https://mem-a", "key", "space", undefined, undefined),
-    sessionSyncLaneKey("session-1", "https://mem-b", "key", "space", undefined, undefined),
-  )
-  assert.notEqual(
-    sessionSyncLaneKey("session-1", "https://mem", "key-a", "space", undefined, undefined),
-    sessionSyncLaneKey("session-1", "https://mem", "key-b", "space", undefined, undefined),
-  )
-  assert.notEqual(
+  const messages = [{ id: "a" }, { id: "b" }]
+  const base = ["https://mem-a", "key-a", "space-a", "agent-a", "host-a"]
+  const states = new Map()
+  states.set(
     sessionSyncLaneKey("session-1", ...base),
-    sessionSyncLaneKey("session-1", "https://mem", "key", "space-a", "agent-b", undefined),
+    selectAcknowledgedDelta(messages.slice(0, 1), undefined, id).next,
   )
-  assert.notEqual(
-    sessionSyncLaneKey("session-1", "https://mem", "key", "space-a", undefined, "host-a"),
-    sessionSyncLaneKey("session-1", "https://mem", "key", "space-a", undefined, "host-b"),
-  )
-  assert.equal(
-    sessionSyncLaneKey("session-1", "https://mem", "key", "space-a", "agent-a", "host-a"),
-    sessionSyncLaneKey("session-1", "https://mem", "key", "space-a", "agent-a", "host-a"),
-  )
+
+  const changedDestinations = [
+    ["https://mem-b", "key-a", "space-a", "agent-a", "host-a"],
+    ["https://mem-a", "key-b", "space-a", "agent-a", "host-a"],
+    ["https://mem-a", "key-a", "space-b", "agent-a", "host-a"],
+    ["https://mem-a", "key-a", "space-a", "agent-b", "host-a"],
+    ["https://mem-a", "key-a", "space-a", "agent-a", "host-b"],
+  ]
+
+  for (const destination of changedDestinations) {
+    const cursor = states.get(sessionSyncLaneKey("session-1", ...destination))
+    assert.equal(cursor, undefined)
+    assert.deepEqual(selectAcknowledgedDelta(messages, cursor, id).messages, messages)
+  }
+
+  const existingCursor = states.get(sessionSyncLaneKey("session-1", ...base))
+  assert.deepEqual(selectAcknowledgedDelta(messages, existingCursor, id).messages, [{ id: "b" }])
 })

--- a/nowledge-mem-opencode-plugin/tests/session-delta.test.mjs
+++ b/nowledge-mem-opencode-plugin/tests/session-delta.test.mjs
@@ -122,13 +122,30 @@ test("recreates the complete Thread after a 400 missing-thread response", async 
   assert.deepEqual(createBodies, [createBody])
 })
 
-test("session checkpoints are isolated by destination space", () => {
+test("session checkpoints are isolated by destination lane", () => {
+  const base = ["https://mem", "key", "space-a", "agent-a", undefined]
   assert.notEqual(
-    sessionSyncLaneKey("session-1", "space-a"),
-    sessionSyncLaneKey("session-1", "space-b"),
+    sessionSyncLaneKey("session-1", "https://mem", "key", "space-a", undefined, undefined),
+    sessionSyncLaneKey("session-1", "https://mem", "key", "space-b", undefined, undefined),
+  )
+  assert.notEqual(
+    sessionSyncLaneKey("session-1", "https://mem-a", "key", "space", undefined, undefined),
+    sessionSyncLaneKey("session-1", "https://mem-b", "key", "space", undefined, undefined),
+  )
+  assert.notEqual(
+    sessionSyncLaneKey("session-1", "https://mem", "key-a", "space", undefined, undefined),
+    sessionSyncLaneKey("session-1", "https://mem", "key-b", "space", undefined, undefined),
+  )
+  assert.notEqual(
+    sessionSyncLaneKey("session-1", ...base),
+    sessionSyncLaneKey("session-1", "https://mem", "key", "space-a", "agent-b", undefined),
+  )
+  assert.notEqual(
+    sessionSyncLaneKey("session-1", "https://mem", "key", "space-a", undefined, "host-a"),
+    sessionSyncLaneKey("session-1", "https://mem", "key", "space-a", undefined, "host-b"),
   )
   assert.equal(
-    sessionSyncLaneKey("session-1", "space-a"),
-    sessionSyncLaneKey("session-1", "space-a"),
+    sessionSyncLaneKey("session-1", "https://mem", "key", "space-a", "agent-a", "host-a"),
+    sessionSyncLaneKey("session-1", "https://mem", "key", "space-a", "agent-a", "host-a"),
   )
 })

--- a/tests/plugin_e2e/test_key_plugins_e2e.py
+++ b/tests/plugin_e2e/test_key_plugins_e2e.py
@@ -1720,7 +1720,7 @@ def test_opencode_thread_sync_timeout_contract():
     assert "timeoutMs: 10_000" not in source
     assert "NMEM_SYNC_TIMEOUT_MS" in readme
     assert "later lifecycle sync safely reconciles" in readme
-    assert "## [0.3.8] - 2026-08-19" in changelog
+    assert "## [0.3.9] - 2026-08-19" in changelog
 
 
 def test_amp_plugin_static_contract_is_self_contained():

--- a/tests/plugin_e2e/test_key_plugins_e2e.py
+++ b/tests/plugin_e2e/test_key_plugins_e2e.py
@@ -520,7 +520,7 @@ def test_key_plugin_static_contracts_are_declared():
     opencode_pkg = _read_json(OPENCODE_PLUGIN / "package.json")
     opencode_source = (OPENCODE_PLUGIN / "src" / "index.ts").read_text(encoding="utf-8")
     assert opencode_pkg["name"] == "opencode-nowledge-mem"
-    assert opencode_pkg["version"] == "0.3.8"
+    assert opencode_pkg["version"] == "0.3.9"
     assert registry_by_id["opencode"]["version"] == opencode_pkg["version"]
     assert registry_by_id["opencode"]["capabilities"]["autoCapture"] is True
     assert registry_by_id["opencode"]["autonomy"]["threads"] == "automatic-capture"
@@ -1461,7 +1461,7 @@ def test_registry_connect_contract_points_agent_prompts_to_universal_skill():
     assert by_id["droid"]["version"] == "0.1.1"
     assert by_id["openclaw"]["version"] == "0.8.31"
     assert by_id["proma"]["version"] == "0.1.5"
-    assert by_id["opencode"]["version"] == "0.3.8"
+    assert by_id["opencode"]["version"] == "0.3.9"
     assert by_id["pi"]["version"] == "0.8.7"
     assert by_id["pi"]["capabilities"]["autoRecall"] is True
     assert by_id["pi"]["autonomy"]["recall"] == "startup-context-injection"
@@ -1712,7 +1712,7 @@ def test_opencode_thread_sync_timeout_contract():
     readme = (OPENCODE_PLUGIN / "README.md").read_text(encoding="utf-8")
     changelog = (OPENCODE_PLUGIN / "CHANGELOG.md").read_text(encoding="utf-8")
 
-    assert pkg["version"] == "0.3.8"
+    assert pkg["version"] == "0.3.9"
     assert opencode_registry["version"] == pkg["version"]
     assert "DEFAULT_THREAD_SYNC_TIMEOUT_MS = 120_000" in timeout_source
     assert "resolveThreadSyncTimeoutMs(process.env.NMEM_SYNC_TIMEOUT_MS)" in source


### PR DESCRIPTION
## Summary

- Scope OpenCode session checkpoints by API URL, API key, space, agent identity, host-agent identity, and session ID.
- Prevent acknowledged cursor state from being reused after switching synchronization destinations.
- Align the OpenCode package, integration registry, README, changelog, generated bundle, and contract checks on version 0.3.9.

## Validation

- `bun test nowledge-mem-opencode-plugin/tests/session-delta.test.mjs`: 9 passed
- Targeted `test_opencode_thread_sync_timeout_contract`: passed
- `npm run check`
- `git diff --check`
- GitHub Actions and CodeRabbit checks pass on `2a0d7870` with no unresolved review threads.