### PR TITLE
feat(openai): add universal ChatGPT and Codex plugin

### DIFF
--- a/integrations.json
+++ b/integrations.json
@@ -1849,6 +1849,64 @@
       "slashCommands": []
     },
     {
+      "id": "openai-plugin",
+      "name": "ChatGPT and Codex Plugin",
+      "category": "surface",
+      "type": "plugin",
+      "version": "0.1.0",
+      "directory": "nowledge-mem-openai-plugin",
+      "transport": "plugin+mcp+oauth",
+      "capabilities": {
+        "workingMemory": true,
+        "search": true,
+        "distill": true,
+        "autoRecall": false,
+        "autoCapture": false,
+        "graphExploration": false,
+        "status": true
+      },
+      "threadSave": {
+        "method": "explicit-handoff",
+        "note": "ChatGPT uses the public Cloud MCP surface; Codex lifecycle hooks remain in the dedicated Codex connector. This universal package does not claim automatic ChatGPT transcript sync."
+      },
+      "autonomy": {
+        "bootstrap": "guided",
+        "recall": "guided",
+        "distill": "guided",
+        "threads": "handoff-only",
+        "bestResultRequires": [
+          "Complete the OpenAI public plugin review before listing the package as available",
+          "Authorize the production Cloud MCP connection through standard OAuth",
+          "Use the dedicated Codex connector when Codex hooks or automatic thread capture are required",
+          "Use explicit save-thread or handoff instructions in ChatGPT when a durable record is needed"
+        ]
+      },
+      "install": {
+        "command": "OpenAI plugin submission and public directory",
+        "detectionHint": "ChatGPT or Codex supports the OpenAI universal Plugins Directory",
+        "configRequired": "Use the OpenAI-hosted OAuth flow for https://cloud.nowledge.co/mcp. Do not paste a local desktop URL into the public plugin listing.",
+        "agentGuide": {
+          "prompt": "Use the Nowledge Mem ChatGPT/Codex plugin for context search, Working Memory, and explicit durable handoffs. ChatGPT does not have Codex's local lifecycle hooks, so save a thread or handoff explicitly when the work should be retained.",
+          "promptZh": "使用 Nowledge Mem 的 ChatGPT/Codex 插件读取工作记忆、搜索已有知识，并在需要时明确保存长期结论。ChatGPT 没有 Codex 的本地生命周期 hooks；需要留存完整工作时，请明确执行保存 thread 或 handoff。"
+        },
+        "docsUrl": "/docs/integrations/openai-plugin"
+      },
+      "toolNaming": {
+        "convention": "mcp-backend",
+        "note": "OpenAI hosts expose the Cloud MCP tools according to their own namespace. The package does not invent a separate tool namespace or alter the dedicated Codex connector."
+      },
+      "standard": {
+        "name": "OpenAI Plugins",
+        "version": "universal-directory",
+        "manifest": ".codex-plugin/plugin.json",
+        "mcp": ".mcp.json",
+        "packagePath": "nowledge-mem-openai-plugin",
+        "compatibleWhen": "The user installs the reviewed public Nowledge Mem plugin from the ChatGPT/Codex universal directory"
+      },
+      "skills": ["read-working-memory", "search-memory", "distill-memory", "save-handoff", "save-thread", "check-integration", "status"],
+      "slashCommands": []
+    },
+    {
       "id": "agent-plugins",
       "name": "Universal Agent Plugin",
       "category": "surface",

--- a/nowledge-mem-openai-plugin/.codex-plugin/plugin.json
+++ b/nowledge-mem-openai-plugin/.codex-plugin/plugin.json
@@ -1,0 +1,20 @@
+{
+  "name": "nowledge-mem-openai",
+  "version": "0.1.0",
+  "description": "Nowledge Mem for ChatGPT and Codex: shared context, memory search, and durable handoffs.",
+  "skills": "./skills/",
+  "mcpServers": "./.mcp.json",
+  "interface": {
+    "displayName": "Nowledge Mem",
+    "shortDescription": "Shared memory for ChatGPT and Codex",
+    "developerName": "Nowledge Labs",
+    "category": "Productivity",
+    "capabilities": ["Read", "Write"],
+    "websiteURL": "https://mem.nowledge.co",
+    "defaultPrompt": [
+      "What do we already know about this?",
+      "Find the relevant context from my Nowledge Mem.",
+      "Save the durable takeaways from this work."
+    ]
+  }
+}

--- a/nowledge-mem-openai-plugin/.codex-plugin/plugin.json
+++ b/nowledge-mem-openai-plugin/.codex-plugin/plugin.json
@@ -6,11 +6,15 @@
   "mcpServers": "./.mcp.json",
   "interface": {
     "displayName": "Nowledge Mem",
-    "shortDescription": "Shared memory for ChatGPT and Codex",
+    "shortDescription": "Memory for ChatGPT and Codex",
+    "longDescription": "Nowledge Mem gives ChatGPT and Codex a durable, user-controlled memory workspace. Search relevant context, read Working Memory, distill decisions, and save explicit handoffs through the authenticated Nowledge Cloud MCP server. ChatGPT uses explicit save and handoff actions; Codex lifecycle hooks remain available only in the dedicated Codex connector.",
     "developerName": "Nowledge Labs",
     "category": "Productivity",
     "capabilities": ["Read", "Write"],
     "websiteURL": "https://mem.nowledge.co",
+    "supportURL": "https://mem.nowledge.co/docs",
+    "privacyPolicyURL": "https://mem.nowledge.co/privacy",
+    "termsOfServiceURL": "https://mem.nowledge.co/terms",
     "defaultPrompt": [
       "What do we already know about this?",
       "Find the relevant context from my Nowledge Mem.",

--- a/nowledge-mem-openai-plugin/.mcp.json
+++ b/nowledge-mem-openai-plugin/.mcp.json
@@ -1,0 +1,9 @@
+{
+  "$schema": "https://developers.openai.com/plugins/schemas/mcp.schema.json",
+  "mcpServers": {
+    "nowledge-mem": {
+      "type": "streamable-http",
+      "url": "https://cloud.nowledge.co/mcp"
+    }
+  }
+}

--- a/nowledge-mem-openai-plugin/.mcp.json
+++ b/nowledge-mem-openai-plugin/.mcp.json
@@ -1,5 +1,4 @@
 {
-  "$schema": "https://developers.openai.com/plugins/schemas/mcp.schema.json",
   "mcpServers": {
     "nowledge-mem": {
       "type": "streamable-http",

--- a/nowledge-mem-openai-plugin/CHANGELOG.md
+++ b/nowledge-mem-openai-plugin/CHANGELOG.md
@@ -1,0 +1,9 @@
+# Changelog
+
+## [0.1.0] - 2026-08-20
+
+### Added
+
+- Initial OpenAI universal plugin package for ChatGPT and Codex.
+- Production Cloud MCP wiring and shared memory skills.
+- Explicit boundary between ChatGPT's MCP access and Codex-only lifecycle hooks.

--- a/nowledge-mem-openai-plugin/README.md
+++ b/nowledge-mem-openai-plugin/README.md
@@ -1,0 +1,51 @@
+# Nowledge Mem for ChatGPT and Codex
+
+This is the OpenAI universal plugin package for Nowledge Mem. OpenAI's public
+plugin directory is shared by ChatGPT and Codex, so one reviewed listing can
+provide the same Cloud memory surface to both products.
+
+## What it provides
+
+- Working Memory and context retrieval at the start of a task
+- Search across memories and prior threads
+- Explicit distillation of durable decisions and procedures
+- Explicit handoff and thread-save workflows
+- Status checks for the connected Nowledge Mem workspace
+
+The package uses the production Cloud MCP endpoint:
+
+```text
+https://cloud.nowledge.co/mcp
+```
+
+The host owns the OAuth 2.1 authorization flow. This package contains no
+credentials, local secrets, install scripts, or machine-specific URLs.
+
+## Important capability boundary
+
+ChatGPT does not receive Codex's local lifecycle hooks or a local transcript
+file. This package therefore does not claim automatic full-thread capture in
+ChatGPT. Use the explicit save-thread or handoff skill when a durable record is
+needed. Codex users should prefer the dedicated Nowledge Mem Codex connector,
+which can install Codex-specific hooks without changing ChatGPT behavior.
+
+The package also does not replace the dedicated connectors for other agents.
+Those connectors remain the right choice when a host offers lifecycle hooks,
+native identity, or transcript import.
+
+## Review and release state
+
+The repository package is ready for OpenAI plugin submission materials. Public
+listing requires a verified OpenAI developer or business identity, a reachable
+production MCP endpoint, standardized OAuth metadata, and OpenAI tool scanning.
+Do not submit this package until those Cloud checks are complete.
+
+Submission handoff: [`SUBMISSION.md`](./SUBMISSION.md).
+
+## Local development
+
+Validate the package without contacting production:
+
+```bash
+python3 tests/test_openai_plugin.py
+```

--- a/nowledge-mem-openai-plugin/SUBMISSION.md
+++ b/nowledge-mem-openai-plugin/SUBMISSION.md
@@ -1,0 +1,49 @@
+# OpenAI plugin submission handoff
+
+This file is for the Nowledge Labs owner who submits the public plugin. It is
+not an automated release step.
+
+## Before opening the portal
+
+1. Verify the Nowledge Labs developer or business identity in the OpenAI
+   Platform and grant the submitter **Apps Management** write access.
+2. Confirm that `https://cloud.nowledge.co/mcp` is the production endpoint to
+   submit. Do not use a local, staging, Access Anywhere, or per-user URL for a
+   universal listing.
+3. Confirm the MCP OAuth 2.1 metadata contract at the production resource:
+   protected-resource metadata, authorization-server metadata, PKCE `S256`,
+   `resource` propagation, issuer identification, and the accepted token
+   endpoint authentication methods.
+4. Scan the production tools and review every tool annotation. Read and write
+   tools must be described honestly; the listing must not imply automatic
+   transcript capture.
+
+## Portal
+
+Open the [OpenAI plugin submission portal](https://platform.openai.com/plugins)
+and create a **With MCP** submission. The package's listing should use:
+
+- Name: `Nowledge Mem`
+- Website: `https://mem.nowledge.co`
+- Support: `https://mem.nowledge.co/docs/support`
+- Integration guide: `https://mem.nowledge.co/docs/integrations`
+- MCP server: `https://cloud.nowledge.co/mcp`
+- Surfaces: ChatGPT and Codex
+- Category: Productivity
+
+Provide a privacy policy and terms URL accepted by the current Nowledge Mem
+website. Use starter prompts that demonstrate recall, explicit saving, and
+handoff. Include both successful read and write test cases, plus an
+unauthorized or missing-authorization case that proves the server fails
+closed.
+
+## Do not claim
+
+- ChatGPT automatic full-thread synchronization
+- Codex hook behavior inside ChatGPT
+- A universal per-user MCP URL or a local desktop endpoint
+- Raft's broker-specific login flow as OpenAI OAuth
+
+The public package is one fixed Cloud integration. Workspace-specific or
+self-hosted endpoints belong in private client configuration unless OpenAI
+explicitly approves a template submission.

--- a/nowledge-mem-openai-plugin/SUBMISSION.md
+++ b/nowledge-mem-openai-plugin/SUBMISSION.md
@@ -33,9 +33,11 @@ and create a **With MCP** submission. The package's listing should use:
 
 Provide a privacy policy and terms URL accepted by the current Nowledge Mem
 website. Use starter prompts that demonstrate recall, explicit saving, and
-handoff. Include both successful read and write test cases, plus an
-unauthorized or missing-authorization case that proves the server fails
-closed.
+handoff. Prepare exactly five positive cases: Working Memory read, semantic
+memory search, prior-thread search, durable memory write, and explicit handoff
+save. Prepare exactly three negative cases: missing authorization, expired or
+wrong-resource authorization, and a write attempted outside the authorized
+space. Each negative case must prove the server fails closed.
 
 ## Do not claim
 

--- a/nowledge-mem-openai-plugin/skills/check-integration/SKILL.md
+++ b/nowledge-mem-openai-plugin/skills/check-integration/SKILL.md
@@ -31,18 +31,18 @@ Do not install the PyPI CLI over the desktop-bundled CLI on the user's own deskt
 If the agent is not on the desktop machine and `nmem` is missing, install the PyPI CLI:
 
 ```bash
-python3 -m pip install --user nmem-cli
-# or: pipx install nmem-cli
-# or for one-off checks: uvx --from nmem-cli nmem --json status
+python3 -m pip install --user 'nmem-cli==0.10.0'
+# or: pipx install 'nmem-cli==0.10.0'
+# or for one-off checks: uvx --from 'nmem-cli==0.10.0' nmem --json status
 
 nmem config client set url https://<their-mem-server>
-nmem config client set api-key nmem_...
+export NMEM_API_KEY='nmem_...'
 nmem --json status
 ```
 
 If `nmem` exists but status fails, Nowledge Mem is not reachable from this machine. Guide the user:
 - Local desktop: open the Nowledge Mem app, then retry `nmem --json status`
-- Remote/client machine: verify the URL/API key with `nmem config client show`
+- Remote/client machine: verify the URL with `nmem --json status`; keep the API key in `NMEM_API_KEY` and never print raw client configuration
 - Full install guide: https://mem.nowledge.co/docs/installation
 - Remote access guide: https://mem.nowledge.co/docs/remote-access
 
@@ -111,7 +111,7 @@ If the agent is not listed above:
 
 - use the Universal Agent Plugin when the host supports Agent Plugins
 - otherwise use direct MCP plus the recommended prompt block
-- use the shared `npx skills` package when the host supports shared skills but has no MCP tool surface
+- use the skills bundled in this package when the host supports shared skills but has no MCP tool surface
 
 Do not describe raw MCP as equivalent to a native connector.
 

--- a/nowledge-mem-openai-plugin/skills/check-integration/SKILL.md
+++ b/nowledge-mem-openai-plugin/skills/check-integration/SKILL.md
@@ -1,0 +1,159 @@
+---
+name: check-integration
+description: Check Nowledge Mem setup, detect your agent, and guide native connector setup. Use when the user asks about setup, configuration, or when memory tools aren't working as expected.
+---
+
+# Check Connector
+
+> Verify Nowledge Mem is running and guide the user to the best connector for their agent.
+
+## When to Use
+
+- User asks about Nowledge Mem setup or configuration
+- Memory tools are failing or not available
+- User asks "is my memory working?" or "how do I set up Nowledge Mem?"
+- First time using Nowledge Mem in this agent
+- User asks about upgrading from skills to a native connector
+
+## Step 1: Check nmem CLI
+
+```bash
+nmem --json status
+```
+
+Use this rule before repairing anything:
+
+- **Same machine as Nowledge Mem Desktop:** use the desktop app's bundled `nmem`. Ask the user to open Nowledge Mem; if the command is still missing, use **Settings → Preferences → Developer Tools → Install bundled CLI**.
+- **Different machine:** install the standalone PyPI package `nmem-cli` on this machine, then point it at the user's Mem server. This covers remote servers, dev boxes, CI runners, hosted agents, and SSH machines. Python 3.11+ is required.
+
+Do not install the PyPI CLI over the desktop-bundled CLI on the user's own desktop unless the user explicitly asks for a standalone CLI.
+
+If the agent is not on the desktop machine and `nmem` is missing, install the PyPI CLI:
+
+```bash
+python3 -m pip install --user nmem-cli
+# or: pipx install nmem-cli
+# or for one-off checks: uvx --from nmem-cli nmem --json status
+
+nmem config client set url https://<their-mem-server>
+nmem config client set api-key nmem_...
+nmem --json status
+```
+
+If `nmem` exists but status fails, Nowledge Mem is not reachable from this machine. Guide the user:
+- Local desktop: open the Nowledge Mem app, then retry `nmem --json status`
+- Remote/client machine: verify the URL/API key with `nmem config client show`
+- Full install guide: https://mem.nowledge.co/docs/installation
+- Remote access guide: https://mem.nowledge.co/docs/remote-access
+
+## Step 2: Detect Agent and Recommend The Best Path
+
+For a fresh install, start from the universal connect skill:
+
+```text
+Read https://mem.nowledge.co/SKILL.md and follow the instructions to install or update Nowledge Mem for the AI tool I am using.
+```
+
+Use this check-integration skill as the diagnostic fallback: confirm what was installed, explain what behavior the user should expect, and repair configuration when something failed.
+
+Do not only answer "install X". Explain the behavior contract the user will get:
+
+1. what starts automatically
+2. what is only guided by skills/rules and still model-driven
+3. whether threads are captured automatically, saved explicitly, or only supported as handoff summaries
+
+Use this priority order:
+
+1. **Native connector first** when the host has one
+2. **Universal Agent Plugin** when the host supports Agent Plugins but has no native connector
+3. **Direct MCP** when the host supports MCP but has no better package path
+4. **Reusable package** when the host supports shared skills/prompts but has no native connector, Agent Plugins support, or MCP tool surface
+
+Fresh users care about outcome, not transport. Tell them what they will actually get after setup.
+
+### Autonomy levels
+
+| Path | What usually happens | What it does not guarantee |
+|------|----------------------|----------------------------|
+| **Native connector** | Strongest setup: session bootstrap is often automatic; some hosts also add auto-capture or hook-driven recall | Exact proactive recall/distill timing can still be host-specific |
+| **Universal Agent Plugin** | Standard Agent Plugins package with shared skills plus local Mem MCP for compatible clients without a dedicated connector | Agent Plugins 1.0 does not provide portable lifecycle hooks or transcript access |
+| **Direct MCP** | Tools are available; with the recommended prompt block, the agent can use them proactively | MCP alone does not create host-enforced autonomy |
+| **Reusable package** | Working Memory, recall, and distill are guided by rules/skills | The host may still ignore the guidance unless prompts and project guidance are strong |
+
+Check which agent you're running in and recommend the native connector if available.
+
+The canonical source for this table is `community/integrations.json`.
+
+| Agent | How to Detect | Native connector setup | Docs |
+|-------|--------------|----------------------|------|
+| **Claude Code** | Running as Claude Code agent; `~/.claude/` exists | `claude plugin marketplace add https://github.com/nowledge-co/community && claude plugin install nowledge-mem@nowledge-community` | [Guide](https://mem.nowledge.co/docs/integrations/claude-code) |
+| **Grok** | Running as Grok; `~/.grok/` exists | `grok plugin install nowledge-co/community#nowledge-mem-claude-code-plugin --trust` | [Guide](https://mem.nowledge.co/docs/integrations/grok) |
+| **OpenClaw** | Running as OpenClaw agent; `~/.openclaw/` exists | `openclaw plugins install clawhub:@nowledge/openclaw-nowledge-mem` | [Guide](https://mem.nowledge.co/docs/integrations/openclaw) |
+| **Cursor** | Running inside Cursor IDE | Copy `nowledge-mem-cursor-plugin` from the community repo into `~/.cursor/plugins/local/nowledge-mem-cursor`, then reload Cursor | [Guide](https://mem.nowledge.co/docs/integrations/cursor) |
+| **Gemini CLI** | Running as Gemini CLI agent; `~/.gemini/` exists | `gemini extensions install https://github.com/nowledge-co/nowledge-mem-gemini-cli --auto-update` or install "Nowledge Mem" from the Extensions Gallery | [Guide](https://mem.nowledge.co/docs/integrations/gemini-cli) |
+| **Google Antigravity** | Running as Antigravity; `~/.gemini/config/plugins/` or `~/.gemini/antigravity/` exists | Install the native plugin: `mkdir -p ~/.gemini/config/plugins && git clone --depth 1 https://github.com/nowledge-co/nowledge-mem-google-antigravity.git ~/.gemini/config/plugins/nowledge-mem`, then restart Antigravity. For remote Mem, run `nmem config mcp show --host google-antigravity` and paste the generated `serverUrl` MCP block into Antigravity's MCP settings. Preview older history with `nmem t sync --from antigravity`; use the Trajectory Extractor only for old cache-only sessions. | [Guide](https://mem.nowledge.co/docs/integrations/google-antigravity) |
+| **Alma** | Running inside Alma; `~/.config/alma/` exists | In Alma: Settings > Plugins > Marketplace, search "Nowledge Mem" | [Guide](https://mem.nowledge.co/docs/integrations/alma) |
+| **Droid** | Running inside Droid (Factory) | Add nowledge-co/community marketplace, install nowledge-mem@nowledge-community | [Guide](https://mem.nowledge.co/docs/integrations/droid) |
+| **Codex** | Running inside Codex desktop or Codex CLI; `~/.codex/` exists | `codex plugin marketplace add nowledge-co/community --sparse .agents --sparse nowledge-mem-codex-plugin && codex plugin add nowledge-mem@nowledge-community`, enable `[features] plugins = true`, `hooks = true`, and `[plugins."nowledge-mem@nowledge-community"] enabled = true`, then run the installed `scripts/install_hooks.py`. It adds the legacy `plugin_hooks` gate only when the host still needs it. Restart Codex and trust the Nowledge Mem hooks when prompted. If Codex local Memory is enabled, turn off **Allow memory generation from tool-assisted tasks**. | [Guide](https://mem.nowledge.co/docs/integrations/codex-cli) |
+| **Bub** | Running inside Bub | `pip install nowledge-mem-bub` | [Guide](https://mem.nowledge.co/docs/integrations/bub) |
+| **Pi** | Running as Pi agent; `~/.pi/` exists | `pi install npm:nowledge-mem-pi` | [Guide](https://mem.nowledge.co/docs/integrations/pi) |
+| **OMP** | Running as OMP agent; `~/.omp/` exists | `omp plugin install nowledge-mem-omp` | [Guide](https://mem.nowledge.co/docs/integrations/omp) |
+| **OpenCode** | Running as OpenCode agent; `~/.config/opencode/` or `.opencode/` exists | `opencode plugin opencode-nowledge-mem -g`; restart OpenCode so idle-event capture hooks load | [Guide](https://mem.nowledge.co/docs/integrations/opencode) |
+| **Craft Agent** | Running inside Craft Agent; `~/.craft-agent/` exists or `CRAFT_CONFIG_DIR` is set | `nmem config mcp show --host craft-agent`, then add the generated source config and guide to the active Craft workspace. Use `nmem t sync --from craft-agent --all-projects --apply` for real session import. | [Guide](https://mem.nowledge.co/docs/integrations/craft-agent) |
+| **Hermes Agent** | Running as Hermes agent; `~/.hermes/` exists | Install the native Hermes provider (or use MCP only as fallback) | [Guide](https://mem.nowledge.co/docs/integrations/hermes) |
+| **Cradle** | Running inside Cradle; the bundled `nowledge-mem` integration appears in Plugin Marketplace | Enable Cradle's bundled Nowledge Mem plugin. Configure its API URL, optional MCP URL, Space, and runtime-only API key as needed. | [Guide](https://mem.nowledge.co/docs/integrations/cradle) |
+| **Arkloop** | Running inside Arkloop; Settings > Memory lists Nowledge | Enable Memory, select Nowledge, then detect the local instance or enter Base URL, API Key, and timeout. | [Guide](https://mem.nowledge.co/docs/integrations/arkloop) |
+| **OpticLM** | Running inside Optic; Extension settings expose Nowledge Mem | Enable Optic's built-in integration. Add direct Mem MCP separately if you also need Working Memory, search, or durable memory tools. | [Guide](https://mem.nowledge.co/docs/integrations/opticlm) |
+
+For Hermes updates, run the setup command from the guide and confirm it prints `Thread import endpoint: /threads/import`. If it prints an old endpoint or no endpoint, the user is likely launching Hermes with a different `HERMES_HOME`; set that explicitly and rerun setup before restart.
+
+If the agent is not listed above:
+
+- use the Universal Agent Plugin when the host supports Agent Plugins
+- otherwise use direct MCP plus the recommended prompt block
+- use the shared `npx skills` package when the host supports shared skills but has no MCP tool surface
+
+Do not describe raw MCP as equivalent to a native connector.
+
+## Step 3: Verify
+
+After setup, verify with:
+
+```bash
+nmem --json m search "test" -n 1
+```
+
+If this returns results (or an empty list with no error), the connector is working.
+
+Then state the expected outcome in plain language:
+
+- **Working Memory**: automatic, guided, or manual
+- **Recall**: automatic, guided, or manual
+- **Distill**: automatic, guided, or manual
+- **Threads**: automatic capture, explicit save, handoff-only, or none
+
+If the path is only `guided`, say what strengthens it:
+
+- keep `nmem` available locally
+- restart the host after install
+- merge the package `AGENTS.md` or equivalent repo guidance when recommended
+- configure the local `nmem` client in remote mode
+
+## What Native Connectors Add
+
+Skills give you CLI-based memory access. Native connectors usually add:
+
+- **Auto-recall**: relevant memories injected before each response (no manual search needed)
+- **Auto-capture**: conversations saved as searchable threads at session end
+- **LLM distillation**: key decisions and insights extracted automatically
+- **Graph tools**: explore connections, evolution chains, and entity relationships
+- **Working Memory**: daily briefing loaded or injected at session start
+- **Slash commands**: `/remember`, `/recall`, `/forget` (where supported)
+
+Do not promise all of these on every host. Match the actual path the user is setting up.
+
+## Links
+
+- [All Connectors](https://mem.nowledge.co/docs/integrations)
+- [Documentation](https://mem.nowledge.co/docs)
+- [Discord Community](https://nowled.ge/discord)

--- a/nowledge-mem-openai-plugin/skills/distill-memory/SKILL.md
+++ b/nowledge-mem-openai-plugin/skills/distill-memory/SKILL.md
@@ -1,0 +1,35 @@
+---
+name: distill-memory
+description: Capture breakthrough moments and valuable insights as searchable memories in your knowledge base.
+---
+
+# Distill Memory
+
+Save proactively when the conversation produces a durable fact, preference, decision, plan, procedure, learning, event, or important context. Do not wait to be asked.
+
+## When to Save
+
+Good candidates include:
+
+- decisions with rationale ("we chose PostgreSQL because ACID is required")
+- repeatable procedures or workflows
+- lessons from debugging, incidents, or root cause analysis
+- durable preferences or constraints
+- plans that future sessions will need to resume cleanly
+- important context that would be lost when the session ends
+
+Skip routine fixes with no generalizable lesson, work in progress that will change, simple Q&A answerable from documentation, and generic information already widely known.
+
+## Add vs Update
+
+- Use `nmem --json m add` when the insight is genuinely new.
+- If an existing memory already captures the same decision, workflow, or preference and the new information refines it, use `nmem m update <id> ...` instead of creating a duplicate.
+- At the end of a substantial task, explicitly check whether one durable memory should be added or updated.
+
+Prefer atomic, standalone memories with strong titles and clear meaning. Focus on what was learned or decided, not routine chatter.
+
+Use structured saves when possible: `--unit-type` (`fact`, `preference`, `decision`, `plan`, `procedure`, `learning`, `context`, `event`), `-l` labels, `-i` importance (0.8–1.0 major decisions, 0.5–0.7 useful patterns, 0.3–0.4 minor notes). For MCP/native tools, pass the same value as `unit_type` when you know it.
+
+## Native Connector
+
+These skills work in any agent via CLI. For auto-recall, auto-capture, and graph tools, check if your agent has a native Nowledge Mem connector — run the `check-integration` skill or see https://mem.nowledge.co/docs/integrations

--- a/nowledge-mem-openai-plugin/skills/read-working-memory/SKILL.md
+++ b/nowledge-mem-openai-plugin/skills/read-working-memory/SKILL.md
@@ -1,0 +1,97 @@
+---
+name: read-working-memory
+description: Read your daily Working Memory briefing to understand current context. Contains active focus areas, priorities, unresolved flags, and recent knowledge changes. Load this automatically at the beginning of sessions for cross-tool continuity.
+---
+
+# Read Working Memory
+
+> Start every session with context. Use Context Bundle when you need owner identity, AI Identity, active scope, active rules, and Working Memory together. Use Working Memory alone for the lighter daily briefing.
+
+## When to Use
+
+**At session start:**
+
+- Beginning of a new conversation
+- Returning to a project after a break
+- When context about recent work would help
+
+**During session:**
+
+- User asks "what am I working on?" or "what's my context?"
+- User references recent priorities or decisions
+- Need to understand what's been happening across tools
+
+**Skip when:**
+
+- Already loaded this session
+- User explicitly wants a fresh start
+- Working on an isolated, context-independent task
+
+## Usage
+
+Prefer Context Bundle for startup or multi-agent sessions:
+
+```bash
+nmem --json context --source-app generic-agent
+```
+
+Multi-agent orchestrators can set `NMEM_AGENT_ID="<agent-slug>"` before launching the child agent. Add `NMEM_SPACE` only when that whole run should override the identity's default space. Use `NMEM_HOST_AGENT_ID` only for advanced external aliases.
+
+Read Working Memory alone when you only need current priorities:
+
+```bash
+nmem --json wm read
+```
+
+If it succeeds but reports `exists: false`, say there is no Working Memory briefing yet.
+
+If the host already knows a project or agent lane, add `--space "<space name>"` to either command.
+
+Only fall back to `~/ai-now/memory.md` for older local-only **Default-space** setups.
+
+### What You'll Find
+
+The Working Memory briefing contains:
+
+- **Active Focus Areas** — Topics you're currently engaged with, ranked by recent activity
+- **Priorities** — Items flagged as important or needing attention
+- **Unresolved Flags** — Contradictions, stale information, or items needing verification
+- **Recent Activity** — What changed in your knowledge base since the last briefing
+- **Deep Links** — References to specific memories for further exploration
+
+### How to Use This Context
+
+1. **Read once at session start** — don't re-read unless asked
+2. **Reference naturally** — mention relevant context when it connects to the current task
+3. **Continuation handoff** — if the task looks like a review, regression, release, resume, or prior-decision question, move straight into `search-memory` after the briefing instead of stopping here
+4. **Don't overwhelm** — share only the parts relevant to what the user is working on
+5. **Avoid duplicate startup reads** — if Context Bundle was already loaded and includes Working Memory, do not read Working Memory again
+6. **Cross-tool continuity** — insights saved in other tools (Cursor, Claude Code, Grok, Codex) appear here
+
+## Examples
+
+```bash
+# Read today's briefing
+nmem --json wm read
+
+# Legacy local-only fallback
+test -f ~/ai-now/memory.md && cat ~/ai-now/memory.md || echo "No Working Memory found. Ensure Nowledge Mem is running with Background Intelligence enabled."
+```
+
+## About Working Memory
+
+Working Memory is generated daily by Nowledge Mem's Background Intelligence. It synthesizes your recent knowledge activity into a concise briefing that any connected AI tool can read.
+
+**Updated daily** at your configured briefing time (default: 8 AM local time).
+
+**Shared across tools** — connected tools read the same lane's briefing. Save an insight in one tool, and that lane's next briefing reflects it for the others.
+
+## Links
+
+- [Documentation](https://mem.nowledge.co/docs)
+- [Nowledge Mem](https://mem.nowledge.co)
+- [Discord Community](https://nowled.ge/discord)
+
+## Native Connector
+
+These skills work in any agent via CLI. For auto-recall, auto-capture, and graph tools, check if your agent has a native Nowledge Mem connector — run the `check-integration` skill or see https://mem.nowledge.co/docs/integrations

--- a/nowledge-mem-openai-plugin/skills/save-handoff/SKILL.md
+++ b/nowledge-mem-openai-plugin/skills/save-handoff/SKILL.md
@@ -1,0 +1,62 @@
+---
+name: save-handoff
+description: Save a concise handoff summary only when the user explicitly requests it. Use this for resumable progress notes in generic agent environments where a real session importer is not guaranteed.
+---
+
+# Save Handoff
+
+> Persist a compact resumable handoff when the user wants a restart point, summary, or checkpoint.
+
+## When to Use
+
+**Only activate when user explicitly says:**
+
+- "Save a handoff"
+- "Checkpoint this"
+- "Leave me a summary"
+- "Remember where we are"
+
+**Never auto-save or suggest saving.** This is always user-initiated.
+
+## Why This Is A Handoff
+
+This reusable package works across many agents. It must not pretend to have a real transcript importer when the runtime may not provide one.
+
+So this skill creates a structured handoff summary with `nmem t create` instead of claiming a lossless thread save.
+
+If the user's tool has a dedicated Nowledge connector with real thread import, prefer that native package instead.
+
+## Usage
+
+Create a structured handoff thread:
+
+```bash
+nmem --json t create   -t "Session Handoff - <topic>"   -c "Goal: ... Decisions: ... Files: ... Risks: ... Next: ..."   -s generic-agent
+```
+
+### Handoff Format
+
+Include these fields:
+
+- Goal
+- Decisions
+- Files
+- Risks
+- Next
+
+### Response Format
+
+After successful save:
+
+```
+✓ Handoff saved
+Title: {title}
+Summary: {content}
+Thread ID: {thread_id}
+```
+
+Never present this as a real transcript import.
+
+## Native Connector
+
+These skills work in any agent via CLI. For auto-recall, auto-capture, and graph tools, check if your agent has a native Nowledge Mem connector — run the `check-integration` skill or see https://mem.nowledge.co/docs/integrations

--- a/nowledge-mem-openai-plugin/skills/save-thread/SKILL.md
+++ b/nowledge-mem-openai-plugin/skills/save-thread/SKILL.md
@@ -1,0 +1,84 @@
+---
+name: save-thread
+description: Deprecated compatibility skill. In portable Agent Plugins environments this must degrade honestly to a resumable handoff, because real transcript-backed thread import is not guaranteed. Prefer save-handoff here, and use native connectors when you need actual session capture.
+---
+
+# Save Thread (Deprecated Compatibility)
+
+> Preserve the old skill name without pretending a generic skill runtime can always import the real session transcript.
+
+## Status
+
+This skill name is **deprecated** and kept only for compatibility.
+
+Use `save-handoff` for portable Agent Plugins or other generic skill environments.
+
+## Why This Cannot Promise Real Thread Save
+
+A shared skills package works across many agent runtimes. In many of them, a skill can influence prompting but cannot read the host agent's real session transcript through a stable programmatic API.
+
+That means this package must not promise a lossless thread import when the runtime may not expose:
+
+- readable session files
+- a transcript/history API
+- a native importer surface wired for that specific agent
+
+If we claimed real thread save here, users would believe later retrieval reflects the actual full session when it may only contain a summary.
+
+## What To Do Instead
+
+In portable Agent Plugins environments, treat `save-thread` as an alias for `save-handoff`:
+
+- save a concise resumable handoff with `nmem t create`
+- state clearly that this is a handoff summary, not a transcript-backed import
+- never present the result as the full original session
+
+## When Real Thread Save Is Feasible
+
+Use a dedicated native connector when the runtime has a real transcript importer.
+
+Examples include Nowledge connectors such as:
+
+- Gemini CLI
+- Claude Code
+
+In those environments, `nmem t save --from <runtime>` can read local session files on the client machine and upload normalized thread messages to Mem.
+
+## When To Use Which Save Surface
+
+Use **save-handoff** when:
+
+- you are in a portable Agent Plugins environment without host transcript access
+- you want a restart point, checkpoint, or concise continuation summary
+- the runtime does not have a proven native thread importer
+
+Use a native **save-thread** only when:
+
+- the agent has a dedicated Nowledge connector for that runtime
+- real transcript import is actually implemented for that runtime
+- you want the actual session captured for later search and inspection
+
+## Usage In Portable Plugin Environments
+
+Create a structured handoff instead of pretending to save the real thread:
+
+```bash
+nmem --json t create   -t "Session Handoff - <topic>"   -c "Goal: ... Decisions: ... Files: ... Risks: ... Next: ..."   -s generic-agent
+```
+
+## Response Format
+
+After successful save in a portable Agent Plugins environment:
+
+```
+✓ Handoff saved
+Title: {title}
+Summary: {content}
+Thread ID: {thread_id}
+```
+
+Always explain that this compatibility skill creates a resumable handoff, not a real transcript import.
+
+## Native Connector
+
+These skills work in any agent via CLI. For auto-recall, auto-capture, and graph tools, check if your agent has a native Nowledge Mem connector — run the `check-integration` skill or see https://mem.nowledge.co/docs/integrations

--- a/nowledge-mem-openai-plugin/skills/search-memory/SKILL.md
+++ b/nowledge-mem-openai-plugin/skills/search-memory/SKILL.md
@@ -27,8 +27,8 @@ description: Search your personal knowledge base when past insights would improv
 
 ## Retrieval Routing
 
-1. Start with `nmem --json m search` for durable knowledge.
-2. Use `nmem --json t search` when the user is really asking about a prior conversation or exact session history.
+1. Start with `nmem --json m search "<query>"` for durable knowledge.
+2. Use `nmem --json t search "<query>"` when the user is really asking about a prior conversation or exact session history.
 3. If a result includes `source_thread`, inspect it progressively with `nmem --json t show <thread_id> --limit 8 --offset 0 --content-limit 1200`.
 4. Prefer the smallest retrieval surface that answers the question.
 

--- a/nowledge-mem-openai-plugin/skills/search-memory/SKILL.md
+++ b/nowledge-mem-openai-plugin/skills/search-memory/SKILL.md
@@ -1,0 +1,41 @@
+---
+name: search-memory
+description: Search your personal knowledge base when past insights would improve response. Recognize when stored breakthroughs, decisions, or solutions are relevant. Search proactively based on context, not just explicit requests.
+---
+
+# Search Memory
+
+> AI-powered search across your personal knowledge base using Nowledge Mem.
+
+## When to Use
+
+**Strong signals — search when:**
+
+- the user references previous work, a prior fix, or an earlier decision
+- the task resumes a named feature, bug, refactor, incident, or subsystem
+- the task is a review, regression, release, docs-alignment, or connector-behavior question
+- a debugging pattern resembles something solved earlier
+- the user asks for rationale, preferences, procedures, or recurring workflow details
+- the user uses implicit recall language: "that approach", "like before", "the pattern we used"
+
+**Contextual signals — consider searching when:**
+
+- complex debugging where prior context would narrow the search space
+- architecture discussion that may intersect with past decisions
+- domain-specific conventions the user has established before
+- the current result is ambiguous and past context would make the answer sharper
+
+## Retrieval Routing
+
+1. Start with `nmem --json m search` for durable knowledge.
+2. Use `nmem --json t search` when the user is really asking about a prior conversation or exact session history.
+3. If a result includes `source_thread`, inspect it progressively with `nmem --json t show <thread_id> --limit 8 --offset 0 --content-limit 1200`.
+4. Prefer the smallest retrieval surface that answers the question.
+
+For continuation-heavy engineering work, search near the start of the task. Do not wait for the user to literally ask for memory search.
+
+If the host already knows the active project or agent lane, add `--space "<space name>"` to these commands.
+
+## Native Connector
+
+These skills work in any agent via CLI. For auto-recall, auto-capture, and graph tools, check if your agent has a native Nowledge Mem connector — run the `check-integration` skill or see https://mem.nowledge.co/docs/integrations

--- a/nowledge-mem-openai-plugin/skills/status/SKILL.md
+++ b/nowledge-mem-openai-plugin/skills/status/SKILL.md
@@ -31,8 +31,8 @@ This shows:
 
 If status fails:
 - Ensure the Nowledge Mem desktop app is running, or start the server manually
-- Check that `nmem` is installed: use the desktop app's **Install CLI**, `pip install nmem-cli`, `uvx --from nmem-cli nmem`, or on Arch Linux `yay -S nmem-cli` / `paru -S nmem-cli`
-- For remote mode, verify `~/.nowledge-mem/config.json` has correct `apiUrl` and `apiKey`
+- Check that `nmem` is installed: use the desktop app's **Install CLI**, `pip install 'nmem-cli==0.10.0'`, `uvx --from 'nmem-cli==0.10.0' nmem`, or on Arch Linux `yay -S nmem-cli` / `paru -S nmem-cli`
+- For remote mode, set `NMEM_API_URL` and `NMEM_API_KEY` for the process, then rerun `nmem --json status`. Never print raw configuration or an API key.
 
 ## Native Connector
 

--- a/nowledge-mem-openai-plugin/skills/status/SKILL.md
+++ b/nowledge-mem-openai-plugin/skills/status/SKILL.md
@@ -1,0 +1,39 @@
+---
+name: status
+description: Check Nowledge Mem connection status, server version, CLI version, and configuration. Use when diagnosing issues or verifying setup.
+---
+
+# Status
+
+> Quick diagnostic for Nowledge Mem connectivity and configuration.
+
+## When to Use
+
+- User asks "is my memory working?" or "check status"
+- Memory operations are failing or returning errors
+- After initial setup to verify everything is connected
+- When switching between local and remote mode
+
+## Usage
+
+```bash
+nmem --json status
+```
+
+This shows:
+- **Connection**: whether the Nowledge Mem server is reachable
+- **Server version**: which version of the backend is running
+- **CLI version**: which version of `nmem` is installed
+- **Mode**: local or remote (with API URL)
+- **Database**: whether the knowledge graph is connected
+
+## Troubleshooting
+
+If status fails:
+- Ensure the Nowledge Mem desktop app is running, or start the server manually
+- Check that `nmem` is installed: use the desktop app's **Install CLI**, `pip install nmem-cli`, `uvx --from nmem-cli nmem`, or on Arch Linux `yay -S nmem-cli` / `paru -S nmem-cli`
+- For remote mode, verify `~/.nowledge-mem/config.json` has correct `apiUrl` and `apiKey`
+
+## Native Connector
+
+These skills work in any agent via CLI. For auto-recall, auto-capture, and graph tools, check if your agent has a native Nowledge Mem connector — run the `check-integration` skill or see https://mem.nowledge.co/docs/integrations

--- a/nowledge-mem-openai-plugin/tests/test_openai_plugin.py
+++ b/nowledge-mem-openai-plugin/tests/test_openai_plugin.py
@@ -1,0 +1,33 @@
+import json
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def main() -> None:
+    manifest_path = ROOT / ".codex-plugin" / "plugin.json"
+    mcp_path = ROOT / ".mcp.json"
+    manifest = json.loads(manifest_path.read_text())
+    mcp = json.loads(mcp_path.read_text())
+
+    assert manifest["name"] == "nowledge-mem-openai"
+    assert manifest["version"] == "0.1.0"
+    assert manifest["skills"] == "./skills/"
+    assert manifest["mcpServers"] == "./.mcp.json"
+    assert mcp["mcpServers"]["nowledge-mem"]["type"] == "streamable-http"
+    assert mcp["mcpServers"]["nowledge-mem"]["url"] == "https://cloud.nowledge.co/mcp"
+
+    package_text = "\n".join(
+        path.read_text(errors="replace")
+        for path in ROOT.rglob("*")
+        if path.is_file() and ".git" not in path.parts and "tests" not in path.parts
+    )
+    for forbidden in ("127.0.0.1", "localhost", "Authorization: Bearer", "api_key"):
+        assert forbidden not in package_text, forbidden
+    assert "automatic full-thread capture" in (ROOT / "README.md").read_text()
+    print("openai plugin package: PASS")
+
+
+if __name__ == "__main__":
+    main()

--- a/nowledge-mem-openai-plugin/tests/test_openai_plugin.py
+++ b/nowledge-mem-openai-plugin/tests/test_openai_plugin.py
@@ -13,6 +13,12 @@ def main() -> None:
 
     assert manifest["name"] == "nowledge-mem-openai"
     assert manifest["version"] == "0.1.0"
+    interface = manifest["interface"]
+    assert len(interface["shortDescription"]) <= 30
+    assert interface["longDescription"]
+    for field in ("supportURL", "privacyPolicyURL", "termsOfServiceURL"):
+        assert interface[field]
+        assert interface[field].startswith("https://")
     assert manifest["skills"] == "./skills/"
     assert manifest["mcpServers"] == "./.mcp.json"
     assert mcp["mcpServers"]["nowledge-mem"]["type"] == "streamable-http"


### PR DESCRIPTION
## What

Adds the OpenAI universal plugin package for the shared ChatGPT/Codex Plugins Directory.

- `.codex-plugin/plugin.json` and production `.mcp.json`
- shared Nowledge Mem skills, README, changelog, and owner submission handoff
- `integrations.json` registration with explicit handoff-only thread semantics
- static package contract test and no loopback/credential material

## Boundary

The package uses `https://cloud.nowledge.co/mcp` and relies on the host OAuth flow. It does not claim ChatGPT automatic transcript capture. Dedicated Codex hooks remain in the native Codex connector; Agent Plugins remains the fallback for other compatible hosts.

## Verification

- `python3 nowledge-mem-openai-plugin/tests/test_openai_plugin.py`
- `python3 -m json.tool integrations.json`
- `git diff --check`

Production OAuth discovery, OpenAI tool scan, and public submission are owner release gates and were intentionally not run.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an OpenAI plugin for ChatGPT and Codex with secure cloud connectivity and OAuth support.
  * Added tools for searching, reviewing, distilling, and saving shared memory.
  * Added integration diagnostics and setup guidance for supported AI agents.
  * Added explicit handoff-based conversation saving for portable environments.

* **Documentation**
  * Added installation, usage, compatibility, submission, and changelog documentation.

* **Tests**
  * Added validation for plugin configuration, required metadata, endpoint settings, and documentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->