### PR TITLE
fix(codex): prefer packaged stop hook runtime

### DIFF
--- a/integrations.json
+++ b/integrations.json
@@ -302,7 +302,7 @@
       "name": "Codex",
       "category": "coding",
       "type": "plugin",
-      "version": "0.1.31",
+      "version": "0.1.32",
       "directory": "nowledge-mem-codex-plugin",
 
       "legacyDirectory": "nowledge-mem-codex-prompts",

--- a/nowledge-mem-codex-plugin/.codex-plugin/plugin.json
+++ b/nowledge-mem-codex-plugin/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "nowledge-mem",
-  "version": "0.1.31",
+  "version": "0.1.32",
   "description": "Your Codex agent remembers past decisions, finds relevant context, and learns from every session, across all your AI tools.",
   "skills": "./skills/",
   "mcpServers": "./.mcp.json",

--- a/nowledge-mem-codex-plugin/CHANGELOG.md
+++ b/nowledge-mem-codex-plugin/CHANGELOG.md
@@ -2,12 +2,18 @@
 
 ## [Unreleased]
 
+## [0.1.32] - 2026-08-20
+
 ### Fixed
 
 - Stop hooks now durably enqueue capture in bounded time. The worker uses the
   CLI's acknowledged JSONL byte checkpoint, while skill telemetry runs in a
   detached child. Plugin and CLI upgrades must land together; no synchronous
   full-session fallback runs inside Stop.
+- The packaged Codex Stop-hook launcher now runs its same-version packaged
+  runtime first and uses the host-level compatibility copy only when the
+  packaged runtime is unavailable, preventing plugin updates from selecting a
+  stale synchronous hook that can exceed Codex's 15-second timeout.
 
 ## [0.1.31] - 2026-08-13
 

--- a/nowledge-mem-codex-plugin/hooks/nmem-stop-launch.py
+++ b/nowledge-mem-codex-plugin/hooks/nmem-stop-launch.py
@@ -21,9 +21,9 @@ def _packaged_hook() -> Path:
 
 
 def main() -> int:
-    hook = _stable_host_hook()
+    hook = _packaged_hook()
     if not hook.is_file():
-        hook = _packaged_hook()
+        hook = _stable_host_hook()
 
     sys.argv = [str(hook), *sys.argv[1:]]
     runpy.run_path(str(hook), run_name="__main__")

--- a/nowledge-mem-codex-plugin/scripts/validate-plugin.mjs
+++ b/nowledge-mem-codex-plugin/scripts/validate-plugin.mjs
@@ -198,10 +198,13 @@ const hookLauncher = readTextIfPresent(path.join(pluginRoot, "hooks/nmem-stop-la
 if (hookLauncher !== null) {
   if (!hookLauncher.includes("runpy.run_path")) fail("Stop hook launcher must delegate with runpy.run_path");
   else ok("Stop hook launcher delegation");
-  if (!hookLauncher.includes("nowledge-mem-stop-save.py")) fail("Stop hook launcher must prefer the stable installed hook");
-  else ok("Stop hook launcher stable fallback");
-  if (!hookLauncher.includes("nmem-stop-save.py")) fail("Stop hook launcher must fall back to the packaged hook");
-  else ok("Stop hook launcher packaged fallback");
+  const packagedSelection = hookLauncher.indexOf("hook = _packaged_hook()");
+  const stableSelection = hookLauncher.indexOf("hook = _stable_host_hook()");
+  if (packagedSelection < 0 || stableSelection < 0 || packagedSelection >= stableSelection) {
+    fail("Stop hook launcher must prefer the packaged hook and use the stable hook only as fallback");
+  } else {
+    ok("Stop hook launcher packaged-first fallback order");
+  }
 }
 
 const integrationsDoc = parseJsonIfPresent(path.join(repoRoot, "integrations.json"), "integrations.json");

--- a/nowledge-mem-codex-plugin/tests/test_codex_plugin.py
+++ b/nowledge-mem-codex-plugin/tests/test_codex_plugin.py
@@ -976,11 +976,13 @@ class LauncherTests(unittest.TestCase):
     def tearDown(self):
         self.temp_dir.cleanup()
 
-    def test_launcher_prefers_stable_host_hook(self):
+    def test_launcher_prefers_packaged_hook_when_host_hook_exists(self):
         codex_home = self.temp_path / ".codex"
         stable_hook = codex_home / "hooks" / "nowledge-mem-stop-save.py"
         stable_hook.parent.mkdir(parents=True)
         stable_hook.write_text("# stable", encoding="utf-8")
+        packaged_hook = self.temp_path / "nmem-stop-save.py"
+        packaged_hook.write_text("# packaged", encoding="utf-8")
         calls = []
 
         def fake_run_path(path, *, run_name):
@@ -988,28 +990,30 @@ class LauncherTests(unittest.TestCase):
             return {}
 
         with mock.patch.dict(self.module.os.environ, {"CODEX_HOME": str(codex_home)}, clear=False), \
-             mock.patch.object(self.module.runpy, "run_path", side_effect=fake_run_path), \
-             mock.patch.object(self.module.sys, "argv", ["launcher", "--event", "stop"]):
-            self.assertEqual(self.module.main(), 0)
-
-        self.assertEqual(calls, [(stable_hook, "__main__", [str(stable_hook), "--event", "stop"])])
-
-    def test_launcher_falls_back_to_packaged_hook(self):
-        missing_hook = self.temp_path / "missing.py"
-        packaged_hook = self.temp_path / "nmem-stop-save.py"
-        calls = []
-
-        def fake_run_path(path, *, run_name):
-            calls.append((Path(path), run_name, list(self.module.sys.argv)))
-            return {}
-
-        with mock.patch.object(self.module, "_stable_host_hook", return_value=missing_hook), \
              mock.patch.object(self.module, "_packaged_hook", return_value=packaged_hook), \
              mock.patch.object(self.module.runpy, "run_path", side_effect=fake_run_path), \
              mock.patch.object(self.module.sys, "argv", ["launcher", "--event", "stop"]):
             self.assertEqual(self.module.main(), 0)
 
         self.assertEqual(calls, [(packaged_hook, "__main__", [str(packaged_hook), "--event", "stop"])])
+
+    def test_launcher_falls_back_to_stable_host_hook(self):
+        missing_hook = self.temp_path / "missing.py"
+        stable_hook = self.temp_path / "nowledge-mem-stop-save.py"
+        stable_hook.write_text("# stable", encoding="utf-8")
+        calls = []
+
+        def fake_run_path(path, *, run_name):
+            calls.append((Path(path), run_name, list(self.module.sys.argv)))
+            return {}
+
+        with mock.patch.object(self.module, "_packaged_hook", return_value=missing_hook), \
+             mock.patch.object(self.module, "_stable_host_hook", return_value=stable_hook), \
+             mock.patch.object(self.module.runpy, "run_path", side_effect=fake_run_path), \
+             mock.patch.object(self.module.sys, "argv", ["launcher", "--event", "stop"]):
+            self.assertEqual(self.module.main(), 0)
+
+        self.assertEqual(calls, [(stable_hook, "__main__", [str(stable_hook), "--event", "stop"])])
 
     def test_launcher_entrypoint_emits_valid_stop_hook_json(self):
         codex_home = self.temp_path / ".codex"

--- a/tests/plugin_e2e/test_key_plugins_e2e.py
+++ b/tests/plugin_e2e/test_key_plugins_e2e.py
@@ -400,7 +400,7 @@ def test_key_plugin_static_contracts_are_declared():
     codex_save_hook = (CODEX_PLUGIN / "hooks" / "nmem-stop-save.py").read_text(encoding="utf-8")
     codex_runtime = (CODEX_PLUGIN / "hooks" / "nmem_runtime.py").read_text(encoding="utf-8")
     assert codex_manifest["name"] == "nowledge-mem"
-    assert codex_manifest["version"] == "0.1.31"
+    assert codex_manifest["version"] == "0.1.32"
     assert registry_by_id["codex-cli"]["version"] == codex_manifest["version"]
     assert codex_manifest["skills"] == "./skills/"
     assert codex_manifest["mcpServers"] == "./.mcp.json"
@@ -416,6 +416,9 @@ def test_key_plugin_static_contracts_are_declared():
     codex_launcher = (CODEX_PLUGIN / "hooks" / "nmem-stop-launch.py").read_text(encoding="utf-8")
     assert "nowledge-mem-stop-save.py" in codex_launcher
     assert "nmem-stop-save.py" in codex_launcher
+    assert codex_launcher.index("hook = _packaged_hook()") < codex_launcher.index(
+        "hook = _stable_host_hook()"
+    )
     assert "extract_skill_outcomes_from_file" in codex_save_hook
     assert "DELEGATED_CONVERSATION_ORIGINATORS" in codex_save_hook
     assert (CODEX_PLUGIN / "hooks" / "skill_outcome.py").exists()


### PR DESCRIPTION
Issue Number: ref #529

## Background

The Codex integration keeps both a packaged Stop-hook runtime and a host-level compatibility copy for older hosts. Plugin version `0.1.31` changed Stop capture to a bounded durable enqueue, but its packaged launcher still preferred the host copy whenever it existed.

## Problem

After a plugin update, the host copy can remain on an older synchronous implementation. The packaged Stop hook then runs that stale implementation under its 15-second timeout, producing intermittent `Stop hook timed out after 15s` failures instead of using the updated packaged runtime.

## How it works

- Prefer `hooks/nmem-stop-save.py` from the same packaged plugin version.
- Use `~/.codex/hooks/nowledge-mem-stop-save.py` only when the packaged runtime is unavailable.
- Preserve the host-level fallback registration and existing duplicate-capture guard.
- Update unit, E2E, and validator contracts so stale host coexistence remains covered.
- Release the packaged hook changes as plugin version `0.1.32`.

A targeted audit found no equivalent packaged-to-stale-host preference in the other hook integrations. Copilot CLI is packaged-first with a host fallback; Kimi Code, Cursor, Claude Code, CodeBuddy, Gemini CLI, Droid, and WorkBuddy use packaged or direct runtime paths; Proma uses a single host-installed model.

## Tests

- Added `test_launcher_prefers_packaged_hook_when_host_hook_exists`.
- Updated the host-fallback unit test and key-plugin E2E contract.
- Local tests were not run in this session; CI is the validation source for this PR.

## Side effects / risks

- Existing sessions still retain a host fallback if their packaged runtime cannot be found.
- Duplicate suppression remains unchanged when plugin and host hooks both fire.
- No runtime behavior was changed for other plugins.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Stop-hook processing now prioritizes the packaged runtime for more consistent behavior.
  * Automatically falls back to the host runtime when the packaged runtime is unavailable.
  * Improved capture reliability with bounded-time checkpointing and telemetry.

* **Chores**
  * Updated the Codex integration and plugin to version 0.1.32.
  * Added release details to the changelog.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->