### PR TITLE
fix(grok): respect passive hook context contract

### DIFF
--- a/.github/workflows/claude-grok-plugin.yml
+++ b/.github/workflows/claude-grok-plugin.yml
@@ -1,0 +1,39 @@
+name: Claude Code and Grok Build plugin
+
+on:
+  pull_request:
+    paths:
+      - ".github/workflows/claude-grok-plugin.yml"
+      - "integrations.json"
+      - "nowledge-mem-claude-code-plugin/**"
+  push:
+    branches:
+      - main
+    paths:
+      - ".github/workflows/claude-grok-plugin.yml"
+      - "integrations.json"
+      - "nowledge-mem-claude-code-plugin/**"
+
+permissions:
+  contents: read
+
+jobs:
+  validate:
+    name: validate (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os:
+          - ubuntu-latest
+          - macos-latest
+          - windows-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+      - name: Install test dependency
+        run: python -m pip install pytest
+      - name: Test Claude Code and Grok Build hook contracts
+        run: python -m pytest nowledge-mem-claude-code-plugin/tests -q

--- a/.github/workflows/claude-grok-plugin.yml
+++ b/.github/workflows/claude-grok-plugin.yml
@@ -30,6 +30,8 @@ jobs:
           - windows-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
       - uses: actions/setup-python@v5
         with:
           python-version: "3.11"

--- a/.github/workflows/claude-grok-plugin.yml
+++ b/.github/workflows/claude-grok-plugin.yml
@@ -33,6 +33,10 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: "3.11"
+      - name: Add Git Bash to PATH
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: '"C:\Program Files\Git\bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append'
       - name: Install test dependency
         run: python -m pip install pytest
       - name: Test Claude Code and Grok Build hook contracts

--- a/nowledge-mem-claude-code-plugin/CHANGELOG.md
+++ b/nowledge-mem-claude-code-plugin/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Automatic Claude-compatible thread capture now durably enqueues the exact
   session and returns without waiting for a complete transcript import.
+- Grok Build no longer performs Context Bundle reads from passive
+  `SessionStart` or `SubagentStart` hooks whose stdout the host discards. The
+  plugin now documents model-invoked `read-working-memory` as Grok's context
+  path and adds trust and hook-registration verification for session capture.
 
 ## [0.7.23] - 2026-08-10
 

--- a/nowledge-mem-claude-code-plugin/README.md
+++ b/nowledge-mem-claude-code-plugin/README.md
@@ -20,6 +20,12 @@ Grok Build:
 grok plugin install nowledge-co/community#nowledge-mem-claude-code-plugin --trust
 ```
 
+Restart Grok Build, then run `grok plugin details nowledge-mem` and open
+`/hooks` to verify that the plugin is enabled, trusted, and its lifecycle
+hooks are registered. Grok can load skills from an enabled plugin while
+still blocking hooks from an untrusted plugin, so skill visibility alone is
+not a capture check.
+
 **Prerequisite:** `nmem` CLI must be in your PATH. Hook capture also needs `python3` or `python` available on the same machine:
 
 ```bash
@@ -47,17 +53,25 @@ This calls the Windows `nmem` via interop — no extra setup or network configur
 
 ## What You Get
 
-**Automatic (no action needed):**
+**Claude Code lifecycle hooks:**
 
 - Context Bundle loaded at every session start, resume, and clear when available, with Working Memory fallback
 - Bounded Context Bundle injected for selected Claude Code subagent types, with routing-only or no-op behavior for simpler agents
 - Per-turn behavioral nudge with memory search, thread search, and save syntax
 - Per-turn managed-skills nudge for recurring procedural work (`find_skills` / `nmem skills match`)
+
+**Grok Build lifecycle hooks:**
+
+- Stop, PreCompact, SubagentStop, and SessionEnd capture the exact Grok Build session through `nmem`
+- Passive Grok hooks do not inject stdout into model context; the `read-working-memory` skill loads Context Bundle on the first relevant turn
+
+**Both hosts:**
+
 - Session conversations captured to your knowledge graph on each response
 - Session conversations captured again before context compaction
-- Context recovered after compaction events
+- Context recovered after compaction events in Claude Code; Grok Build can re-run `read-working-memory` after compaction when continuity is needed
 
-**Autonomous skills (Claude acts on its own):**
+**Autonomous skills (the host invokes when relevant):**
 
 - **Search Memory** -- searches both distilled memories and prior sessions when continuity matters
 - **Distill Memory** -- suggests saving breakthroughs and decisions
@@ -78,18 +92,24 @@ This calls the Windows `nmem` via interop — no extra setup or network configur
 
 | Event | Trigger | Action |
 |-------|---------|--------|
-| `SessionStart` | New, resume, or clear | Loads Context Bundle via `nmem context`, then falls back to `nmem wm read` |
-| `SessionStart` | After compaction | Re-loads Context Bundle or Working Memory + checkpoint prompt |
+| `SessionStart` | New, resume, or clear | Claude Code loads Context Bundle via `nmem context`, then falls back to `nmem wm read` |
+| `SessionStart` | After compaction | Claude Code re-loads Context Bundle or Working Memory + checkpoint prompt |
 | `SubagentStart` | Claude Code spawns a subagent | Selects full context, routing-only, or no-op behavior from `agent_type` |
-| `UserPromptSubmit` | Every user message | Injects search/save syntax as context |
+| `UserPromptSubmit` | Every user message | Claude Code injects search/save syntax as context |
 | `PreCompact` | Before manual or automatic compaction | Saves the exact Claude Code or Grok Build session by hook `session_id` before context is compressed |
 | `Stop` | Model finishes responding | Captures session to knowledge graph |
 | `SubagentStop` | Grok Build subagent finishes | Captures the subagent session without blocking the subagent gate |
 | `SessionEnd` | Grok Build process exits | Performs a final best-effort session capture after the last turn |
 
-The `SessionStart` hook tries `nmem context` first so Claude receives owner identity, AI Identity, active space, active rules, Working Memory, and KFS paths when the installed CLI supports it. It falls back to `nmem wm read`, then to `~/ai-now/memory.md` only as the **Default-space** compatibility path.
+In Claude Code, the `SessionStart` hook tries `nmem context` first so the model receives owner identity, AI Identity, active space, active rules, Working Memory, and KFS paths when the installed CLI supports it. It falls back to `nmem wm read`, then to `~/ai-now/memory.md` only as the **Default-space** compatibility path.
 
-The `SubagentStart` hook reuses the same source but caps the complete bootstrap envelope at 4 KiB. Full Context Bundle injection uses the exact, case-sensitive `NMEM_SUBAGENT_CONTEXT_TYPES` allowlist, which defaults to `Plan,code-reviewer,architect,researcher`. `Explore` receives no Mem prompt by default; other unlisted types receive retrieval routing without loading the Context Bundle. Setting the variable replaces the default allowlist, and an empty value disables full Context Bundle injection for every type.
+The Claude Code `SubagentStart` hook reuses the same source but caps the complete bootstrap envelope at 4 KiB. Full Context Bundle injection uses the exact, case-sensitive `NMEM_SUBAGENT_CONTEXT_TYPES` allowlist, which defaults to `Plan,code-reviewer,architect,researcher`. `Explore` receives no Mem prompt by default; other unlisted types receive retrieval routing without loading the Context Bundle. Setting the variable replaces the default allowlist, and an empty value disables full Context Bundle injection for every type.
+
+Grok Build treats `SessionStart`, `UserPromptSubmit`, and `SubagentStart` as
+passive hooks and discards their stdout. The plugin therefore does not spend
+an API call producing context that Grok cannot deliver. Grok exposes the same
+Context Bundle flow through the model-invoked `read-working-memory` skill;
+run `/read-working-memory` explicitly when you want to force a refresh.
 
 The `PreCompact` hook runs the same client-side thread save before the host compresses context. The `Stop`, `SubagentStop`, and `SessionEnd` hooks run it again through a detached worker with a bounded retry window, so short transcript-flush delays or process exit do not turn into silent no-op saves. Claude Code uses `nmem t save --from claude-code`; Grok Build uses `nmem t save --from grok`. Both paths pass the host session id into `nmem t save`, so concurrent sessions in the same project do not have to rely on "latest session" guessing.
 
@@ -153,7 +173,15 @@ Shared spaces, default retrieval, and agent guidance still live in Mem's own spa
 claude plugin marketplace update nowledge-community
 claude plugin update nowledge-mem@nowledge-community
 # Restart Claude Code to apply changes
+
+# Grok Build
+grok plugin update nowledge-mem
+grok plugin details nowledge-mem
 ```
+
+After a Grok Build or plugin update, restart Grok and re-check `/hooks`. A
+completed turn should create or update a `grok-*` thread in Mem; plugin skills
+being visible does not prove capture hooks are trusted and active.
 
 ## Customize without editing the plugin
 
@@ -172,6 +200,11 @@ Use `CLAUDE.local.md` for small personal memory-behavior changes such as "prefer
 **Server not running:** Start the Nowledge Mem desktop app, or run `nmem serve` on your server
 
 **Check status:** Run `/status` or `nmem status` to see connection details
+
+**Grok skills load but sessions are not captured:** Run
+`grok plugin details nowledge-mem`, then inspect `/hooks`. Reinstall with
+`--trust` if the hooks are blocked, restart Grok Build, complete one turn, and
+confirm a recent thread with `nmem t search "a phrase from that turn" --source grok`.
 
 ## Links
 

--- a/nowledge-mem-claude-code-plugin/scripts/nmem-hook-read.sh
+++ b/nowledge-mem-claude-code-plugin/scripts/nmem-hook-read.sh
@@ -40,6 +40,11 @@ fi
 case "${CLAUDE_PLUGIN_ROOT:-}" in
   */.grok/*|*\\.grok\\*) SOURCE_APP="grok" ;;
 esac
+if [ "$SOURCE_APP" = "grok" ]; then
+  # Grok Build treats SessionStart and SubagentStart as passive hooks and
+  # discards stdout. Context is loaded through the plugin skill instead.
+  exit 0
+fi
 
 parse_context='import sys,json; d=json.load(sys.stdin); c=d.get("rendered_markdown") or d.get("content") or ""; print(c) if c else sys.exit(1)'
 parse_existing_space_wm='import sys,json; d=json.load(sys.stdin); c=d.get("content",""); print(c) if d.get("exists") and c else sys.exit(1)'

--- a/nowledge-mem-claude-code-plugin/scripts/nmem-hook-read.sh
+++ b/nowledge-mem-claude-code-plugin/scripts/nmem-hook-read.sh
@@ -1,8 +1,10 @@
 #!/bin/sh
 # Best-effort Context Bundle / Working Memory injection for Claude Code / Grok Build lifecycle hooks.
 
-if ! command -v nmem >/dev/null 2>&1; then
-  if command -v nmem.cmd >/dev/null 2>&1; then
+NMEM_COMMAND="$(command -v nmem 2>/dev/null || true)"
+case "$NMEM_COMMAND" in
+  ""|*.cmd|*.CMD)
+    if command -v nmem.cmd >/dev/null 2>&1; then
     escape_cmd_arg() {
       printf '%s' "$1" | sed 's/\\/\\\\/g; s/"/\\"/g'
     }
@@ -14,8 +16,9 @@ if ! command -v nmem >/dev/null 2>&1; then
       done
       cmd.exe /s /c "\"nmem.cmd\"$q"
     }
-  fi
-fi
+    fi
+    ;;
+esac
 
 PY="$(command -v python3 2>/dev/null || command -v python 2>/dev/null || true)"
 

--- a/nowledge-mem-claude-code-plugin/scripts/nmem-hook-subagent.py
+++ b/nowledge-mem-claude-code-plugin/scripts/nmem-hook-subagent.py
@@ -31,6 +31,23 @@ point, not complete evidence."""
 _READ_HOOK = Path(__file__).resolve().with_name("nmem-hook-read.sh")
 
 
+def _looks_like_grok_path(value: str | None) -> bool:
+    if not value:
+        return False
+    normalized = value.replace("\\", "/")
+    return "/.grok/" in normalized or normalized.endswith("/.grok")
+
+
+def _is_grok_runtime() -> bool:
+    return bool(
+        os.environ.get("GROK_SESSION_ID")
+        or os.environ.get("GROK_HOOK_EVENT")
+        or os.environ.get("GROK_WORKSPACE_ROOT")
+        or os.environ.get("GROK_PLUGIN_ROOT")
+        or _looks_like_grok_path(os.environ.get("CLAUDE_PLUGIN_ROOT"))
+    )
+
+
 def _read_hook_input() -> dict[str, Any]:
     raw = sys.stdin.read()
     if not raw.strip():
@@ -104,6 +121,11 @@ def _write_response(additional_context: str) -> None:
 def main(payload: dict[str, Any] | None = None) -> int:
     if payload is None:
         payload = _read_hook_input()
+
+    # Grok Build ignores stdout from passive SubagentStart hooks. Avoid a
+    # Context Bundle read that cannot reach the child model.
+    if _is_grok_runtime():
+        return 0
 
     agent_type = str(payload.get("agent_type") or "").strip()
     context_types = _context_types()

--- a/nowledge-mem-claude-code-plugin/skills/read-working-memory/SKILL.md
+++ b/nowledge-mem-claude-code-plugin/skills/read-working-memory/SKILL.md
@@ -1,15 +1,15 @@
 ---
 name: read-working-memory
-description: Read your daily Working Memory briefing to understand current context. Contains active focus areas, priorities, unresolved flags, and recent knowledge changes. Load this automatically at the beginning of sessions for cross-tool continuity.
+description: Read your daily Working Memory briefing to understand current context. Contains active focus areas, priorities, unresolved flags, and recent knowledge changes. In Grok Build, invoke this on the first relevant turn because passive startup-hook output is not model context.
 ---
 
 # Read Working Memory
 
-> Start every session with context. Claude Code and Grok Build hooks prefer Context Bundle when available: owner identity, AI Identity, active scope, active rules, and Working Memory. Working Memory alone is the lighter fallback.
+> Start every relevant session with context. Claude Code hooks prefer Context Bundle when available: owner identity, AI Identity, active scope, active rules, and Working Memory. Grok Build loads the same context through this skill because it discards passive hook stdout. Working Memory alone is the lighter fallback.
 
 ## When to Use
 
-**At session start:**
+**At session start or the first relevant Grok Build turn:**
 
 - Beginning of a new conversation
 - Returning to a project after a break
@@ -65,7 +65,7 @@ The Working Memory briefing contains:
 
 ### How to Use This Context
 
-1. **Read once at session start** — don't re-read unless asked
+1. **Read once at session start** — in Grok Build, run this skill on the first relevant turn; don't re-read unless asked
 2. **Reference naturally** — mention relevant context when it connects to the current task
 3. **Avoid duplicate reads** — if Context Bundle was already injected and includes Working Memory, do not read Working Memory again
 4. **Don't overwhelm** — share only the parts relevant to what the user is working on

--- a/nowledge-mem-claude-code-plugin/tests/test_nmem_hook_read.py
+++ b/nowledge-mem-claude-code-plugin/tests/test_nmem_hook_read.py
@@ -26,6 +26,14 @@ def _run_hook(tmp_path: Path, *, cwd: Path, env: dict[str, str]) -> subprocess.C
     shell = shutil.which("sh")
     assert shell is not None, "sh is required to exercise the packaged hook"
     hook_env = os.environ.copy()
+    for marker in (
+        "GROK_SESSION_ID",
+        "GROK_HOOK_EVENT",
+        "GROK_WORKSPACE_ROOT",
+        "GROK_PLUGIN_ROOT",
+        "CLAUDE_PLUGIN_ROOT",
+    ):
+        hook_env.pop(marker, None)
     hook_env.update(env)
     hook_env["HOME"] = str(tmp_path / "home")
     (Path(hook_env["HOME"]) / "ai-now").mkdir(parents=True, exist_ok=True)

--- a/nowledge-mem-claude-code-plugin/tests/test_nmem_hook_read.py
+++ b/nowledge-mem-claude-code-plugin/tests/test_nmem_hook_read.py
@@ -7,6 +7,13 @@ from pathlib import Path
 SCRIPT_PATH = Path(__file__).parent.parent / "scripts" / "nmem-hook-read.sh"
 
 
+def _shell_path(path: Path) -> str:
+    value = path.as_posix()
+    if os.name == "nt" and len(value) >= 3 and value[1:3] == ":/":
+        return f"/{value[0].lower()}{value[2:]}"
+    return value
+
+
 def _write_fake_nmem(bin_dir: Path, body: str) -> Path:
     fake_nmem = bin_dir / "nmem"
     fake_nmem.write_text("#!/bin/sh\n" + body, encoding="utf-8")
@@ -322,7 +329,10 @@ esac
     result = _run_hook(
         tmp_path,
         cwd=tmp_path,
-        env={"PATH": f"{bin_dir}:/bin:/usr/bin", "NMEM_SPACE": 'project"2024'},
+        env={
+            "PATH": f"{_shell_path(bin_dir)}:/bin:/usr/bin",
+            "NMEM_SPACE": 'project"2024',
+        },
     )
 
     assert result.returncode == 0

--- a/nowledge-mem-claude-code-plugin/tests/test_nmem_hook_read.py
+++ b/nowledge-mem-claude-code-plugin/tests/test_nmem_hook_read.py
@@ -1,4 +1,5 @@
 import os
+import shutil
 import subprocess
 from pathlib import Path
 
@@ -18,8 +19,10 @@ def _run_hook(tmp_path: Path, *, cwd: Path, env: dict[str, str]) -> subprocess.C
     hook_env.update(env)
     hook_env["HOME"] = str(tmp_path / "home")
     (Path(hook_env["HOME"]) / "ai-now").mkdir(parents=True, exist_ok=True)
+    shell = shutil.which("sh", path=hook_env.get("PATH"))
+    assert shell is not None, "sh is required to exercise the packaged hook"
     return subprocess.run(
-        ["/bin/sh", str(SCRIPT_PATH)],
+        [shell, str(SCRIPT_PATH)],
         cwd=str(cwd),
         env=hook_env,
         text=True,

--- a/nowledge-mem-claude-code-plugin/tests/test_nmem_hook_read.py
+++ b/nowledge-mem-claude-code-plugin/tests/test_nmem_hook_read.py
@@ -1,6 +1,7 @@
 import os
 import shutil
 import subprocess
+import sys
 from pathlib import Path
 
 
@@ -330,7 +331,10 @@ esac
         tmp_path,
         cwd=tmp_path,
         env={
-            "PATH": f"{_shell_path(bin_dir)}:/bin:/usr/bin",
+            "PATH": (
+                f"{_shell_path(bin_dir)}:"
+                f"{_shell_path(Path(sys.executable).parent)}:/bin:/usr/bin"
+            ),
             "NMEM_SPACE": 'project"2024',
         },
     )

--- a/nowledge-mem-claude-code-plugin/tests/test_nmem_hook_read.py
+++ b/nowledge-mem-claude-code-plugin/tests/test_nmem_hook_read.py
@@ -121,7 +121,7 @@ esac
     assert "context --source-app claude-code --agent-id reviewer --host-agent-id lody:reviewer" in command_log
 
 
-def test_read_hook_uses_grok_source_app_when_grok_env_is_present(tmp_path):
+def test_read_hook_skips_grok_passive_context_output(tmp_path):
     bin_dir = tmp_path / "bin"
     bin_dir.mkdir()
     calls = tmp_path / "calls.log"
@@ -148,12 +148,11 @@ esac
     )
 
     assert result.returncode == 0
-    assert result.stdout.strip() == "grok context"
-    command_log = calls.read_text(encoding="utf-8")
-    assert "context --source-app grok" in command_log
+    assert result.stdout == ""
+    assert not calls.exists()
 
 
-def test_read_hook_uses_grok_source_app_when_only_plugin_root_is_present(tmp_path):
+def test_read_hook_skips_grok_when_only_plugin_root_is_present(tmp_path):
     bin_dir = tmp_path / "bin"
     bin_dir.mkdir()
     calls = tmp_path / "calls.log"
@@ -182,12 +181,11 @@ esac
     )
 
     assert result.returncode == 0
-    assert result.stdout.strip() == "grok plugin context"
-    command_log = calls.read_text(encoding="utf-8")
-    assert "context --source-app grok" in command_log
+    assert result.stdout == ""
+    assert not calls.exists()
 
 
-def test_read_hook_uses_grok_source_app_for_claude_compat_plugin_root(tmp_path):
+def test_read_hook_skips_grok_for_claude_compat_plugin_root(tmp_path):
     bin_dir = tmp_path / "bin"
     bin_dir.mkdir()
     calls = tmp_path / "calls.log"
@@ -219,9 +217,8 @@ esac
     )
 
     assert result.returncode == 0
-    assert result.stdout.strip() == "grok compat context"
-    command_log = calls.read_text(encoding="utf-8")
-    assert "context --source-app grok" in command_log
+    assert result.stdout == ""
+    assert not calls.exists()
 
 
 def test_read_hook_falls_back_to_default_space_when_project_space_empty(tmp_path):

--- a/nowledge-mem-claude-code-plugin/tests/test_nmem_hook_read.py
+++ b/nowledge-mem-claude-code-plugin/tests/test_nmem_hook_read.py
@@ -15,12 +15,12 @@ def _write_fake_nmem(bin_dir: Path, body: str) -> Path:
 
 
 def _run_hook(tmp_path: Path, *, cwd: Path, env: dict[str, str]) -> subprocess.CompletedProcess[str]:
+    shell = shutil.which("sh")
+    assert shell is not None, "sh is required to exercise the packaged hook"
     hook_env = os.environ.copy()
     hook_env.update(env)
     hook_env["HOME"] = str(tmp_path / "home")
     (Path(hook_env["HOME"]) / "ai-now").mkdir(parents=True, exist_ok=True)
-    shell = shutil.which("sh", path=hook_env.get("PATH"))
-    assert shell is not None, "sh is required to exercise the packaged hook"
     return subprocess.run(
         [shell, str(SCRIPT_PATH)],
         cwd=str(cwd),

--- a/nowledge-mem-claude-code-plugin/tests/test_nmem_hook_subagent.py
+++ b/nowledge-mem-claude-code-plugin/tests/test_nmem_hook_subagent.py
@@ -21,8 +21,16 @@ def _load_module():
 
 
 @pytest.fixture(autouse=True)
-def _clear_subagent_context_override(monkeypatch):
-    monkeypatch.delenv("NMEM_SUBAGENT_CONTEXT_TYPES", raising=False)
+def _clear_subagent_test_environment(monkeypatch):
+    for marker in (
+        "GROK_SESSION_ID",
+        "GROK_HOOK_EVENT",
+        "GROK_WORKSPACE_ROOT",
+        "GROK_PLUGIN_ROOT",
+        "CLAUDE_PLUGIN_ROOT",
+        "NMEM_SUBAGENT_CONTEXT_TYPES",
+    ):
+        monkeypatch.delenv(marker, raising=False)
 
 
 def test_packaged_subagent_hook_uses_bounded_wrapper():
@@ -45,7 +53,7 @@ def test_grok_subagent_start_skips_passive_context_output():
     ), mock.patch.object(module, "_load_context") as load, \
          mock.patch.object(module.sys, "stdout", stdout):
         assert module.main(
-            {"hookEventName": "subagent_start", "subagentType": "architect"}
+            {"hook_event_name": "SubagentStart", "agent_type": "architect"}
         ) == 0
 
     load.assert_not_called()

--- a/nowledge-mem-claude-code-plugin/tests/test_nmem_hook_subagent.py
+++ b/nowledge-mem-claude-code-plugin/tests/test_nmem_hook_subagent.py
@@ -35,6 +35,23 @@ def test_packaged_subagent_hook_uses_bounded_wrapper():
     assert hook["timeout"] > _load_module().SUBAGENT_CONTEXT_TIMEOUT_SECONDS
 
 
+def test_grok_subagent_start_skips_passive_context_output():
+    module = _load_module()
+    stdout = io.StringIO()
+
+    with mock.patch.dict(
+        module.os.environ,
+        {"GROK_HOOK_EVENT": "subagent_start"},
+    ), mock.patch.object(module, "_load_context") as load, \
+         mock.patch.object(module.sys, "stdout", stdout):
+        assert module.main(
+            {"hookEventName": "subagent_start", "subagentType": "architect"}
+        ) == 0
+
+    load.assert_not_called()
+    assert stdout.getvalue() == ""
+
+
 def test_selected_subagent_injects_bounded_context_and_boundary():
     module = _load_module()
     stdout = io.StringIO()


### PR DESCRIPTION
### Issue

Issue Number: close nowledge-co/mem#1379, ref #486

### Background

The shared Claude Code / Grok Build plugin uses lifecycle hooks for context and session capture. Grok Build supports the plugin package and capture environment, but its official hook contract treats `SessionStart`, `UserPromptSubmit`, and `SubagentStart` as passive events whose stdout is discarded.

### What problem does this PR solve?

The plugin still ran Context Bundle reads during Grok passive hooks and documented their stdout as automatic model context. Users could see working skills and capture while being told that startup context was injected even though Grok never delivered that output. Grok trust failures were also easy to miss because enabled skills do not prove plugin hooks are registered.

### How does it work?

- Preserve Grok Stop, PreCompact, SubagentStop, and SessionEnd capture unchanged.
- Skip Context Bundle reads when the read or subagent hook detects the Grok runtime, avoiding work whose output cannot reach the model.
- Make the model-invoked `read-working-memory` skill the documented Grok context path while keeping Claude Code startup and subagent injection unchanged.
- Add Grok install/update checks for plugin trust and hook registration, including a capture smoke command.
- Add regression coverage for native Grok variables, `GROK_PLUGIN_ROOT`, and the Claude-compatible plugin path under `.grok`.

This does not weaken hook trust, change thread identity, or alter `nmem t capture --from grok` routing.

### Tests

- [x] Unit / source-pin test
- [ ] Integration test
- [ ] Live / manual test
- [ ] No need to test

Added regression cases in `test_nmem_hook_read.py` and `test_nmem_hook_subagent.py`. GitHub Actions run [32385883626](https://github.com/nowledge-co/community/actions/runs/32385883626) passed the full plugin test suite on Ubuntu, macOS, and Windows. No local tests were run in this execution; repository CI was the validation gate.

### Side effects / risks

The behavior change is limited to Grok passive context-producing hooks. If Grok later adds model-facing passive-hook output, the official contract and these guards must be revisited. Claude Code context injection and both hosts' session capture remain unchanged.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Grok Build now loads working memory through an explicit skill when needed, rather than relying on passive lifecycle hooks.
  - Claude Code and Grok Build now have clearly differentiated context and session-capture behavior.

- **Bug Fixes**
  - Prevented discarded passive hook output from injecting unintended context in Grok Build.
  - Improved trust and hook-registration verification for reliable session capture.

- **Documentation**
  - Updated setup, lifecycle, troubleshooting, and restart guidance for Grok Build.
  - Added guidance for autonomous skills and context loading.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
