### PR TITLE
test(opencode): align static contract with 0.3.10

### DIFF
--- a/tests/plugin_e2e/test_key_plugins_e2e.py
+++ b/tests/plugin_e2e/test_key_plugins_e2e.py
@@ -524,7 +524,7 @@ def test_key_plugin_static_contracts_are_declared():
     opencode_pkg = _read_json(OPENCODE_PLUGIN / "package.json")
     opencode_source = (OPENCODE_PLUGIN / "src" / "index.ts").read_text(encoding="utf-8")
     assert opencode_pkg["name"] == "opencode-nowledge-mem"
-    assert opencode_pkg["version"] == "0.3.9"
+    assert opencode_pkg["version"] == "0.3.10"
     assert registry_by_id["opencode"]["version"] == opencode_pkg["version"]
     assert registry_by_id["opencode"]["capabilities"]["autoCapture"] is True
     assert registry_by_id["opencode"]["autonomy"]["threads"] == "automatic-capture"
@@ -1475,7 +1475,7 @@ def test_registry_connect_contract_points_agent_prompts_to_universal_skill():
     assert by_id["droid"]["version"] == "0.1.1"
     assert by_id["openclaw"]["version"] == "0.8.32"
     assert by_id["proma"]["version"] == "0.1.5"
-    assert by_id["opencode"]["version"] == "0.3.9"
+    assert by_id["opencode"]["version"] == "0.3.10"
     assert by_id["pi"]["version"] == "0.8.7"
     assert by_id["pi"]["capabilities"]["autoRecall"] is True
     assert by_id["pi"]["autonomy"]["recall"] == "startup-context-injection"


### PR DESCRIPTION
### Issue

Ref: nowledge-co/mem#2123

### Problem

Community PR #548 bumped the OpenCode package and canonical registry to `0.3.10`, but two shared plugin contract assertions remained pinned to `0.3.9`. Any later integration change running those functions failed on unrelated OpenCode metadata.

### Fix

Align both source-pin expectations with the package and registry at `0.3.10`. OpenCode runtime behavior, package contents, and registry metadata are unchanged.

### Tests

- Focused OpenCode version contract -> 5 assertions passed.
- `test_registry_connect_contract_points_agent_prompts_to_universal_skill` -> passed.
- `test_key_plugin_static_contracts_are_declared` now passes both corrected OpenCode assertions and proceeds to a separate pre-existing Copilot hook expectation failure; that independent drift is not mixed into this PR.
- `git diff --check` -> pass.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only version string updates with no production code or integration behavior changes.
> 
> **Overview**
> Updates **OpenCode version expectations** in the shared plugin E2E contract tests from `0.3.9` to **`0.3.10`**, matching the package and `integrations.json` registry after the earlier bump in community PR #548.
> 
> The changes are limited to **`test_key_plugin_static_contracts_are_declared`** (package `package.json` pin) and **`test_registry_connect_contract_points_agent_prompts_to_universal_skill`** (registry `by_id["opencode"]["version"]`). No plugin source, registry metadata, or runtime behavior is modified in this diff.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 371f6e398aa0d58de3362780268ef34b27504c8e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->