### PR TITLE
docs(claude-code-plugin): point to nmem CLI for graph/Crystal queries

### DIFF
--- a/nowledge-mem-claude-code-plugin/README.md
+++ b/nowledge-mem-claude-code-plugin/README.md
@@ -195,25 +195,17 @@ Use `CLAUDE.local.md` for small personal memory-behavior changes such as "prefer
 
 ## Beyond the default tools
 
-The MCP tools this plugin exposes are a deliberately small set -- memory
-search/write, thread retrieval, typed filesystem access, skill feedback, and
-a few others. That is on purpose: giving Claude Code every internal Nowledge
-Mem tool would bloat every model request with tool schemas, which is exactly
-what caused real slowdowns before this set was bounded.
-
-Graph-relationship queries -- expanding a memory's or Crystal's neighbors,
-walking an EVOLVES chain, and similar -- aren't in that default set. For
-those, use the `nmem` CLI directly (it's already installed alongside this
-plugin):
+The `nmem` CLI (already installed alongside this plugin) can do a lot more
+than the per-turn MCP tools cover -- including graph and relationship
+queries:
 
 ```bash
 nmem graph expand <memory-or-crystal-id> --depth 2
 nmem graph evolves <memory-id>
 ```
 
-`nmem --help` and `nmem graph --help` list everything else the CLI can do
-that the default MCP surface doesn't cover -- reach for it whenever you need
-something the per-turn tools don't expose.
+Run `nmem --help` (and `nmem graph --help`, `nmem <command> --help`, etc.)
+to see its full capabilities.
 
 ## Troubleshooting
 

--- a/nowledge-mem-claude-code-plugin/README.md
+++ b/nowledge-mem-claude-code-plugin/README.md
@@ -197,7 +197,8 @@ Use `CLAUDE.local.md` for small personal memory-behavior changes such as "prefer
 
 The `nmem` CLI (already installed alongside this plugin) can do a lot more
 than the per-turn MCP tools cover -- including graph and relationship
-queries:
+queries. **We recommend reaching for `nmem` directly** whenever you need
+something outside the per-turn tool set:
 
 ```bash
 nmem graph expand <memory-or-crystal-id> --depth 2

--- a/nowledge-mem-claude-code-plugin/README.md
+++ b/nowledge-mem-claude-code-plugin/README.md
@@ -193,6 +193,28 @@ Claude Code already has a clean override surface.
 
 Use `CLAUDE.local.md` for small personal memory-behavior changes such as "prefer saving Chinese notes" or "be more aggressive about searching prior release work" without forcing that rule on the whole team.
 
+## Beyond the default tools
+
+The MCP tools this plugin exposes are a deliberately small set -- memory
+search/write, thread retrieval, typed filesystem access, skill feedback, and
+a few others. That is on purpose: giving Claude Code every internal Nowledge
+Mem tool would bloat every model request with tool schemas, which is exactly
+what caused real slowdowns before this set was bounded.
+
+Graph-relationship queries -- expanding a memory's or Crystal's neighbors,
+walking an EVOLVES chain, and similar -- aren't in that default set. For
+those, use the `nmem` CLI directly (it's already installed alongside this
+plugin):
+
+```bash
+nmem graph expand <memory-or-crystal-id> --depth 2
+nmem graph evolves <memory-id>
+```
+
+`nmem --help` and `nmem graph --help` list everything else the CLI can do
+that the default MCP surface doesn't cover -- reach for it whenever you need
+something the per-turn tools don't expose.
+
 ## Troubleshooting
 
 **nmem not found:** Install with `pip install nmem-cli` or `pipx install nmem-cli`. If you're in WSL, see the [WSL setup](#wsl-setup) above.

--- a/nowledge-mem-claude-code-plugin/README.md
+++ b/nowledge-mem-claude-code-plugin/README.md
@@ -195,10 +195,10 @@ Use `CLAUDE.local.md` for small personal memory-behavior changes such as "prefer
 
 ## Beyond the default tools
 
-The `nmem` CLI (already installed alongside this plugin) can do a lot more
-than the per-turn MCP tools cover -- including graph and relationship
-queries. **We recommend reaching for `nmem` directly** whenever you need
-something outside the per-turn tool set:
+Use the MCP tools for the day-to-day per-turn loop. For anything beyond
+that -- including graph and relationship queries -- reach for the `nmem`
+CLI directly (already installed alongside this plugin). We recommend it
+whenever you hit a gap in the per-turn tool set:
 
 ```bash
 nmem graph expand <memory-or-crystal-id> --depth 2

--- a/nowledge-mem-codebuddy-plugin/README.md
+++ b/nowledge-mem-codebuddy-plugin/README.md
@@ -57,6 +57,21 @@ Diagnostics are written to `~/.codebuddy/logs/nowledge-mem-hook.log` unless `COD
 
 Use `~/.codebuddy/CODEBUDDY.md`, project `CODEBUDDY.md`, or `.codebuddy/rules/*.md`. Do not edit installed marketplace files.
 
+## Beyond the default tools
+
+Use the MCP tools for the day-to-day per-turn loop. For anything beyond
+that -- including graph and relationship queries -- reach for the `nmem`
+CLI directly (already installed alongside this plugin). We recommend it
+whenever you hit a gap in the per-turn tool set:
+
+```bash
+nmem graph expand <memory-or-crystal-id> --depth 2
+nmem graph evolves <memory-id>
+```
+
+Run `nmem --help` (and `nmem graph --help`, `nmem <command> --help`, etc.)
+to see its full capabilities.
+
 ## Links
 
 - [CodeBuddy guide](https://mem.nowledge.co/docs/integrations/codebuddy)

--- a/nowledge-mem-codex-plugin/README.md
+++ b/nowledge-mem-codex-plugin/README.md
@@ -363,6 +363,21 @@ If you used `nowledge-mem-codex-prompts` before:
 | `distill` | `$nowledge-mem:distill-memory` |
 | *(none)* | `$nowledge-mem:status` |
 
+## Beyond the default tools
+
+Use the MCP tools for the day-to-day per-turn loop. For anything beyond
+that -- including graph and relationship queries -- reach for the `nmem`
+CLI directly (already installed alongside this plugin). We recommend it
+whenever you hit a gap in the per-turn tool set:
+
+```bash
+nmem graph expand <memory-or-crystal-id> --depth 2
+nmem graph evolves <memory-id>
+```
+
+Run `nmem --help` (and `nmem graph --help`, `nmem <command> --help`, etc.)
+to see its full capabilities.
+
 ## Troubleshooting
 
 - **"Command not found: nmem"**: update the plugin to `0.1.29` or newer. Its

--- a/nowledge-mem-codex-prompts/README.md
+++ b/nowledge-mem-codex-prompts/README.md
@@ -110,6 +110,21 @@ Then copy or merge the project guidance file:
 curl -O https://raw.githubusercontent.com/nowledge-co/community/main/nowledge-mem-codex-prompts/AGENTS.md
 ```
 
+## Beyond the default tools
+
+Use the MCP tools for the day-to-day per-turn loop. For anything beyond
+that -- including graph and relationship queries -- reach for the `nmem`
+CLI directly (already installed alongside this integration). We recommend
+it whenever you hit a gap in the per-turn tool set:
+
+```bash
+nmem graph expand <memory-or-crystal-id> --depth 2
+nmem graph evolves <memory-id>
+```
+
+Run `nmem --help` (and `nmem graph --help`, `nmem <command> --help`, etc.)
+to see its full capabilities.
+
 ## Troubleshooting
 
 - **"Command not found: uvx"** → Install uv with `curl -LsSf https://astral.sh/uv/install.sh | sh`

--- a/nowledge-mem-copilot-cli-plugin/README.md
+++ b/nowledge-mem-copilot-cli-plugin/README.md
@@ -133,6 +133,21 @@ Copilot CLI already has a native instruction layer. Use that as your override pa
 
 Keep the plugin for lifecycle hooks and capture. Put your custom memory behavior in Copilot instruction files so updates do not wipe it out.
 
+## Beyond the default tools
+
+Use the MCP tools for the day-to-day per-turn loop. For anything beyond
+that -- including graph and relationship queries -- reach for the `nmem`
+CLI directly (already installed alongside this plugin). We recommend it
+whenever you hit a gap in the per-turn tool set:
+
+```bash
+nmem graph expand <memory-or-crystal-id> --depth 2
+nmem graph evolves <memory-id>
+```
+
+Run `nmem --help` (and `nmem graph --help`, `nmem <command> --help`, etc.)
+to see its full capabilities.
+
 ## Troubleshooting
 
 **nmem not found:** Install with `pip install nmem-cli` or `pipx install nmem-cli`. If you're in WSL, see the [WSL setup](#wsl-setup) above.

--- a/nowledge-mem-cursor-plugin/README.md
+++ b/nowledge-mem-cursor-plugin/README.md
@@ -108,6 +108,21 @@ Verify capture with a distinctive phrase from the session:
 nmem t search "distinctive phrase"
 ```
 
+## Beyond The Default Tools
+
+Use the MCP tools for the day-to-day per-turn loop. For anything beyond
+that -- including graph and relationship queries -- reach for the `nmem`
+CLI directly. We recommend it whenever you hit a gap in the per-turn
+tool set:
+
+```bash
+nmem graph expand <memory-or-crystal-id> --depth 2
+nmem graph evolves <memory-id>
+```
+
+Run `nmem --help` (and `nmem graph --help`, `nmem <command> --help`, etc.)
+to see its full capabilities.
+
 ## Spaces And Identity
 
 Spaces are optional. The startup and capture hooks honor `NMEM_SPACE` (or legacy `NMEM_SPACE_ID`), `NMEM_AGENT_ID`, and `NMEM_HOST_AGENT_ID` when Cursor is launched in a stable lane.

--- a/nowledge-mem-kimi-code-plugin/README.md
+++ b/nowledge-mem-kimi-code-plugin/README.md
@@ -189,6 +189,21 @@ Use Kimi Code's own instruction surfaces for personal behavior:
 
 Do not edit files under `$KIMI_CODE_HOME/plugins/managed/`; those are managed copies and can be replaced by Kimi Code updates.
 
+## Beyond the default tools
+
+Use the MCP tools for the day-to-day per-turn loop. For anything beyond
+that -- including graph and relationship queries -- reach for the `nmem`
+CLI directly (already installed alongside this plugin). We recommend it
+whenever you hit a gap in the per-turn tool set:
+
+```bash
+nmem graph expand <memory-or-crystal-id> --depth 2
+nmem graph evolves <memory-id>
+```
+
+Run `nmem --help` (and `nmem graph --help`, `nmem <command> --help`, etc.)
+to see its full capabilities.
+
 ## Links
 
 - [Kimi Code guide](https://mem.nowledge.co/docs/integrations/kimi-code)

--- a/nowledge-mem-opencode-plugin/README.md
+++ b/nowledge-mem-opencode-plugin/README.md
@@ -177,6 +177,21 @@ For multi-agent orchestrators, set `NMEM_AGENT_ID=<agent-slug>` per spawned Open
 
 Shared spaces, default retrieval, and agent guidance still come from Mem's own space profile. OpenCode should pick the lane once, not invent a second plugin-local memory partition.
 
+## Beyond the default tools
+
+Use the MCP tools for the day-to-day per-turn loop. For anything beyond
+that -- including graph and relationship queries -- reach for the `nmem`
+CLI directly (already installed alongside this plugin). We recommend it
+whenever you hit a gap in the per-turn tool set:
+
+```bash
+nmem graph expand <memory-or-crystal-id> --depth 2
+nmem graph evolves <memory-id>
+```
+
+Run `nmem --help` (and `nmem graph --help`, `nmem <command> --help`, etc.)
+to see its full capabilities.
+
 ## Troubleshooting
 
 - **nmem not found.** Install with `pip install nmem-cli`, or on Arch Linux `yay -S nmem-cli` / `paru -S nmem-cli`, then run `nmem status` to verify.


### PR DESCRIPTION
### Background

The default MCP tool set every recognized-host plugin in this repo exposes (Grok Build/Claude Code, Codex, Kimi Code, Gemini CLI, Cursor, CodeBuddy, Copilot CLI, OpenCode -- the exact list in `nowledge-co/mem`'s `docs/implementation/EXTERNAL_MCP_SURFACE.md`) is intentionally bounded to a small per-turn set. It does not include graph-relationship tools (`memory_neighbors`, `list_crystals`, `explore_graph`, etc.).

### Problem

A user asked why a Crystal's graph neighbors can't be queried via MCP. The backend/REST layer fully supports it, but none of these plugins' READMEs mentioned the bounded tool set or pointed to any alternative -- so there was no documented path forward for graph/relationship queries in any of them.

### Fix

Adds a short "Beyond the default tools" note to every plugin covering a recognized host, recommending the `nmem` CLI for anything outside the per-turn MCP loop -- ordered explicitly as MCP tools first for the day-to-day loop, `nmem` CLI for gaps beyond that (not "prefer nmem over MCP" in general). `nmem` is already a prerequisite for every one of these plugins, so no new install step.

`nowledge-mem-gemini-cli` already had a "Direct `nmem` Use Is Always Allowed" section; extended it in place instead of adding a duplicate section (nowledge-co/nowledge-mem-gemini-cli#5), and this PR bumps that nested submodule's pointer to pick it up.

### Tests

No need to test -- docs-only change (README additions), no code path affected.