### PR TITLE
fix(cursor): use the desktop startup context tool

### DIFF
--- a/integrations.json
+++ b/integrations.json
@@ -29,7 +29,7 @@
         "search": true,
         "distill": true,
         "autoRecall": true,
-        "autoCapture": false,
+        "autoCapture": true,
         "graphExploration": false,
         "status": true
       },
@@ -610,7 +610,7 @@
       "name": "Cursor",
       "category": "coding",
       "type": "plugin",
-      "version": "0.2.0",
+      "version": "0.2.1",
       "directory": "nowledge-mem-cursor-plugin",
       "transport": "mcp+hook",
       "capabilities": {

--- a/nowledge-mem-cursor-plugin/.cursor-plugin/plugin.json
+++ b/nowledge-mem-cursor-plugin/.cursor-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "nowledge-mem-cursor",
   "description": "Bring startup context, memory recall, and automatic Cursor transcript capture into Cursor with Nowledge Mem.",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "author": {
     "name": "Nowledge Labs",
     "email": "hello@nowledge-labs.ai",

--- a/nowledge-mem-cursor-plugin/CHANGELOG.md
+++ b/nowledge-mem-cursor-plugin/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 ## Unreleased
 
+## [0.2.1] - 2026-08-27
+
+### Fixed
+
+- Pointed all Cursor MCP guidance at `read_context_bundle`, the briefing tool
+  served by the desktop MCP surface, instead of the Cloud-only legacy
+  `read_working_memory` compatibility name.
+
+### Changed
+
 - Stop capture now hands the exact conversation transcript to the shared
   durable queue instead of waiting for the full importer in the hook process.
 

--- a/nowledge-mem-cursor-plugin/README.md
+++ b/nowledge-mem-cursor-plugin/README.md
@@ -6,7 +6,7 @@ This package follows Cursor's plugin format with `.cursor-plugin/plugin.json`, b
 
 ## What You Get
 
-- MCP-backed `read_working_memory`, `memory_search`, `thread_search`, `thread_fetch_messages`, `memory_add`, and `memory_update`
+- MCP-backed `read_context_bundle`, `memory_search`, `thread_search`, `thread_fetch_messages`, `memory_add`, and `memory_update`
 - Session-start Context Bundle or Working Memory bootstrap when `nmem` is available
 - Automatic import of the exact current Cursor Agent transcript on `stop`
 - Cursor rules for Working Memory timing, proactive recall, retrieval routing, and add-vs-update behavior

--- a/nowledge-mem-cursor-plugin/rules/nowledge-mem.mdc
+++ b/nowledge-mem-cursor-plugin/rules/nowledge-mem.mdc
@@ -8,8 +8,8 @@ Use Nowledge Mem as the primary external memory system in Cursor.
 ## Working Memory
 
 - The package may already inject Context Bundle or Working Memory at session start through a Cursor hook when `nmem` is available.
-- If a fresh `<nowledge_working_memory>` block is already present in the session context, do not immediately call `read_working_memory` again.
-- Read Working Memory with `read_working_memory` near session start, resume, or when the user explicitly asks about current priorities if the hook did not load it or a refresh is needed.
+- If a fresh Context Bundle or `<nowledge_working_memory>` block is already present in the session context, do not immediately call `read_context_bundle` again.
+- Read `read_context_bundle` near session start, resume, or when the user explicitly asks about current priorities if the hook did not load context or a refresh is needed. Its Working Memory section is the supported desktop briefing surface.
 - After reading it, reuse that context mentally. Do not re-read on every turn unless the session context changed materially, the user asks for a refresh, or a long-running session clearly needs it.
 - If the task is clearly a continuation, review, regression, release, or prior-decision question, move from Working Memory into targeted recall instead of stopping at the briefing.
 

--- a/nowledge-mem-cursor-plugin/scripts/validate-plugin.mjs
+++ b/nowledge-mem-cursor-plugin/scripts/validate-plugin.mjs
@@ -167,9 +167,23 @@ async function main() {
     'does not currently have a first-class Nowledge live session importer',
   ];
   const readmeText = await assertNonEmpty('README.md');
+  const workingMemorySkillText = await assertNonEmpty('skills/read-working-memory/SKILL.md');
   for (const staleClaim of staleClaims) {
     if (ruleText.includes(staleClaim) || readmeText.includes(staleClaim)) {
       fail(`Cursor plugin still contains stale transcript-capture guidance: ${staleClaim}`);
+    }
+  }
+
+  for (const [relPath, text] of [
+    ['README.md', readmeText],
+    ['rules/nowledge-mem.mdc', ruleText],
+    ['skills/read-working-memory/SKILL.md', workingMemorySkillText],
+  ]) {
+    if (text.includes('read_working_memory')) {
+      fail(`${relPath} must not instruct Cursor to call the Cloud-only read_working_memory compatibility tool`);
+    }
+    if (!text.includes('read_context_bundle')) {
+      fail(`${relPath} must point Cursor at the desktop read_context_bundle tool`);
     }
   }
 

--- a/nowledge-mem-cursor-plugin/skills/read-working-memory/SKILL.md
+++ b/nowledge-mem-cursor-plugin/skills/read-working-memory/SKILL.md
@@ -5,9 +5,7 @@ description: Read the user's Working Memory briefing when current priorities, re
 
 # Read Working Memory
 
-Use `read_context_bundle` when startup identity, agent lane, space scope, or Rules could matter. It includes owner identity, resolved AI Identity, active scope, active rules, Working Memory, and KFS paths.
-
-Use the `read_working_memory` MCP tool to load only the user's current focus, priorities, and unresolved context when the session-start hook did not already provide it or when a lightweight refresh is needed.
+Use `read_context_bundle` when the session-start hook did not already provide fresh context or when a refresh is needed. It is the supported desktop MCP briefing surface and includes owner identity, resolved AI Identity, active scope, active rules, Working Memory, and KFS paths.
 
 ## When To Use
 
@@ -19,7 +17,7 @@ Use the `read_working_memory` MCP tool to load only the user's current focus, pr
 ## Usage Pattern
 
 - If a fresh Context Bundle or `<nowledge_working_memory>` block is already present, reuse it instead of reading again immediately.
-- Otherwise, read Context Bundle or Working Memory once near the start of the session.
+- Otherwise, call `read_context_bundle` once near the start of the session and use its Working Memory section for the current briefing.
 - If the task is clearly a continuation, review, regression, release, or prior-decision question, move into `search-memory` after the briefing instead of stopping there.
 - Reuse that context mentally instead of re-reading on every turn.
 - Only refresh if the session context changed materially, the user asks, or the work has gone on long enough that a fresh briefing is clearly useful.

--- a/tests/plugin_e2e/test_key_plugins_e2e.py
+++ b/tests/plugin_e2e/test_key_plugins_e2e.py
@@ -339,6 +339,7 @@ def test_key_plugin_static_contracts_are_declared():
     assert claude_marketplace_plugin["version"] == claude_manifest["version"]
     assert registry_by_id["claude-code"]["version"] == claude_manifest["version"]
     assert registry_by_id["grok"]["version"] == claude_manifest["version"]
+    assert registry_by_id["claude-code"]["capabilities"]["autoCapture"] is True
     assert {"SessionStart", "SubagentStart", "UserPromptSubmit", "PreCompact", "Stop"} <= set(claude_hooks)
     assert "nmem-hook-read.sh" in json.dumps(claude_hooks)
     assert "nmem-hook-subagent.py" in json.dumps(claude_hooks["SubagentStart"])
@@ -611,7 +612,14 @@ def test_key_plugin_static_contracts_are_declared():
     cursor_stop_hook = (CURSOR_PLUGIN / "hooks" / "stop-save.mjs").read_text(
         encoding="utf-8"
     )
-    assert cursor_manifest["version"] == "0.2.0"
+    cursor_readme = (CURSOR_PLUGIN / "README.md").read_text(encoding="utf-8")
+    cursor_rule = (CURSOR_PLUGIN / "rules" / "nowledge-mem.mdc").read_text(
+        encoding="utf-8"
+    )
+    cursor_working_memory_skill = (
+        CURSOR_PLUGIN / "skills" / "read-working-memory" / "SKILL.md"
+    ).read_text(encoding="utf-8")
+    assert cursor_manifest["version"] == "0.2.1"
     assert cursor_hooks["hooks"]["sessionStart"][0]["timeout"] == 15
     assert cursor_hooks["hooks"]["stop"][0] == {
         "command": "node ./hooks/stop-save.mjs",
@@ -630,6 +638,9 @@ def test_key_plugin_static_contracts_are_declared():
     assert "'--session-id'," in cursor_stop_hook
     assert "ATTEMPT_DELAYS_MS" in cursor_stop_hook
     assert "latest" not in cursor_stop_hook.lower()
+    for cursor_guidance in (cursor_readme, cursor_rule, cursor_working_memory_skill):
+        assert "read_context_bundle" in cursor_guidance
+        assert "read_working_memory" not in cursor_guidance
 
     workbuddy_marketplace = _read_json(
         COMMUNITY_ROOT / ".workbuddy-plugin" / "marketplace.json"
@@ -1454,7 +1465,7 @@ def test_registry_connect_contract_points_agent_prompts_to_universal_skill():
     assert "slock" in by_id["raft"]["aliases"]
     assert by_id["copilot-cli"]["version"] == "0.1.4"
     assert by_id["gemini-cli"]["version"] == "0.1.9"
-    assert by_id["cursor"]["version"] == "0.2.0"
+    assert by_id["cursor"]["version"] == "0.2.1"
     assert by_id["cursor"]["transport"] == "mcp+hook"
     assert by_id["cursor"]["capabilities"]["autoCapture"] is True
     assert by_id["cursor"]["threadSave"]["method"] == "hook+cli-native"


### PR DESCRIPTION
### Issue

Ref: nowledge-co/mem#2076

### Background

Cursor connects its bundled MCP configuration to the desktop endpoint. That endpoint's bounded external-agent contract serves `read_context_bundle`; `read_working_memory` is a Cloud-only legacy compatibility name.

### Problem

The Cursor README, always-on rule, and read-working-memory skill told the model to call `read_working_memory`. A user following the shipped package therefore received tool-not-found on the normal desktop surface. The registry also advertised Claude Code `autoCapture: false` despite the package's active Stop capture hook.

### How it works

- Points every Cursor MCP guidance surface at `read_context_bundle` and explains that its Working Memory section is the supported briefing path.
- Extends the package validator and plugin static gate so the unsupported name cannot return in README, rules, or the skill.
- Aligns Claude Code registry metadata with its shipped capture hooks.
- Bumps the Cursor package and registry version to `0.2.1` and records the user-visible fix.

### Tests

- `node scripts/validate-plugin.mjs` -> validated manifest, capture hooks, skills, MCP config, registry, and marketplace.
- `node --test tests/*.test.mjs` -> 7 passed, 0 failed.
- Focused static contract script -> 8 assertions passed across registry, version parity, and all three Cursor guidance files.
- The repository's combined Python function reaches and passes the new assertions, then fails on a pre-existing OpenCode `0.3.10` vs stale `0.3.9` expectation introduced on current `main`; this PR does not mask or mix that unrelated drift.

### Rollout

The parent `nowledge-co/mem` documentation and submodule-pointer PR will be opened only after this child commit is available, and the child must merge first.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation, validation, and registry metadata only; no runtime hook or MCP server logic changes in this diff.
> 
> **Overview**
> **Fixes desktop Cursor users hitting tool-not-found** when agents followed shipped docs and called the Cloud-only `read_working_memory` name instead of the desktop MCP tool `read_context_bundle`.
> 
> The Cursor package **0.2.1** updates the README, always-on rule, and `read-working-memory` skill so startup/briefing guidance consistently uses **`read_context_bundle`** and treats its Working Memory section as the supported desktop briefing surface. **`validate-plugin.mjs`** and the plugin e2e gate now **reject** `read_working_memory` in those guidance files and **require** `read_context_bundle`, so the wrong name cannot slip back in.
> 
> **Registry alignment:** `integrations.json` sets Claude Code **`autoCapture: true`** to match its Stop capture hooks, and bumps Cursor to **0.2.1** with version parity in tests.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7bae70c5d39a1818c62007962c9bdb3bcf84ae94. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->