### PR TITLE
fix: keep DSH registry bundle compatible with latest host

### DIFF
--- a/integrations.json
+++ b/integrations.json
@@ -1308,7 +1308,7 @@
       "name": "DeepSeek Harness",
       "category": "coding",
       "type": "plugin",
-      "version": "0.1.3",
+      "version": "0.1.4",
       "directory": "nowledge-mem-deepseek-harness-plugin",
       "externalRepo": "https://github.com/nowledge-co/nowledge-mem-deepseek-harness",
       "transport": "dsh-bundle+mcp+cli",

--- a/nowledge-mem-deepseek-harness-plugin/CHANGELOG.md
+++ b/nowledge-mem-deepseek-harness-plugin/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 0.1.4
+
+- Flushes DSH write-behind session persistence before exporting a completed
+  turn, while keeping Mem capture fail-open when the host storage backend is
+  unavailable.
+- Detects the Context Bundle from DSH's model-visible derived message surface,
+  so compaction can re-inject it when the prior snapshot is no longer visible.
+
 ## 0.1.3
 
 - Makes the sandbox-unavailable `danger-full-access` retry fail closed unless

--- a/nowledge-mem-deepseek-harness-plugin/package.json
+++ b/nowledge-mem-deepseek-harness-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nowledge-mem-deepseek-harness",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "description": "Community DeepSeek Harness bundle for Nowledge Mem: Context Bundle, prompt-time recall, Mem MCP tools, and DSH thread capture.",
   "type": "module",
   "main": "src/index.js",

--- a/nowledge-mem-deepseek-harness-plugin/src/context.js
+++ b/nowledge-mem-deepseek-harness-plugin/src/context.js
@@ -1,0 +1,11 @@
+/**
+ * Return whether the Mem Context Bundle is still visible to the model.
+ *
+ * DSH compaction keeps the raw event log but may replace the model-visible
+ * surface, so checking session.events would treat a hidden bundle as present.
+ */
+export function hasContextBundle(session, pluginName = 'nowledge-mem') {
+  return session.deriveMessages().some(message => message.source.kind === 'plugin'
+    && message.source.plugin === pluginName
+    && message.source.form === 'snapshot')
+}

--- a/nowledge-mem-deepseek-harness-plugin/src/index.js
+++ b/nowledge-mem-deepseek-harness-plugin/src/index.js
@@ -14,6 +14,8 @@ import z from '@deepseek-ai/schemastery'
 import { createUserMessage } from '@deepseek-ai/dsh-llm'
 
 import { DEFAULT_PROMPT_RECALL_PATTERN, shouldRecallForPrompt } from './recall.js'
+import { hasContextBundle } from './context.js'
+import { flushBeforeImport } from './session-flush.js'
 import {
   errorMessage,
   isSandboxUnavailableError,
@@ -28,7 +30,7 @@ import {
 } from './thread-import.js'
 
 export const name = 'nowledge-mem'
-export const inject = ['agents', 'shell']
+export const inject = ['agents', 'sessions', 'shell']
 
 const DEFAULT_SOURCE_APP = 'deepseek-harness'
 const DEFAULT_CLI_PATH = 'nmem'
@@ -247,13 +249,6 @@ function pluginContextMessage(form, sectionName, text) {
   })
 }
 
-function hasContextBundle(session) {
-  return session.events.some(event => event.type === 'user/message'
-    && event.data.source.kind === 'plugin'
-    && event.data.source.plugin === name
-    && event.data.source.form === 'snapshot')
-}
-
 async function loadContextMessage(ctx, config, signal, session) {
   const output = successfulStdout(await runNmem(
     ctx,
@@ -459,7 +454,7 @@ export function apply(ctx, config = {}) {
     if (decision.kind === 'reject' || signal.aborted) return decision
     try {
       const additions = []
-      if (resolved.contextOnSessionStart && !hasContextBundle(agent.session)) {
+      if (resolved.contextOnSessionStart && !hasContextBundle(agent.session, name)) {
         const contextMessage = await loadContextMessage(ctx, resolved, signal, agent.session)
         if (contextMessage !== undefined) additions.push(contextMessage)
       }
@@ -484,6 +479,14 @@ export function apply(ctx, config = {}) {
       .catch(() => undefined)
       .then(async () => {
         try {
+          // DSH persistence is write-behind. Make the session log durable before
+          // exporting its events, while keeping Mem capture fail-open if the
+          // host persistence backend is unavailable.
+          await flushBeforeImport(
+            ctx,
+            session,
+            error => warn(ctx, `nowledge-mem: DSH session flush failed before transcript import: ${errorMessage(error)}`),
+          )
           const acknowledgedCursor = await importSession(
             ctx,
             resolved,

--- a/nowledge-mem-deepseek-harness-plugin/src/session-flush.js
+++ b/nowledge-mem-deepseek-harness-plugin/src/session-flush.js
@@ -1,0 +1,9 @@
+export async function flushBeforeImport(ctx, session, report) {
+  try {
+    await ctx.sessions.flush(session)
+    return true
+  } catch (error) {
+    report(error)
+    return false
+  }
+}

--- a/nowledge-mem-deepseek-harness-plugin/tests/thread-import.test.mjs
+++ b/nowledge-mem-deepseek-harness-plugin/tests/thread-import.test.mjs
@@ -5,6 +5,8 @@ import {
   buildThreadImportArgs,
   sessionThreadTitle,
 } from '../src/thread-import.js'
+import { hasContextBundle } from '../src/context.js'
+import { flushBeforeImport } from '../src/session-flush.js'
 
 function userEvent(seq, content, source = { kind: 'user' }) {
   return {
@@ -87,4 +89,28 @@ test('rebuilds reconciliation arguments from the full payload', () => {
   assert.equal(argumentValue(reconciliationArgs, '--idempotency-key'), undefined)
   assert.equal(argumentValue(reconciliationArgs, '--space-id'), 'space-1')
   assert.equal(argumentValue(reconciliationArgs, '--agent-id'), 'agent-1')
+})
+
+test('checks the model-visible session projection after compaction', () => {
+  const contextMessage = {
+    source: { kind: 'plugin', plugin: 'nowledge-mem', form: 'snapshot' },
+  }
+
+  assert.equal(hasContextBundle({ deriveMessages: () => [contextMessage] }), true)
+  assert.equal(hasContextBundle({ deriveMessages: () => [] }), false)
+})
+
+test('flushes DSH write-behind persistence before import and fails open', async () => {
+  const calls = []
+  const session = {}
+  const ctx = { sessions: { flush: async value => calls.push(value) } }
+
+  assert.equal(await flushBeforeImport(ctx, session, () => assert.fail('unexpected flush error')), true)
+  assert.deepEqual(calls, [session])
+
+  const error = new Error('storage unavailable')
+  const reported = []
+  const failingCtx = { sessions: { flush: async () => { throw error } } }
+  assert.equal(await flushBeforeImport(failingCtx, session, value => reported.push(value)), false)
+  assert.deepEqual(reported, [error])
 })

--- a/tests/plugin_e2e/test_key_plugins_e2e.py
+++ b/tests/plugin_e2e/test_key_plugins_e2e.py
@@ -1525,7 +1525,7 @@ def test_registry_connect_contract_points_agent_prompts_to_universal_skill():
         "nowledge-mem-save-handoff",
     ]
     dsh = by_id["deepseek-harness"]
-    assert dsh["version"] == "0.1.3"
+    assert dsh["version"] == "0.1.4"
     assert dsh["type"] == "plugin"
     assert dsh["directory"] == "nowledge-mem-deepseek-harness-plugin"
     assert dsh["externalRepo"] == "https://github.com/nowledge-co/nowledge-mem-deepseek-harness"
@@ -1593,7 +1593,7 @@ def test_deepseek_harness_plugin_static_contract_is_self_contained():
     )
 
     assert pkg["name"] == "nowledge-mem-deepseek-harness"
-    assert pkg["version"] == "0.1.3"
+    assert pkg["version"] == "0.1.4"
     assert pkg["type"] == "module"
     assert pkg["main"] == "src/index.js"
     assert pkg["dsh"]["bundle"]["patch"] == "./cordis.patch.yml"


### PR DESCRIPTION
## Background
The canonical DeepSeek Harness plugin now needs to account for DSH's write-behind session persistence and compaction behavior. The community registry mirrors this bundle and must remain aligned with the installable package.

## Problem
The registry package could export a completed turn before DSH persistence was durable, and raw event inspection could mistake a compacted-away Context Bundle for a still-visible snapshot. The registry and package metadata also remained at the previous version.

## How it works
- Awaits the DSH `sessions.flush()` checkpoint before transcript export, while keeping Mem capture fail-open on host storage errors.
- Detects Context Bundle visibility from `session.deriveMessages()`.
- Bumps the mirrored package and registry to `0.1.4`.
- Adds focused behavior coverage for compaction visibility and flush failure handling.

## Test evidence
- `node --test nowledge-mem-deepseek-harness-plugin/tests/*.test.mjs` (21 passed)
- `node --check` for changed JavaScript files
- `git diff --check`

Canonical implementation PR: https://github.com/nowledge-co/nowledge-mem-deepseek-harness/pull/5
Parent task: https://github.com/nowledge-co/mem/issues/1707
