### PR TITLE
fix(opencode): support Node Desktop CLI transport

### DIFF
--- a/integrations.json
+++ b/integrations.json
@@ -1092,7 +1092,7 @@
       "name": "OpenCode",
       "category": "coding",
       "type": "plugin",
-      "version": "0.3.9",
+      "version": "0.3.10",
       "directory": "nowledge-mem-opencode-plugin",
       "transport": "cli+http",
       "capabilities": {

--- a/nowledge-mem-opencode-plugin/CHANGELOG.md
+++ b/nowledge-mem-opencode-plugin/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## [0.3.10] - 2026-08-26
+
+### Fixed
+
+- CLI-backed tools now work in OpenCode Desktop's Node sidecar, where Bun's
+  shell helper is unavailable. The fallback launches `nmem` with an exact argv
+  array, preserving spaces and special characters without shell parsing. On
+  Windows it resolves the Rust executable behind the installed `nmem.cmd`
+  wrapper before launching it.
+
 ## [0.3.9] - 2026-08-19
 
 ### Fixed

--- a/nowledge-mem-opencode-plugin/README.md
+++ b/nowledge-mem-opencode-plugin/README.md
@@ -57,7 +57,7 @@ The plugin follows OpenCode's standard plugin update mechanism. To pin a specifi
 
 ```json
 {
-  "plugin": ["opencode-nowledge-mem@0.3.9"]
+  "plugin": ["opencode-nowledge-mem@0.3.10"]
 }
 ```
 

--- a/nowledge-mem-opencode-plugin/dist/index.js
+++ b/nowledge-mem-opencode-plugin/dist/index.js
@@ -1,10 +1,78 @@
-// Generated from src/index.ts. Run bun run build before publishing.
+// Generated from src/index.ts. Run npm run build before publishing.
 
 // src/index.ts
 import { tool } from "@opencode-ai/plugin";
-import { existsSync, readFileSync } from "node:fs";
+import { existsSync as existsSync2, readFileSync as readFileSync2 } from "node:fs";
 import { homedir } from "node:os";
 import { join } from "node:path";
+
+// src/cli-runner.mjs
+import { execFile } from "node:child_process";
+import { existsSync, readFileSync } from "node:fs";
+var MAX_OUTPUT_BYTES = 64 * 1024 * 1024;
+function createNmemCliRunner(shell, execFileImpl = execFile, { platform = process.platform, readFileImpl = readFileSync, existsImpl = existsSync } = {}) {
+  if (typeof shell === "function") {
+    return async (args) => shell`nmem --json ${args}`.text();
+  }
+  let commandPromise;
+  const command = async () => {
+    if (platform !== "win32") return "nmem";
+    commandPromise ??= resolveWindowsNmemExecutable(execFileImpl, readFileImpl, existsImpl);
+    return commandPromise;
+  };
+  return async (args) => {
+    const executable = await command();
+    if (!executable) {
+      const error = new Error("nmem CLI executable was not found");
+      error.code = "ENOENT";
+      throw error;
+    }
+    return new Promise((resolve, reject) => {
+      execFileImpl(
+        executable,
+        ["--json", ...args],
+        { encoding: "utf8", maxBuffer: MAX_OUTPUT_BYTES },
+        (error, stdout, stderr) => {
+          if (error) {
+            error.stderr = String(stderr ?? "");
+            reject(error);
+            return;
+          }
+          resolve(String(stdout ?? ""));
+        }
+      );
+    });
+  };
+}
+function runExecFile(execFileImpl, file, args, options) {
+  return new Promise((resolve) => {
+    execFileImpl(file, args, options, (error, stdout, stderr) => {
+      resolve({ error, stdout: String(stdout ?? ""), stderr: String(stderr ?? "") });
+    });
+  });
+}
+async function resolveWindowsNmemExecutable(execFileImpl, readFileImpl, existsImpl) {
+  const whereOptions = { encoding: "utf8", maxBuffer: 64 * 1024 };
+  const direct = await runExecFile(execFileImpl, "where.exe", ["nmem.exe"], whereOptions);
+  if (!direct.error) {
+    const directPath = direct.stdout.split(/\r?\n/).map((line) => line.trim()).find((line) => line && existsImpl(line));
+    if (directPath) return directPath;
+  }
+  const wrapper = await runExecFile(execFileImpl, "where.exe", ["nmem.cmd"], whereOptions);
+  if (wrapper.error) return null;
+  for (const candidate of wrapper.stdout.split(/\r?\n/).map((line) => line.trim())) {
+    if (!candidate) continue;
+    let contents;
+    try {
+      contents = readFileImpl(candidate, "utf8");
+    } catch {
+      continue;
+    }
+    const match = contents.match(/^\s*"([^"\r\n]+\.exe)"\s+%\*\s*$/m);
+    if (match?.[1] && existsImpl(match[1])) return match[1];
+  }
+  return null;
+}
 
 // src/session-delta.ts
 import { createHash } from "node:crypto";
@@ -142,13 +210,14 @@ var index_default = {
   id: "nowledge-mem",
   server: async (input) => {
     const { $, client, directory } = input;
+    const runNmemCli = createNmemCliRunner($);
     async function nmem(args) {
       try {
-        const result = await $`nmem --json ${withAmbientSpaceArg(args)}`.text();
+        const result = await runNmemCli(withAmbientSpaceArg(args));
         return result.trim();
       } catch (err) {
         const stderr = String(err?.stderr ?? "");
-        if (stderr.includes("command not found") || stderr.includes("not recognized")) {
+        if (err?.code === "ENOENT" || stderr.includes("command not found") || stderr.includes("not recognized")) {
           return JSON.stringify({
             error: "nmem CLI not found. Install it from Nowledge Mem: Settings > Developer Tools > Install CLI, or run: pip install nmem-cli"
           });
@@ -167,8 +236,8 @@ var index_default = {
     function readSharedConfig() {
       const path = join(homedir(), ".nowledge-mem", "config.json");
       try {
-        if (!existsSync(path)) return {};
-        const parsed = JSON.parse(readFileSync(path, "utf8"));
+        if (!existsSync2(path)) return {};
+        const parsed = JSON.parse(readFileSync2(path, "utf8"));
         return parsed && typeof parsed === "object" && !Array.isArray(parsed) ? parsed : {};
       } catch {
         return {};

--- a/nowledge-mem-opencode-plugin/package.json
+++ b/nowledge-mem-opencode-plugin/package.json
@@ -1,12 +1,13 @@
 {
   "name": "opencode-nowledge-mem",
-  "version": "0.3.9",
+  "version": "0.3.10",
   "description": "Nowledge Mem plugin for OpenCode. Cross-tool knowledge with idle-event thread capture, Context Bundle, search, save, and handoffs.",
   "type": "module",
   "main": "dist/index.js",
   "scripts": {
     "build": "esbuild src/index.ts --bundle --platform=node --format=esm --external:@opencode-ai/plugin --outfile=dist/index.js --banner:js='// Generated from src/index.ts. Run npm run build before publishing.'",
-    "check": "npm run build && node --check dist/index.js"
+    "check": "npm run build && node --check dist/index.js",
+    "test": "node --test tests/*.test.mjs"
   },
   "files": [
     "dist",

--- a/nowledge-mem-opencode-plugin/src/cli-runner.mjs
+++ b/nowledge-mem-opencode-plugin/src/cli-runner.mjs
@@ -1,0 +1,91 @@
+import { execFile } from "node:child_process"
+import { existsSync, readFileSync } from "node:fs"
+
+const MAX_OUTPUT_BYTES = 64 * 1024 * 1024
+
+/**
+ * Build the CLI transport supported by the current OpenCode host.
+ *
+ * OpenCode CLI supplies Bun's tagged-template shell while OpenCode Desktop's
+ * Node sidecar intentionally leaves it undefined. The Node fallback uses an
+ * argv array directly so Space names and user content never pass through a
+ * shell parser. Windows desktop installs expose a `.cmd` wrapper, so the
+ * fallback resolves the Rust `.exe` behind our generated wrapper first.
+ */
+export function createNmemCliRunner(
+  shell,
+  execFileImpl = execFile,
+  { platform = process.platform, readFileImpl = readFileSync, existsImpl = existsSync } = {},
+) {
+  if (typeof shell === "function") {
+    return async (args) => shell`nmem --json ${args}`.text()
+  }
+
+  let commandPromise
+  const command = async () => {
+    if (platform !== "win32") return "nmem"
+    commandPromise ??= resolveWindowsNmemExecutable(execFileImpl, readFileImpl, existsImpl)
+    return commandPromise
+  }
+
+  return async (args) => {
+    const executable = await command()
+    if (!executable) {
+      const error = new Error("nmem CLI executable was not found")
+      error.code = "ENOENT"
+      throw error
+    }
+    return new Promise((resolve, reject) => {
+      execFileImpl(
+        executable,
+        ["--json", ...args],
+        { encoding: "utf8", maxBuffer: MAX_OUTPUT_BYTES },
+        (error, stdout, stderr) => {
+          if (error) {
+            error.stderr = String(stderr ?? "")
+            reject(error)
+            return
+          }
+          resolve(String(stdout ?? ""))
+        },
+      )
+    })
+  }
+}
+
+function runExecFile(execFileImpl, file, args, options) {
+  return new Promise((resolve) => {
+    execFileImpl(file, args, options, (error, stdout, stderr) => {
+      resolve({ error, stdout: String(stdout ?? ""), stderr: String(stderr ?? "") })
+    })
+  })
+}
+
+async function resolveWindowsNmemExecutable(execFileImpl, readFileImpl, existsImpl) {
+  const whereOptions = { encoding: "utf8", maxBuffer: 64 * 1024 }
+  const direct = await runExecFile(execFileImpl, "where.exe", ["nmem.exe"], whereOptions)
+  if (!direct.error) {
+    const directPath = direct.stdout
+      .split(/\r?\n/)
+      .map((line) => line.trim())
+      .find((line) => line && existsImpl(line))
+    if (directPath) return directPath
+  }
+
+  const wrapper = await runExecFile(execFileImpl, "where.exe", ["nmem.cmd"], whereOptions)
+  if (wrapper.error) return null
+  for (const candidate of wrapper.stdout.split(/\r?\n/).map((line) => line.trim())) {
+    if (!candidate) continue
+    let contents
+    try {
+      contents = readFileImpl(candidate, "utf8")
+    } catch {
+      continue
+    }
+    // This is the exact wrapper shape emitted by the desktop app's Rust CLI
+    // installer. Do not execute arbitrary batch files through a shell.
+    const match = contents.match(/^\s*"([^"\r\n]+\.exe)"\s+%\*\s*$/m)
+    if (match?.[1] && existsImpl(match[1])) return match[1]
+  }
+  return null
+}

--- a/nowledge-mem-opencode-plugin/src/index.ts
+++ b/nowledge-mem-opencode-plugin/src/index.ts
@@ -4,6 +4,7 @@ import { existsSync, readFileSync } from "node:fs"
 import { homedir } from "node:os"
 import { join } from "node:path"
 
+import { createNmemCliRunner } from "./cli-runner.mjs"
 import {
   appendAcknowledgedRemoteCount,
   createAcknowledgedRemoteCount,
@@ -55,18 +56,21 @@ export default {
   id: "nowledge-mem",
   server: async (input) => {
     const { $, client, directory } = input
+    const runNmemCli = createNmemCliRunner($)
 
     // --- CLI transport (for memory operations) ---
 
     async function nmem(args: string[]): Promise<string> {
       try {
-        // Bun's $ tagged template escapes each array element as a separate
-        // shell argument, so values containing spaces/quotes are safe.
-        const result = await $`nmem --json ${withAmbientSpaceArg(args)}`.text()
+        const result = await runNmemCli(withAmbientSpaceArg(args))
         return result.trim()
       } catch (err: any) {
         const stderr = String(err?.stderr ?? "")
-        if (stderr.includes("command not found") || stderr.includes("not recognized")) {
+        if (
+          err?.code === "ENOENT" ||
+          stderr.includes("command not found") ||
+          stderr.includes("not recognized")
+        ) {
           return JSON.stringify({
             error: "nmem CLI not found. Install it from Nowledge Mem: Settings > Developer Tools > Install CLI, or run: pip install nmem-cli",
           })

--- a/nowledge-mem-opencode-plugin/tests/cli-runner.test.mjs
+++ b/nowledge-mem-opencode-plugin/tests/cli-runner.test.mjs
@@ -1,0 +1,81 @@
+import assert from "node:assert/strict"
+import test from "node:test"
+
+import { createNmemCliRunner } from "../src/cli-runner.mjs"
+
+test("Node fallback invokes nmem with exact argv", async () => {
+  let invocation
+  const execFile = (file, args, options, callback) => {
+    invocation = { file, args, options }
+    callback(null, '{"ok":true}\n', "")
+  }
+
+  const run = createNmemCliRunner(undefined, execFile)
+  const output = await run(["m", "search", "project one", "$(touch nope)"])
+
+  assert.equal(output, '{"ok":true}\n')
+  assert.deepEqual(invocation, {
+    file: "nmem",
+    args: ["--json", "m", "search", "project one", "$(touch nope)"],
+    options: { encoding: "utf8", maxBuffer: 64 * 1024 * 1024 },
+  })
+})
+
+test("Bun shell remains the preferred CLI transport", async () => {
+  let template
+  const shell = (strings, ...values) => {
+    template = { strings: [...strings], values }
+    return { text: async () => "bun-result" }
+  }
+  const execFile = () => assert.fail("Node fallback must not run when Bun shell is available")
+
+  const run = createNmemCliRunner(shell, execFile)
+  const args = ["wm", "--space", "Project One"]
+
+  assert.equal(await run(args), "bun-result")
+  assert.deepEqual(template.values, [args])
+})
+
+test("Windows resolves the Rust executable behind the desktop cmd wrapper", async () => {
+  const calls = []
+  const rustExecutable = String.raw`C:\Users\User\AppData\Local\Nowledge Mem\_up_\rust-backend\nmem.exe`
+  const wrapper = String.raw`C:\Users\User\AppData\Local\Nowledge Mem\cli\nmem.cmd`
+  const execFile = (file, args, options, callback) => {
+    calls.push({ file, args, options })
+    if (file === "where.exe" && args[0] === "nmem.exe") {
+      callback(new Error("not found"), "", "")
+    } else if (file === "where.exe" && args[0] === "nmem.cmd") {
+      callback(null, `${wrapper}\r\n`, "")
+    } else {
+      callback(null, "{\"ok\":true}\n", "")
+    }
+  }
+  const readFile = (path) => {
+    assert.equal(path, wrapper)
+    return `@echo off\r\n"${rustExecutable}" %*\r\n`
+  }
+  const run = createNmemCliRunner(undefined, execFile, {
+    platform: "win32",
+    readFileImpl: readFile,
+    existsImpl: (path) => path === rustExecutable,
+  })
+
+  assert.equal(await run(["m", "search", "project one", "& unsafe"]), '{"ok":true}\n')
+  assert.equal(calls.at(-1).file, rustExecutable)
+  assert.deepEqual(calls.at(-1).args, ["--json", "m", "search", "project one", "& unsafe"])
+  assert.deepEqual(calls.at(-1).options, { encoding: "utf8", maxBuffer: 64 * 1024 * 1024 })
+})
+
+test("Node fallback preserves stderr on process failures", async () => {
+  const execFile = (_file, _args, _options, callback) => {
+    const error = new Error("nmem exited with status 1")
+    callback(error, "", "server unavailable")
+  }
+
+  const run = createNmemCliRunner(undefined, execFile)
+
+  await assert.rejects(run(["status"]), (error) => {
+    assert.equal(error.stderr, "server unavailable")
+    return true
+  })
+})


### PR DESCRIPTION
### Issue

Issue Number: close #541

### Background

The OpenCode plugin has a CLI transport for memory tools and a separate HTTP
transport for large thread operations. OpenCode's Bun host supplies a `$`
shell helper, but OpenCode Desktop's Node sidecar intentionally does not.

### What problem does this PR solve?

On OpenCode Desktop, every CLI-backed `nowledge_mem_*` tool failed with
`TypeError: $ is not a function`, leaving only HTTP-backed thread operations
usable.

### How does it work?

The plugin keeps Bun's tagged-template runner when the host provides it. On
Node, it invokes `nmem` through `child_process.execFile` with
`["--json", ...args]`, preserving each argument exactly without shell parsing.
The existing error mapping remains intact, including stderr, with an explicit
`ENOENT` path for a missing CLI. The HTTP transport and thread capture behavior
are unchanged.

### Tests

- [x] `npm test` — 12 passed, 0 failed, including exact Node argv with spaces
  and shell metacharacters, Bun-path preference, and stderr preservation.
- [x] `npm run check` — esbuild completed and `node --check dist/index.js`
  passed.
- [x] `git diff --check` — passed.

### Side effects / risks

- [x] No Rust, Python, Kuzu, Cloud, database, or HTTP contract changes.
- [x] Bumped the OpenCode plugin and registry version from 0.3.9 to 0.3.10.
- [x] Regenerated the published `dist/index.js` entry point.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped to OpenCode plugin CLI invocation with tests; no Mem server, auth, or HTTP contract changes.
> 
> **Overview**
> Fixes **CLI-backed `nowledge_mem_*` tools on OpenCode Desktop**, where the host does not provide Bun’s `$` shell helper and previously failed with `TypeError: $ is not a function`.
> 
> The plugin now routes `nmem` through **`createNmemCliRunner`**: when `$` exists (OpenCode CLI), behavior is unchanged; on Node it runs **`execFile` with `["--json", ...args]`** so spaces and shell metacharacters stay in argv and are not parsed by a shell. Missing CLI is surfaced via **`ENOENT`** as well as existing stderr patterns. On **Windows**, the fallback resolves the Rust **`nmem.exe`** behind the desktop **`nmem.cmd`** wrapper before launch.
> 
> **HTTP thread capture** and idle/compaction sync are untouched. Version is bumped to **0.3.10** in the package, registry, README pin, and regenerated **`dist/index.js`**, with **`npm test`** covering Node argv, Bun preference, Windows resolution, and stderr preservation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e37009a4c8b5dcb6e92f44889c8eee75dd354d5c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->