### PR TITLE
fix(grok): quote Windows nmem cmd paths

### DIFF
--- a/nowledge-mem-claude-code-plugin/scripts/nmem-hook-save.py
+++ b/nowledge-mem-claude-code-plugin/scripts/nmem-hook-save.py
@@ -330,11 +330,14 @@ def _cmd_exe_path(path: str) -> str:
 
 def _build_nmem_command(nmem: str, *args: str) -> list[str]:
     if nmem.lower().endswith(".cmd"):
+        command_line = subprocess.list2cmdline([_cmd_exe_path(nmem), *args])
         return [
             "cmd.exe",
             "/s",
             "/c",
-            subprocess.list2cmdline([_cmd_exe_path(nmem), *args]),
+            # /s /c strips the first and last quote pair. Wrap the complete
+            # command so a quoted .cmd path keeps its executable boundary.
+            f'"{command_line}"',
         ]
     return [nmem, *args]
 

--- a/nowledge-mem-claude-code-plugin/tests/test_nmem_hook_save.py
+++ b/nowledge-mem-claude-code-plugin/tests/test_nmem_hook_save.py
@@ -198,6 +198,20 @@ def test_build_command_wraps_windows_cmd_for_wsl_bridge():
     assert "--session-id session-1" in command[3]
 
 
+def test_build_command_preserves_spaces_in_windows_cmd_path():
+    command = nmem_hook_save._build_command(
+        r"C:\Users\Alice\AppData\Local\Nowledge Mem CLI\bin\nmem.cmd",
+        {"session_id": "session-with-spaces"},
+    )
+
+    assert command[:3] == ["cmd.exe", "/s", "/c"]
+    assert command[3].startswith(
+        r'""C:\Users\Alice\AppData\Local\Nowledge Mem CLI\bin\nmem.cmd"'
+    )
+    assert command[3].endswith('"')
+    assert "--session-id session-with-spaces" in command[3]
+
+
 def test_build_command_converts_wsl_project_path_for_windows_cmd():
     with patch.object(nmem_hook_save.shutil, "which", return_value=None), \
         patch.dict(nmem_hook_save.os.environ, {"WSL_DISTRO_NAME": "Ubuntu"}):


### PR DESCRIPTION
## Summary

- preserve quoted Windows `.cmd` executable paths when launching `nmem`
- add regression coverage for an installation path containing spaces

## Problem

`cmd.exe /s /c` strips the first and last quote pair from its command string.
Passing the `subprocess.list2cmdline` result directly therefore breaks when
`nmem.cmd` lives under a path such as `Nowledge Mem CLI`.

## Fix

Wrap the complete generated command line in an outer quote pair. The inner
pair continues to quote the executable path, while the outer pair satisfies
`cmd.exe /s /c` parsing. Direct executable invocation is unchanged.

## Tests

`python3 -m pytest nowledge-mem-claude-code-plugin/tests/test_nmem_hook_save.py -q`

Result: `37 passed in 0.18s`.
