### PR TITLE
docs: classify LangGraph as an agent framework

### DIFF
--- a/integrations.json
+++ b/integrations.json
@@ -1688,7 +1688,7 @@
     {
       "id": "langgraph",
       "name": "LangGraph",
-      "category": "orchestrator",
+      "category": "framework",
       "type": "connector",
       "version": "0.1.0",
       "directory": "nowledge-mem-langgraph",


### PR DESCRIPTION
## Summary
- classify the LangGraph connector as a framework in the canonical registry
- keep orchestrator classification for actual agent hosts

Part of nowledge-co/mem#1740.