### PR TITLE
fix(dsh): keep incremental thread titles stable

### DIFF
--- a/nowledge-mem-deepseek-harness-plugin/CHANGELOG.md
+++ b/nowledge-mem-deepseek-harness-plugin/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Keeps the imported thread title session-scoped across incremental batches and
+  rebuilds reconciliation arguments from the full payload.
 - Turn-end capture now imports only events after the last acknowledged DSH
   sequence, stamps stable message external IDs, and replays safely after event
   compaction or a failed write.

--- a/nowledge-mem-deepseek-harness-plugin/src/index.js
+++ b/nowledge-mem-deepseek-harness-plugin/src/index.js
@@ -7,7 +7,6 @@
  * after completed turns.
  */
 
-import { createHash } from 'node:crypto'
 import { mkdtemp, rm, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
@@ -15,6 +14,11 @@ import z from '@deepseek-ai/schemastery'
 import { createUserMessage } from '@deepseek-ai/dsh-llm'
 
 import { importAcknowledgement, selectUnacknowledgedEvents } from './session-delta.js'
+import {
+  boundText,
+  buildThreadImportArgs,
+  sessionThreadTitle,
+} from './thread-import.js'
 
 export const name = 'nowledge-mem'
 export const inject = ['agents', 'shell']
@@ -83,11 +87,7 @@ function optionalString(value) {
   return trimmed === undefined || trimmed === '' ? undefined : trimmed
 }
 
-export function boundText(text, maxChars) {
-  if (text.length <= maxChars) return text
-  if (maxChars <= 1) return text.slice(0, Math.max(0, maxChars))
-  return `${text.slice(0, maxChars - 1)}...`
-}
+export { boundText }
 
 function requireSafeInteger(field, value, minimum) {
   if (!Number.isSafeInteger(value) || value < minimum) {
@@ -377,19 +377,7 @@ function importRole(event) {
   }
 }
 
-function firstUserTitle(messages, sessionId) {
-  const firstUser = messages.find(message => message.role === 'user')
-  if (firstUser === undefined) return `DeepSeek Harness ${sessionId}`
-  const firstLine = firstUser.content.split(/\r?\n/u).find(line => line.trim() !== '')?.trim()
-  return firstLine === undefined ? `DeepSeek Harness ${sessionId}` : boundText(firstLine, 80)
-}
-
-function stableThreadId(sessionId) {
-  const safe = sessionId.replace(/[^A-Za-z0-9._-]+/gu, '-').replace(/^-+|-+$/gu, '')
-  return `deepseek-harness-${safe === '' ? 'session' : safe}`
-}
-
-function buildThreadImportDelta(session, maxMessageChars, sourceApp, acknowledgedSeq) {
+function buildThreadImportDelta(session, maxMessageChars, sourceApp, acknowledgedSeq, title) {
   const delta = selectUnacknowledgedEvents(session.events, acknowledgedSeq)
   const messages = []
   const sessionId = String(session.header.id)
@@ -430,7 +418,7 @@ function buildThreadImportDelta(session, maxMessageChars, sourceApp, acknowledge
     acknowledgedSeq: delta.nextSeq,
     reset: delta.reset,
     payload: {
-      title: firstUserTitle(messages, sessionId),
+      title,
       messages,
       metadata: {
         source_app: sourceApp,
@@ -445,48 +433,49 @@ function buildThreadImportDelta(session, maxMessageChars, sourceApp, acknowledge
 }
 
 export function buildThreadImportPayload(session, maxMessageChars, sourceApp = DEFAULT_SOURCE_APP) {
-  return buildThreadImportDelta(session, maxMessageChars, sourceApp, -1)?.payload
+  const sessionId = String(session.header.id)
+  const title = sessionThreadTitle(
+    session.events,
+    sessionId,
+    name,
+    messageText,
+    maxMessageChars,
+  )
+  return buildThreadImportDelta(session, maxMessageChars, sourceApp, -1, title)?.payload
 }
 
 async function importSession(ctx, config, session, cursor) {
+  const sessionId = String(session.header.id)
+  const title = sessionThreadTitle(
+    session.events,
+    sessionId,
+    name,
+    messageText,
+    config.maxThreadMessageChars,
+    cursor?.title,
+  )
   let delta = buildThreadImportDelta(
     session,
     config.maxThreadMessageChars,
     config.sourceApp,
     cursor?.seq ?? -1,
+    title,
   )
   if (delta === undefined) return undefined
   let payload = delta.payload
   const staging = await mkdtemp(join(tmpdir(), 'dsh-nowledge-mem-'))
   const file = join(staging, 'thread.json')
   try {
-    const baseImportArgs = [
-      '--json',
-      't',
-      'import',
-      '--file',
-      file,
-      '--source',
-      config.sourceApp,
-      '--id',
-      stableThreadId(String(session.header.id)),
-      '--title',
-      payload.title,
-    ]
-    if (config.spaceId !== undefined) baseImportArgs.push('--space-id', config.spaceId)
-    if (config.agentId !== undefined) baseImportArgs.push('--agent-id', config.agentId)
     const expectedMessageCount = cursor !== undefined && !delta.reset ? cursor.count : undefined
-    const importArgs = [...baseImportArgs]
-    if (expectedMessageCount !== undefined) {
-      const batchFingerprint = createHash('sha256')
-        .update(JSON.stringify(payload.messages))
-        .digest('hex')
-      importArgs.push('--expected-message-count', String(expectedMessageCount))
-      importArgs.push(
-        '--idempotency-key',
-        `deepseek-harness:${session.header.id}:${expectedMessageCount}-${expectedMessageCount + payload.messages.length}:${batchFingerprint}`,
-      )
-    }
+    let importArgs = buildThreadImportArgs({
+      file,
+      sourceApp: config.sourceApp,
+      sessionId,
+      payload,
+      spaceId: config.spaceId,
+      agentId: config.agentId,
+      expectedMessageCount,
+    })
     await writeFile(file, JSON.stringify(payload), { mode: 0o600 })
     let result = await runNmem(ctx, config, importArgs, undefined, true, undefined, session)
     let stdout = successfulStdout(result)
@@ -499,12 +488,21 @@ async function importSession(ctx, config, session, cursor) {
         config.maxThreadMessageChars,
         config.sourceApp,
         -1,
+        title,
       )
       if (reconciliation === undefined) return undefined
       delta = reconciliation
       payload = reconciliation.payload
+      importArgs = buildThreadImportArgs({
+        file,
+        sourceApp: config.sourceApp,
+        sessionId,
+        payload,
+        spaceId: config.spaceId,
+        agentId: config.agentId,
+      })
       await writeFile(file, JSON.stringify(payload), { mode: 0o600 })
-      result = await runNmem(ctx, config, baseImportArgs, undefined, true, undefined, session)
+      result = await runNmem(ctx, config, importArgs, undefined, true, undefined, session)
       stdout = successfulStdout(result)
       acknowledgement = stdout === undefined
         ? { status: 'failed' }
@@ -514,6 +512,7 @@ async function importSession(ctx, config, session, cursor) {
     return {
       seq: delta.acknowledgedSeq,
       count: acknowledgement.messageCount,
+      title,
     }
   } finally {
     await rm(staging, { recursive: true, force: true })

--- a/nowledge-mem-deepseek-harness-plugin/src/thread-import.js
+++ b/nowledge-mem-deepseek-harness-plugin/src/thread-import.js
@@ -1,0 +1,69 @@
+import { createHash } from 'node:crypto'
+
+export function boundText(text, maxChars) {
+  if (text.length <= maxChars) return text
+  if (maxChars <= 1) return text.slice(0, Math.max(0, maxChars))
+  return `${text.slice(0, maxChars - 1)}...`
+}
+
+export function sessionThreadTitle(
+  events,
+  sessionId,
+  pluginName,
+  renderMessage,
+  maxMessageChars,
+  establishedTitle,
+) {
+  if (typeof establishedTitle === 'string' && establishedTitle !== '') return establishedTitle
+  for (const event of events) {
+    if (event.type !== 'user/message') continue
+    const message = event.data
+    if (message?.source?.kind === 'plugin' && message.source.plugin === pluginName) continue
+    const content = boundText(renderMessage(message).trim(), maxMessageChars)
+    const firstLine = content.split(/\r?\n/u).find(line => line.trim() !== '')?.trim()
+    if (firstLine !== undefined) return boundText(firstLine, 80)
+  }
+  return `DeepSeek Harness ${sessionId}`
+}
+
+export function stableThreadId(sessionId) {
+  const safe = sessionId.replace(/[^A-Za-z0-9._-]+/gu, '-').replace(/^-+|-+$/gu, '')
+  return `deepseek-harness-${safe === '' ? 'session' : safe}`
+}
+
+export function buildThreadImportArgs({
+  file,
+  sourceApp,
+  sessionId,
+  payload,
+  spaceId,
+  agentId,
+  expectedMessageCount,
+}) {
+  const args = [
+    '--json',
+    't',
+    'import',
+    '--file',
+    file,
+    '--source',
+    sourceApp,
+    '--id',
+    stableThreadId(sessionId),
+    '--title',
+    payload.title,
+  ]
+  if (spaceId !== undefined) args.push('--space-id', spaceId)
+  if (agentId !== undefined) args.push('--agent-id', agentId)
+  if (expectedMessageCount === undefined) return args
+
+  const batchFingerprint = createHash('sha256')
+    .update(JSON.stringify(payload.messages))
+    .digest('hex')
+  args.push('--expected-message-count', String(expectedMessageCount))
+  args.push(
+    '--idempotency-key',
+    `deepseek-harness:${sessionId}:${expectedMessageCount}-${expectedMessageCount + payload.messages.length}:${batchFingerprint}`,
+  )
+  return args
+}

--- a/nowledge-mem-deepseek-harness-plugin/tests/thread-import.test.mjs
+++ b/nowledge-mem-deepseek-harness-plugin/tests/thread-import.test.mjs
@@ -1,0 +1,91 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+
+import {
+  buildThreadImportArgs,
+  sessionThreadTitle,
+} from '../src/thread-import.js'
+
+function userEvent(seq, content, source = { kind: 'user' }) {
+  return {
+    type: 'user/message',
+    seq,
+    data: { content, source },
+  }
+}
+
+function argumentValue(args, name) {
+  const index = args.indexOf(name)
+  return index < 0 ? undefined : args[index + 1]
+}
+
+test('keeps one session-scoped title when later or compacted windows start elsewhere', () => {
+  const events = [
+    userEvent(1, 'Injected context', { kind: 'plugin', plugin: 'nowledge-mem' }),
+    userEvent(2, '\nOriginal session question\nmore detail'),
+    { type: 'assistant/message', seq: 3 },
+    userEvent(4, 'Later continuation prompt'),
+  ]
+
+  const title = sessionThreadTitle(
+    events,
+    'session-1',
+    'nowledge-mem',
+    message => message.content,
+    16_000,
+  )
+
+  assert.equal(title, 'Original session question')
+  assert.notEqual(title, events.at(-1).data.content)
+
+  const compactedTitle = sessionThreadTitle(
+    [events.at(-1)],
+    'session-1',
+    'nowledge-mem',
+    message => message.content,
+    16_000,
+    title,
+  )
+  assert.equal(compactedTitle, 'Original session question')
+})
+
+test('rebuilds reconciliation arguments from the full payload', () => {
+  const deltaPayload = {
+    title: 'Later continuation prompt',
+    messages: [{ role: 'user', content: 'Later continuation prompt' }],
+  }
+  const fullPayload = {
+    title: 'Original session question',
+    messages: [
+      { role: 'user', content: 'Original session question' },
+      { role: 'user', content: 'Later continuation prompt' },
+    ],
+  }
+
+  const deltaArgs = buildThreadImportArgs({
+    file: '/tmp/thread.json',
+    sourceApp: 'deepseek-harness',
+    sessionId: 'session-1',
+    payload: deltaPayload,
+    spaceId: 'space-1',
+    agentId: 'agent-1',
+    expectedMessageCount: 3,
+  })
+  const reconciliationArgs = buildThreadImportArgs({
+    file: '/tmp/thread.json',
+    sourceApp: 'deepseek-harness',
+    sessionId: 'session-1',
+    payload: fullPayload,
+    spaceId: 'space-1',
+    agentId: 'agent-1',
+  })
+
+  assert.equal(argumentValue(deltaArgs, '--title'), deltaPayload.title)
+  assert.equal(argumentValue(deltaArgs, '--expected-message-count'), '3')
+  assert.match(argumentValue(deltaArgs, '--idempotency-key'), /^deepseek-harness:session-1:3-4:/u)
+  assert.equal(argumentValue(reconciliationArgs, '--title'), fullPayload.title)
+  assert.equal(argumentValue(reconciliationArgs, '--expected-message-count'), undefined)
+  assert.equal(argumentValue(reconciliationArgs, '--idempotency-key'), undefined)
+  assert.equal(argumentValue(reconciliationArgs, '--space-id'), 'space-1')
+  assert.equal(argumentValue(reconciliationArgs, '--agent-id'), 'agent-1')
+})

--- a/tests/plugin_e2e/test_key_plugins_e2e.py
+++ b/tests/plugin_e2e/test_key_plugins_e2e.py
@@ -1611,6 +1611,7 @@ def test_deepseek_harness_plugin_static_contract_is_self_contained():
     assert "typeof value === 'string' && value.length > 0" in patch
     assert "'X-NMEM-Agent-ID': process.env.NMEM_AGENT_ID" in patch
     assert "sessionThreadTitle(" in source
+    assert "cursor?.title" in source
     assert source.count("buildThreadImportArgs({") == 2
     assert "payload.title" in thread_import
     assert "expectedMessageCount === undefined" in thread_import

--- a/tests/plugin_e2e/test_key_plugins_e2e.py
+++ b/tests/plugin_e2e/test_key_plugins_e2e.py
@@ -1577,6 +1577,9 @@ def test_deepseek_harness_plugin_static_contract_is_self_contained():
     pkg = _read_json(DEEPSEEK_HARNESS_PLUGIN / "package.json")
     patch = (DEEPSEEK_HARNESS_PLUGIN / "cordis.patch.yml").read_text(encoding="utf-8")
     source = (DEEPSEEK_HARNESS_PLUGIN / "src" / "index.js").read_text(encoding="utf-8")
+    thread_import = (DEEPSEEK_HARNESS_PLUGIN / "src" / "thread-import.js").read_text(
+        encoding="utf-8"
+    )
     readme = (DEEPSEEK_HARNESS_PLUGIN / "README.md").read_text(encoding="utf-8")
     registry = _read_json(COMMUNITY_ROOT / "integrations.json")
     dsh_registry = next(
@@ -1607,6 +1610,10 @@ def test_deepseek_harness_plugin_static_contract_is_self_contained():
     assert "Object.fromEntries(Object.entries" in patch
     assert "typeof value === 'string' && value.length > 0" in patch
     assert "'X-NMEM-Agent-ID': process.env.NMEM_AGENT_ID" in patch
+    assert "sessionThreadTitle(" in source
+    assert source.count("buildThreadImportArgs({") == 2
+    assert "payload.title" in thread_import
+    assert "expectedMessageCount === undefined" in thread_import
 
     assert "export const inject = ['agents', 'shell']" in source
     assert "ctx.on('agent/pre-step'" in source


### PR DESCRIPTION
### Issue

Issue Number: ref #524

### Background

The DeepSeek Harness plugin incrementally imports surface events into one stable Nowledge Mem thread. A live cursor carries the acknowledged DSH sequence and server message count; conflicts fall back to a full reconciliation import.

### What problem does this PR solve?

Each delta previously derived `payload.title` from that batch's first user message. The same stable thread identity was therefore submitted with different titles over time. On checkpoint conflict, `payload` was replaced with the full reconciliation payload, but the CLI arguments retained the earlier delta title.

The current Mem append path does not overwrite an existing persisted title, so this is not presently a stored-title rename. It is still an inconsistent import contract: response metadata and submitted arguments can drift from the payload, and future consumers cannot safely assume one session has one title.

### How does it work?

- Adds dependency-free `src/thread-import.js` for bounded title selection, stable thread IDs, and payload-to-CLI argument construction.
- Derives the title from the session's first non-plugin, non-empty user message rather than the delta slice.
- Stores the established title in the live acknowledged cursor. Later batches and compacted event windows reuse it even when the original first user event is no longer present.
- Builds optimistic append arguments from the delta payload, retaining `--expected-message-count` and the stable batch idempotency key.
- After a checkpoint conflict, rebuilds arguments from the full reconciliation payload and deliberately omits optimistic append fields.

Stable thread identity, message external IDs, Space/Agent routing, checkpoint acknowledgement, exact replay, and compaction replay behavior are unchanged. The package version remains coordinated with concurrent PR #513, which owns the pending `0.1.3` bump.

### Tests

- [x] Unit test
  - `node --check src/index.js && node --check src/thread-import.js && node --test tests/*.test.mjs`
  - Result: 7 passed, 0 failed.
  - Covers first-user session title selection, exclusion of prompts generated by any plugin, established-title reuse for a later/compacted window, payload-matched title arguments, and removal of checkpoint/idempotency fields during reconciliation.
- [x] Integration/static contract
  - `python -m pytest tests/plugin_e2e/test_key_plugins_e2e.py -k deepseek_harness -q`
  - Result: 1 passed, 32 deselected.
- [x] Baseline comparison
  - The full key-plugin suite reports 3 unrelated Copilot/WorkBuddy/Kimi failures on this branch, identical to clean `origin/main@073e363f`: 3 failed, 23 passed, 7 skipped.
- [x] Diff validation
  - `git diff --check` is clean.
- [ ] Current merged head
  - Local tests were not rerun after merging current `main` and extending the cross-plugin title regression; fresh CI is pending on the updated head.

### Side effects / risks

- The title is durable for the lifetime of the plugin's existing in-memory cursor. If the plugin restarts after DSH has already compacted away the original user event, the original title cannot be reconstructed from the remaining DSH event window; the server's existing append path still preserves its persisted title.
- The helper imports only Node's cross-platform `node:crypto`; no shell- or path-specific behavior is introduced.
- No schema, database, public protocol, or persistent-format changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Imported thread titles now remain consistent across incremental batches and compaction.
  * Conflict reconciliation now uses the complete payload, preserving accurate message counts and identifiers.
  * Plugin-generated messages are excluded when determining thread titles.

* **Refactor**
  * Improved thread import handling for titles, stable identifiers, and command-line options.

* **Tests**
  * Added coverage for title stability, reconciliation behavior, optional message counts, and identifier preservation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->