### PR TITLE
test(copilot): pin hook contracts to their implementation

### DIFF
--- a/tests/plugin_e2e/test_key_plugins_e2e.py
+++ b/tests/plugin_e2e/test_key_plugins_e2e.py
@@ -552,15 +552,18 @@ def test_key_plugin_static_contracts_are_declared():
 
     copilot_manifest = _read_json(COPILOT_PLUGIN / ".claude-plugin" / "plugin.json")
     copilot_hooks = _read_json(COPILOT_PLUGIN / "hooks" / "hooks.json")
+    copilot_hook = (COPILOT_PLUGIN / "hooks" / "copilot-hook.py").read_text(
+        encoding="utf-8"
+    )
     copilot_capture = (COPILOT_PLUGIN / "hooks" / "copilot-stop-save.py").read_text(encoding="utf-8")
     assert copilot_manifest["version"] == "0.1.4"
     assert copilot_marketplace_plugin["version"] == copilot_manifest["version"]
     assert registry_by_id["copilot-cli"]["version"] == copilot_manifest["version"]
-    assert "--source-app copilot-cli" in json.dumps(copilot_hooks)
-    assert "NMEM_AGENT_ID" in json.dumps(copilot_hooks)
-    assert "NMEM_HOST_AGENT_ID" in json.dumps(copilot_hooks)
-    assert "rendered_markdown" in json.dumps(copilot_hooks)
-    assert "wm read" in json.dumps(copilot_hooks)
+    assert '"context", "--source-app", "copilot-cli"' in copilot_hook
+    assert "NMEM_AGENT_ID" in copilot_hook
+    assert "NMEM_HOST_AGENT_ID" in copilot_hook
+    assert "rendered_markdown" in copilot_hook
+    assert '"wm", "read"' in copilot_hook
     assert "CREATE_NO_WINDOW" in copilot_capture
 
     droid_manifest = _read_json(DROID_PLUGIN / ".factory-plugin" / "plugin.json")


### PR DESCRIPTION
### Issue

Ref: nowledge-co/mem#2124

### Problem

The Copilot cross-shell hook refactor moved context argument construction, identity forwarding, response decoding, and Working Memory fallback into `hooks/copilot-hook.py`. The shared static gate still searched serialized `hooks.json`, which now only owns script launch and lifecycle event routing.

### Fix

Read the Python hook in the existing static test and pin the five implementation contracts there. Existing manifest, marketplace, lifecycle-wrapper, and capture assertions remain unchanged. No Copilot runtime or package behavior changes.

### Tests

- Focused Copilot implementation source pins -> 6 assertions passed.
- The full `test_key_plugin_static_contracts_are_declared` passes the corrected OpenCode and Copilot sections and proceeds through Droid, Gemini, and Proma; it then exposes an independent pre-existing Cursor stop-hook assertion drift, which is not mixed into this PR.
- `git diff --check` -> pass.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only change; no Copilot plugin runtime or packaging behavior is modified.
> 
> **Overview**
> Updates the Copilot section of **`test_key_plugin_static_contracts_are_declared`** so static contract checks target **`hooks/copilot-hook.py`** instead of serialized **`hooks.json`**.
> 
> After the cross-shell refactor, **`hooks.json`** mainly wires script launch and lifecycle routing; context **`--source-app`**, identity env forwarding, **`rendered_markdown`** handling, and Working Memory fallback live in the Python hook. The test loads that file and asserts the same five implementation strings there (with slightly stricter argv-shaped expectations for context and **`wm read`**). Manifest, marketplace, and **`copilot-stop-save.py`** assertions are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 34adbaec57808b432f3d52a6b40641d8848ddc78. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->