### PR TITLE
fix(cursor): resolve hooks from plugin root

### DIFF
--- a/integrations.json
+++ b/integrations.json
@@ -610,7 +610,7 @@
       "name": "Cursor",
       "category": "coding",
       "type": "plugin",
-      "version": "0.2.0",
+      "version": "0.2.1",
       "directory": "nowledge-mem-cursor-plugin",
       "transport": "mcp+hook",
       "capabilities": {

--- a/nowledge-mem-cursor-plugin/.cursor-plugin/plugin.json
+++ b/nowledge-mem-cursor-plugin/.cursor-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "nowledge-mem-cursor",
   "description": "Bring startup context, memory recall, and automatic Cursor transcript capture into Cursor with Nowledge Mem.",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "author": {
     "name": "Nowledge Labs",
     "email": "hello@nowledge-labs.ai",

--- a/nowledge-mem-cursor-plugin/CHANGELOG.md
+++ b/nowledge-mem-cursor-plugin/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Fixed automatic session startup and stop capture when Cursor runs plugin
+  hooks from a project directory instead of the installed plugin directory.
 - Stop capture now hands the exact conversation transcript to the shared
   durable queue instead of waiting for the full importer in the hook process.
 

--- a/nowledge-mem-cursor-plugin/hooks/hooks.json
+++ b/nowledge-mem-cursor-plugin/hooks/hooks.json
@@ -3,13 +3,13 @@
   "hooks": {
     "sessionStart": [
       {
-        "command": "node ./hooks/session-start.mjs",
+        "command": "node \"${CURSOR_PLUGIN_ROOT}/hooks/session-start.mjs\"",
         "timeout": 15
       }
     ],
     "stop": [
       {
-        "command": "node ./hooks/stop-save.mjs",
+        "command": "node \"${CURSOR_PLUGIN_ROOT}/hooks/stop-save.mjs\"",
         "timeout": 40
       }
     ]

--- a/nowledge-mem-cursor-plugin/scripts/validate-plugin.mjs
+++ b/nowledge-mem-cursor-plugin/scripts/validate-plugin.mjs
@@ -182,8 +182,8 @@ async function main() {
     fail('hooks/hooks.json must define a sessionStart hook');
   }
   const sessionStartCommand = sessionStartHooks[0]?.command;
-  if (sessionStartCommand !== 'node ./hooks/session-start.mjs') {
-    fail('hooks/hooks.json sessionStart command must stay node ./hooks/session-start.mjs');
+  if (sessionStartCommand !== 'node "${CURSOR_PLUGIN_ROOT}/hooks/session-start.mjs"') {
+    fail('hooks/hooks.json sessionStart command must resolve from CURSOR_PLUGIN_ROOT');
   }
   if (sessionStartHooks[0]?.timeout !== 15) {
     fail('hooks/hooks.json sessionStart timeout must stay 15 seconds');
@@ -192,8 +192,8 @@ async function main() {
   if (!Array.isArray(stopHooks) || stopHooks.length === 0) {
     fail('hooks/hooks.json must define a stop hook for real transcript capture');
   }
-  if (stopHooks[0]?.command !== 'node ./hooks/stop-save.mjs') {
-    fail('hooks/hooks.json stop command must stay node ./hooks/stop-save.mjs');
+  if (stopHooks[0]?.command !== 'node "${CURSOR_PLUGIN_ROOT}/hooks/stop-save.mjs"') {
+    fail('hooks/hooks.json stop command must resolve from CURSOR_PLUGIN_ROOT');
   }
   if (stopHooks[0]?.timeout !== 40) {
     fail('hooks/hooks.json stop timeout must stay 40 seconds');

--- a/nowledge-mem-cursor-plugin/tests/cursor-hooks.test.mjs
+++ b/nowledge-mem-cursor-plugin/tests/cursor-hooks.test.mjs
@@ -1,5 +1,5 @@
 import assert from 'node:assert/strict';
-import { mkdtempSync, rmSync } from 'node:fs';
+import { mkdtempSync, readFileSync, rmSync } from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
 import test from 'node:test';
@@ -15,6 +15,22 @@ import {
 function temporaryStateRoot() {
   return mkdtempSync(path.join(os.tmpdir(), 'nmem-cursor-hook-test-'));
 }
+
+test('plugin hooks resolve bundled scripts independently of the project cwd', () => {
+  const hooksPath = new URL('../hooks/hooks.json', import.meta.url);
+  const hooks = JSON.parse(readFileSync(hooksPath, 'utf8'));
+
+  assert.equal(
+    hooks.hooks.sessionStart[0].command,
+    'node "${CURSOR_PLUGIN_ROOT}/hooks/session-start.mjs"',
+  );
+  assert.equal(
+    hooks.hooks.stop[0].command,
+    'node "${CURSOR_PLUGIN_ROOT}/hooks/stop-save.mjs"',
+  );
+  assert.doesNotMatch(hooks.hooks.sessionStart[0].command, /node \.\/hooks\//);
+  assert.doesNotMatch(hooks.hooks.stop[0].command, /node \.\/hooks\//);
+});
 
 test('sessionStart emits only the documented additional_context field', () => {
   const output = buildHookOutput({


### PR DESCRIPTION
Issue Number: ref nowledge-co/mem-feedback#265

## Background

Cursor plugin hooks are loaded from the installed plugin package, but Cursor executes marketplace plugin commands from the active workspace. Cursor exposes `CURSOR_PLUGIN_ROOT` for commands that need a bundled file.

## Problem

The published `sessionStart` and `stop` commands use `node ./hooks/...`. With a project open, Node looks below the project root and exits with `MODULE_NOT_FOUND` before the hook code can return fail-open output or write its diagnostic log. MCP remains healthy, which makes the missing automatic transcript capture look like a backend failure.

## How it works

- Resolve both bundled hook scripts through quoted `${CURSOR_PLUGIN_ROOT}` paths, independent of workspace cwd and safe for plugin paths containing spaces.
- Bump the Cursor integration and package manifests together to `0.2.1` and record the user-visible fix in the changelog.
- Update the package validator and add a Node regression that rejects relative `node ./hooks/...` commands.

The stdin parser and exact-session capture contract are unchanged. Cursor's current hook schema already supplies stable `conversation_id` and `transcript_path` fields; this PR does not guess a latest session or derive identity heuristically.

## Tests

- `node --test tests/*.test.mjs` -> 8 passed, 0 failed
- `node scripts/validate-plugin.mjs` -> validated
- `git diff --check` -> passed

## Side effects / risks

- No Rust, Python, MCP configuration, or import behavior changes.
- A real Cursor/Windows install remains the final host-level smoke; CI should exercise the package tests across supported OS runners.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped Cursor plugin packaging fix; hook script logic and capture contracts are unchanged, with validator and test guardrails only.
> 
> **Overview**
> Fixes **broken automatic context bootstrap and transcript capture** when Cursor runs marketplace plugin hooks with the **workspace as cwd** instead of the installed plugin directory. Relative `node ./hooks/...` commands could fail with `MODULE_NOT_FOUND` while MCP still looked healthy.
> 
> **sessionStart** and **stop** hook commands in `hooks/hooks.json` now invoke bundled scripts via quoted `${CURSOR_PLUGIN_ROOT}/hooks/...` paths so Node always loads the plugin package scripts regardless of project directory (including paths with spaces).
> 
> Releases as **Cursor integration / plugin 0.2.1** (`integrations.json`, `.cursor-plugin/plugin.json`, changelog). `validate-plugin.mjs` enforces the new commands, and a regression test rejects relative `./hooks/` hook commands.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b79a2413e644cb6030041c8c46f0e03eeaa7ab61. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->