### PR TITLE
fix(dsh): require host-resolved sandbox escalation

### DIFF
--- a/nowledge-mem-deepseek-harness-plugin/CHANGELOG.md
+++ b/nowledge-mem-deepseek-harness-plugin/CHANGELOG.md
@@ -2,8 +2,8 @@
 
 ## Unreleased
 
-- Requires the DSH host to resolve the `danger-full-access` policy before a
-  sandbox-unavailable `nmem` command can be retried.
+- Makes the sandbox-unavailable `danger-full-access` retry fail closed unless
+  the plugin explicitly opts in and the DSH host resolves the policy.
 - Turn-end capture now imports only events after the last acknowledged DSH
   sequence, stamps stable message external IDs, and replays safely after event
   compaction or a failed write.

--- a/nowledge-mem-deepseek-harness-plugin/CHANGELOG.md
+++ b/nowledge-mem-deepseek-harness-plugin/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Requires the DSH host to resolve the `danger-full-access` policy before a
+  sandbox-unavailable `nmem` command can be retried.
 - Turn-end capture now imports only events after the last acknowledged DSH
   sequence, stamps stable message external IDs, and replays safely after event
   compaction or a failed write.

--- a/nowledge-mem-deepseek-harness-plugin/README.md
+++ b/nowledge-mem-deepseek-harness-plugin/README.md
@@ -94,6 +94,15 @@ Mem MCP tools are registered through DSH's MCP bridge under the `nowledge_mem` n
 
 After each completed DSH turn, the plugin serializes user, assistant, and tool-result events, skips its own injected context messages, and imports the transcript into Mem as `source=deepseek-harness`.
 
+### Sandbox Compatibility Retry
+
+The plugin does not retry a sandbox-unavailable `nmem` command with
+`danger-full-access` by default. An operator who explicitly accepts that wider
+access may set `allowDangerFullAccessRetry: true` in the `nowledge-mem` plugin
+config. Even with that opt-in, the retry runs only when the DSH host provides
+`ctx.sandboxPolicy` and resolves the requested policy; otherwise it fails
+closed and logs why the retry was skipped.
+
 ## Known Limitations
 
 - DeepSeek Harness is in developer preview, so public package APIs may change.

--- a/nowledge-mem-deepseek-harness-plugin/src/index.js
+++ b/nowledge-mem-deepseek-harness-plugin/src/index.js
@@ -70,6 +70,7 @@ export const Config = z.object({
   contextOnSessionStart: z.boolean(),
   recallOnPrompt: z.boolean(),
   syncOnTurnEnd: z.boolean(),
+  allowDangerFullAccessRetry: z.boolean(),
   promptRecallPattern: z.string(),
   recallLimit: z.number(),
   maxPromptChars: z.number(),
@@ -108,6 +109,7 @@ function resolveConfig(config = {}) {
     contextOnSessionStart: config.contextOnSessionStart ?? true,
     recallOnPrompt: config.recallOnPrompt ?? true,
     syncOnTurnEnd: config.syncOnTurnEnd ?? true,
+    allowDangerFullAccessRetry: config.allowDangerFullAccessRetry ?? false,
     promptRecallPattern: new RegExp(config.promptRecallPattern ?? DEFAULT_PROMPT_RECALL_PATTERN, 'iu'),
     recallLimit: config.recallLimit ?? DEFAULT_RECALL_LIMIT,
     maxPromptChars: config.maxPromptChars ?? DEFAULT_PROMPT_MAX_CHARS,
@@ -156,7 +158,12 @@ async function runNmem(ctx, config, args, signal, includeImportOrigin, stdin, se
     stdin,
     env: envFor(config, includeImportOrigin),
   }
-  return await runShellWithHostSandboxRetry(ctx, request, session)
+  return await runShellWithHostSandboxRetry(
+    ctx,
+    request,
+    session,
+    config.allowDangerFullAccessRetry,
+  )
 }
 
 function successfulStdout(result) {

--- a/nowledge-mem-deepseek-harness-plugin/src/index.js
+++ b/nowledge-mem-deepseek-harness-plugin/src/index.js
@@ -14,6 +14,12 @@ import { join } from 'node:path'
 import z from '@deepseek-ai/schemastery'
 import { createUserMessage } from '@deepseek-ai/dsh-llm'
 
+import {
+  errorMessage,
+  isSandboxUnavailableError,
+  runShellWithHostSandboxRetry,
+  warn,
+} from './sandbox-retry.js'
 import { importAcknowledgement, selectUnacknowledgedEvents } from './session-delta.js'
 
 export const name = 'nowledge-mem'
@@ -28,7 +34,6 @@ const DEFAULT_THREAD_MESSAGE_MAX_CHARS = 16_000
 const DEFAULT_RECALL_LIMIT = 8
 const DEFAULT_TIMEOUT_MS = 8_000
 const DEFAULT_STDOUT_MAX_BYTES = 512 * 1024
-const SANDBOX_UNAVAILABLE_CODE = 'SANDBOX_UNAVAILABLE'
 const DEFAULT_PROMPT_RECALL_PATTERN = [
   'remember',
   'memory',
@@ -139,40 +144,7 @@ function envFor(config, includeImportOrigin) {
   return env
 }
 
-function errorMessage(error) {
-  if (error instanceof Error) return `${error.name}: ${error.message}`
-  return String(error)
-}
-
-function warn(ctx, message) {
-  if (typeof ctx.logger?.warn === 'function') ctx.logger.warn(message)
-}
-
-export function isSandboxUnavailableError(error) {
-  if (typeof error !== 'object' || error === null) return false
-  return error.code === SANDBOX_UNAVAILABLE_CODE || error.name === 'SandboxUnavailableError'
-}
-
-function dangerFullAccessPolicy(ctx, session) {
-  const service = typeof ctx.get === 'function' ? ctx.get('sandboxPolicy') : undefined
-  if (typeof service?.resolve === 'function') {
-    try {
-      return service.resolve(session === undefined
-        ? { mode: 'danger-full-access' }
-        : { session, mode: 'danger-full-access' })
-    } catch (error) {
-      warn(ctx, `nowledge-mem: failed to resolve danger-full-access sandbox policy: ${errorMessage(error)}`)
-    }
-  }
-  return {
-    mode: 'danger-full-access',
-    workspaceRoot: optionalString(session?.header?.cwd) ?? process.cwd(),
-  }
-}
-
-async function runShell(ctx, request) {
-  return await ctx.shell.run(ctx.shell.resolve(request))
-}
+export { isSandboxUnavailableError }
 
 async function runNmem(ctx, config, args, signal, includeImportOrigin, stdin, session) {
   const command = [config.cliPath, ...args].map(shellQuote).join(' ')
@@ -184,24 +156,7 @@ async function runNmem(ctx, config, args, signal, includeImportOrigin, stdin, se
     stdin,
     env: envFor(config, includeImportOrigin),
   }
-  try {
-    return await runShell(ctx, request)
-  } catch (error) {
-    if (!isSandboxUnavailableError(error)) {
-      warn(ctx, `nowledge-mem: nmem shell call failed: ${errorMessage(error)}`)
-      return undefined
-    }
-    warn(ctx, `nowledge-mem: nmem shell sandbox unavailable; retrying without sandbox confinement: ${errorMessage(error)}`)
-  }
-  try {
-    return await runShell(ctx, {
-      ...request,
-      sandboxPolicy: dangerFullAccessPolicy(ctx, session),
-    })
-  } catch (error) {
-    warn(ctx, `nowledge-mem: nmem shell retry failed: ${errorMessage(error)}`)
-    return undefined
-  }
+  return await runShellWithHostSandboxRetry(ctx, request, session)
 }
 
 function successfulStdout(result) {

--- a/nowledge-mem-deepseek-harness-plugin/src/sandbox-retry.js
+++ b/nowledge-mem-deepseek-harness-plugin/src/sandbox-retry.js
@@ -38,7 +38,12 @@ async function runShell(ctx, request) {
   return await ctx.shell.run(ctx.shell.resolve(request))
 }
 
-export async function runShellWithHostSandboxRetry(ctx, request, session) {
+export async function runShellWithHostSandboxRetry(
+  ctx,
+  request,
+  session,
+  allowDangerFullAccessRetry = false,
+) {
   let sandboxError
   try {
     return await runShell(ctx, request)
@@ -48,6 +53,11 @@ export async function runShellWithHostSandboxRetry(ctx, request, session) {
       return undefined
     }
     sandboxError = error
+  }
+
+  if (!allowDangerFullAccessRetry) {
+    warn(ctx, `nowledge-mem: nmem shell sandbox unavailable and danger-full-access retry is not enabled; skipping retry: ${errorMessage(sandboxError)}`)
+    return undefined
   }
 
   const sandboxPolicy = resolveDangerFullAccessPolicy(ctx, session)

--- a/nowledge-mem-deepseek-harness-plugin/src/sandbox-retry.js
+++ b/nowledge-mem-deepseek-harness-plugin/src/sandbox-retry.js
@@ -1,0 +1,66 @@
+const SANDBOX_UNAVAILABLE_CODE = 'SANDBOX_UNAVAILABLE'
+
+export function errorMessage(error) {
+  if (error instanceof Error) return `${error.name}: ${error.message}`
+  return String(error)
+}
+
+export function warn(ctx, message) {
+  if (typeof ctx.logger?.warn === 'function') ctx.logger.warn(message)
+}
+
+export function isSandboxUnavailableError(error) {
+  if (typeof error !== 'object' || error === null) return false
+  return error.code === SANDBOX_UNAVAILABLE_CODE || error.name === 'SandboxUnavailableError'
+}
+
+export function resolveDangerFullAccessPolicy(ctx, session) {
+  let service
+  try {
+    service = typeof ctx.get === 'function' ? ctx.get('sandboxPolicy') : undefined
+  } catch (error) {
+    warn(ctx, `nowledge-mem: failed to access sandbox policy service: ${errorMessage(error)}`)
+    return undefined
+  }
+  if (typeof service?.resolve !== 'function') return undefined
+
+  try {
+    return service.resolve(session === undefined
+      ? { mode: 'danger-full-access' }
+      : { session, mode: 'danger-full-access' }) ?? undefined
+  } catch (error) {
+    warn(ctx, `nowledge-mem: failed to resolve danger-full-access sandbox policy: ${errorMessage(error)}`)
+    return undefined
+  }
+}
+
+async function runShell(ctx, request) {
+  return await ctx.shell.run(ctx.shell.resolve(request))
+}
+
+export async function runShellWithHostSandboxRetry(ctx, request, session) {
+  let sandboxError
+  try {
+    return await runShell(ctx, request)
+  } catch (error) {
+    if (!isSandboxUnavailableError(error)) {
+      warn(ctx, `nowledge-mem: nmem shell call failed: ${errorMessage(error)}`)
+      return undefined
+    }
+    sandboxError = error
+  }
+
+  const sandboxPolicy = resolveDangerFullAccessPolicy(ctx, session)
+  if (sandboxPolicy === undefined) {
+    warn(ctx, `nowledge-mem: nmem shell sandbox unavailable and host did not grant danger-full-access; skipping retry: ${errorMessage(sandboxError)}`)
+    return undefined
+  }
+
+  warn(ctx, `nowledge-mem: nmem shell sandbox unavailable; retrying with host-resolved danger-full-access policy: ${errorMessage(sandboxError)}`)
+  try {
+    return await runShell(ctx, { ...request, sandboxPolicy })
+  } catch (error) {
+    warn(ctx, `nowledge-mem: nmem shell retry failed: ${errorMessage(error)}`)
+    return undefined
+  }
+}

--- a/nowledge-mem-deepseek-harness-plugin/tests/sandbox-retry.test.mjs
+++ b/nowledge-mem-deepseek-harness-plugin/tests/sandbox-retry.test.mjs
@@ -1,0 +1,124 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+
+import { runShellWithHostSandboxRetry } from '../src/sandbox-retry.js'
+
+function sandboxUnavailable() {
+  return Object.assign(new Error('sandbox unavailable'), { code: 'SANDBOX_UNAVAILABLE' })
+}
+
+function testContext({ policyService, policyServiceError, runResults }) {
+  const requests = []
+  const warnings = []
+  const ctx = {
+    logger: {
+      warn(message) {
+        warnings.push(message)
+      },
+    },
+    shell: {
+      resolve(request) {
+        return request
+      },
+      async run(request) {
+        requests.push(request)
+        const result = runResults.shift()
+        if (result instanceof Error) throw result
+        return result
+      },
+    },
+  }
+  if (policyService !== undefined || policyServiceError !== undefined) {
+    ctx.get = key => {
+      assert.equal(key, 'sandboxPolicy')
+      if (policyServiceError !== undefined) throw policyServiceError
+      return policyService
+    }
+  }
+  return { ctx, requests, warnings }
+}
+
+test('does not resolve a privileged policy when the normal shell call succeeds', async () => {
+  const success = { exitCode: 0, stdout: { text: 'ok' } }
+  const fixture = testContext({
+    policyServiceError: new Error('must not resolve'),
+    runResults: [success],
+  })
+
+  const result = await runShellWithHostSandboxRetry(fixture.ctx, { command: 'nmem status' })
+
+  assert.equal(result, success)
+  assert.equal(fixture.requests.length, 1)
+  assert.deepEqual(fixture.warnings, [])
+})
+
+test('skips the privileged retry when the host has no sandbox policy service', async () => {
+  const fixture = testContext({ runResults: [sandboxUnavailable()] })
+
+  const result = await runShellWithHostSandboxRetry(fixture.ctx, { command: 'nmem status' })
+
+  assert.equal(result, undefined)
+  assert.equal(fixture.requests.length, 1)
+  assert.match(fixture.warnings.at(-1), /host did not grant danger-full-access; skipping retry/)
+})
+
+test('skips the privileged retry when host policy resolution throws', async () => {
+  const fixture = testContext({
+    policyService: {
+      resolve() {
+        throw new Error('policy denied')
+      },
+    },
+    runResults: [sandboxUnavailable()],
+  })
+
+  const result = await runShellWithHostSandboxRetry(fixture.ctx, { command: 'nmem status' })
+
+  assert.equal(result, undefined)
+  assert.equal(fixture.requests.length, 1)
+  assert.ok(fixture.warnings.some(message => message.includes('failed to resolve danger-full-access sandbox policy')))
+  assert.match(fixture.warnings.at(-1), /host did not grant danger-full-access; skipping retry/)
+})
+
+test('skips the privileged retry when host policy service lookup throws', async () => {
+  const fixture = testContext({
+    policyServiceError: new Error('service unavailable'),
+    runResults: [sandboxUnavailable()],
+  })
+
+  const result = await runShellWithHostSandboxRetry(fixture.ctx, { command: 'nmem status' })
+
+  assert.equal(result, undefined)
+  assert.equal(fixture.requests.length, 1)
+  assert.ok(fixture.warnings.some(message => message.includes('failed to access sandbox policy service')))
+  assert.match(fixture.warnings.at(-1), /host did not grant danger-full-access; skipping retry/)
+})
+
+test('retries exactly once with a host-resolved sandbox policy', async () => {
+  const policy = { mode: 'danger-full-access', workspaceRoot: '/workspace' }
+  const session = { header: { id: 'session-1' } }
+  const resolveCalls = []
+  const success = { exitCode: 0, stdout: { text: 'ok' } }
+  const fixture = testContext({
+    policyService: {
+      resolve(request) {
+        resolveCalls.push(request)
+        return policy
+      },
+    },
+    runResults: [sandboxUnavailable(), success],
+  })
+
+  const result = await runShellWithHostSandboxRetry(
+    fixture.ctx,
+    { command: 'nmem status' },
+    session,
+  )
+
+  assert.equal(result, success)
+  assert.deepEqual(resolveCalls, [{ session, mode: 'danger-full-access' }])
+  assert.equal(fixture.requests.length, 2)
+  assert.equal(fixture.requests[0].sandboxPolicy, undefined)
+  assert.equal(fixture.requests[1].sandboxPolicy, policy)
+  assert.ok(fixture.warnings.some(message => message.includes('host-resolved danger-full-access policy')))
+})

--- a/nowledge-mem-deepseek-harness-plugin/tests/sandbox-retry.test.mjs
+++ b/nowledge-mem-deepseek-harness-plugin/tests/sandbox-retry.test.mjs
@@ -55,7 +55,12 @@ test('does not resolve a privileged policy when the normal shell call succeeds',
 test('skips the privileged retry when the host has no sandbox policy service', async () => {
   const fixture = testContext({ runResults: [sandboxUnavailable()] })
 
-  const result = await runShellWithHostSandboxRetry(fixture.ctx, { command: 'nmem status' })
+  const result = await runShellWithHostSandboxRetry(
+    fixture.ctx,
+    { command: 'nmem status' },
+    undefined,
+    true,
+  )
 
   assert.equal(result, undefined)
   assert.equal(fixture.requests.length, 1)
@@ -72,7 +77,12 @@ test('skips the privileged retry when host policy resolution throws', async () =
     runResults: [sandboxUnavailable()],
   })
 
-  const result = await runShellWithHostSandboxRetry(fixture.ctx, { command: 'nmem status' })
+  const result = await runShellWithHostSandboxRetry(
+    fixture.ctx,
+    { command: 'nmem status' },
+    undefined,
+    true,
+  )
 
   assert.equal(result, undefined)
   assert.equal(fixture.requests.length, 1)
@@ -86,12 +96,30 @@ test('skips the privileged retry when host policy service lookup throws', async 
     runResults: [sandboxUnavailable()],
   })
 
-  const result = await runShellWithHostSandboxRetry(fixture.ctx, { command: 'nmem status' })
+  const result = await runShellWithHostSandboxRetry(
+    fixture.ctx,
+    { command: 'nmem status' },
+    undefined,
+    true,
+  )
 
   assert.equal(result, undefined)
   assert.equal(fixture.requests.length, 1)
   assert.ok(fixture.warnings.some(message => message.includes('failed to access sandbox policy service')))
   assert.match(fixture.warnings.at(-1), /host did not grant danger-full-access; skipping retry/)
+})
+
+test('does not resolve a privileged policy without explicit plugin opt-in', async () => {
+  const fixture = testContext({
+    policyServiceError: new Error('must not resolve'),
+    runResults: [sandboxUnavailable()],
+  })
+
+  const result = await runShellWithHostSandboxRetry(fixture.ctx, { command: 'nmem status' })
+
+  assert.equal(result, undefined)
+  assert.equal(fixture.requests.length, 1)
+  assert.match(fixture.warnings.at(-1), /danger-full-access retry is not enabled; skipping retry/)
 })
 
 test('retries exactly once with a host-resolved sandbox policy', async () => {
@@ -113,6 +141,7 @@ test('retries exactly once with a host-resolved sandbox policy', async () => {
     fixture.ctx,
     { command: 'nmem status' },
     session,
+    true,
   )
 
   assert.equal(result, success)

--- a/tests/plugin_e2e/test_key_plugins_e2e.py
+++ b/tests/plugin_e2e/test_key_plugins_e2e.py
@@ -1577,6 +1577,9 @@ def test_deepseek_harness_plugin_static_contract_is_self_contained():
     pkg = _read_json(DEEPSEEK_HARNESS_PLUGIN / "package.json")
     patch = (DEEPSEEK_HARNESS_PLUGIN / "cordis.patch.yml").read_text(encoding="utf-8")
     source = (DEEPSEEK_HARNESS_PLUGIN / "src" / "index.js").read_text(encoding="utf-8")
+    sandbox_retry = (DEEPSEEK_HARNESS_PLUGIN / "src" / "sandbox-retry.js").read_text(
+        encoding="utf-8"
+    )
     readme = (DEEPSEEK_HARNESS_PLUGIN / "README.md").read_text(encoding="utf-8")
     registry = _read_json(COMMUNITY_ROOT / "integrations.json")
     dsh_registry = next(
@@ -1612,9 +1615,10 @@ def test_deepseek_harness_plugin_static_contract_is_self_contained():
     assert "ctx.on('agent/pre-step'" in source
     assert "ctx.on('session/event'" in source
     assert "event.type === 'turn/end'" in source
-    assert "SANDBOX_UNAVAILABLE" in source
+    assert "SANDBOX_UNAVAILABLE" in sandbox_retry
     assert "isSandboxUnavailableError" in source
-    assert "sandboxPolicy: dangerFullAccessPolicy(ctx, session)" in source
+    assert "runShellWithHostSandboxRetry(ctx, request, session)" in source
+    assert "host did not grant danger-full-access; skipping retry" in sandbox_retry
     assert "pre-step context injection failed" in source
     assert "turn-end transcript import failed" in source
     assert "'--json', 'context', '--source-app', config.sourceApp" in source

--- a/tests/plugin_e2e/test_key_plugins_e2e.py
+++ b/tests/plugin_e2e/test_key_plugins_e2e.py
@@ -1617,8 +1617,10 @@ def test_deepseek_harness_plugin_static_contract_is_self_contained():
     assert "event.type === 'turn/end'" in source
     assert "SANDBOX_UNAVAILABLE" in sandbox_retry
     assert "isSandboxUnavailableError" in source
-    assert "runShellWithHostSandboxRetry(ctx, request, session)" in source
+    assert "runShellWithHostSandboxRetry(" in source
+    assert "allowDangerFullAccessRetry: config.allowDangerFullAccessRetry ?? false" in source
     assert "host did not grant danger-full-access; skipping retry" in sandbox_retry
+    assert "danger-full-access retry is not enabled; skipping retry" in sandbox_retry
     assert "pre-step context injection failed" in source
     assert "turn-end transcript import failed" in source
     assert "'--json', 'context', '--source-app', config.sourceApp" in source


### PR DESCRIPTION
### Issue

Issue Number: close #523

### Background

The DeepSeek Harness plugin invokes `nmem` through the host shell and retains a compatibility retry for `SANDBOX_UNAVAILABLE`. The upstream DSH sandbox contract separates approval from policy resolution: `approveEscalation(...)` obtains consent, while `ctx.sandboxPolicy.resolve({ mode })` only resolves an already-approved wider mode.

### What problem does this PR solve?

When the host omitted `sandboxPolicy`, or when `sandboxPolicy.resolve(...)` threw, the plugin fabricated its own `danger-full-access` policy and retried anyway. A compatibility fallback could therefore silently widen filesystem access without a host-resolved policy.

### How does it work?

- Moves shell retry behavior into dependency-free `src/sandbox-retry.js` so the complete decision boundary can be tested without unpublished DSH peer packages.
- Runs the normal shell request first and does not consult privileged policy on success.
- Adds `allowDangerFullAccessRetry`, defaulting to `false`, because this internal hook has no DSH tool-call approval context.
- On `SANDBOX_UNAVAILABLE`, the plugin first requires that explicit opt-in, then asks the host's `sandboxPolicy` service to resolve the `danger-full-access` request.
- Disabled opt-in, missing service, service lookup failure, resolver failure, or an empty resolution all fail closed: the plugin logs a bounded diagnostic and skips the retry.
- Explicit opt-in plus a concrete host-resolved policy permits exactly one retry, and the policy is passed through unchanged.
- Non-sandbox failures and retry failures retain the existing warning-and-return behavior.

This does not change normal `nmem` arguments, environment propagation, session identity, Space routing, or transcript import semantics. The package version remains unchanged in this PR because concurrent PR #513 owns the pending `0.1.3` release bump; merge ordering will determine the next standalone release version.

### Tests

- [x] Unit test
  - `node --check src/index.js && node --check src/sandbox-retry.js && node --test tests/*.test.mjs`
  - Result: 11 passed, 0 failed.
  - Covers normal success, default-disabled retry, missing policy service, throwing service lookup, throwing policy resolution, and exactly one explicitly enabled host-resolved retry.
- [x] Integration/static contract
  - `python -m pytest tests/plugin_e2e/test_key_plugins_e2e.py -k deepseek_harness -q`
  - Result: 1 passed, 32 deselected.
- [x] Baseline comparison
  - The full `test_key_plugins_e2e.py` suite reports the same 3 unrelated Copilot/WorkBuddy/Kimi failures on this branch and a clean detached `origin/main@073e363f`; this PR adds no full-suite regression.
- [x] Diff validation
  - `git diff --check` is clean.

### Side effects / risks

- The compatibility retry is now disabled by default. Operators must set `allowDangerFullAccessRetry: true` only when they explicitly accept the wider access.
- Older DSH compositions without `ctx.sandboxPolicy` cannot retry even after opt-in. This is intentional fail-closed behavior; the original command still runs normally when the configured shell backend can execute it.
- The retry continues to request `danger-full-access`, but the plugin can neither approve nor construct that policy locally.
- No schema, persistence format, public protocol, or database changes.
