### PR TITLE
fix(mcp): canonicalize community endpoints

### DIFF
--- a/.github/workflows/mcp-endpoint-contract.yml
+++ b/.github/workflows/mcp-endpoint-contract.yml
@@ -1,0 +1,23 @@
+name: MCP endpoint contract
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: read
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+      - name: Reject legacy trailing-slash MCP endpoints
+        run: python -m unittest tests/plugin_e2e/test_mcp_endpoint_contract.py

--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ Add to your tool's MCP settings:
 {
   "mcpServers": {
     "nowledge-mem": {
-      "url": "http://127.0.0.1:14242/mcp/",
+      "url": "http://127.0.0.1:14242/mcp",
       "type": "streamableHttp"
     }
   }

--- a/integrations.json
+++ b/integrations.json
@@ -2406,7 +2406,7 @@
         ]
       },
       "install": {
-        "command": "Point your MCP client at http://127.0.0.1:14242/mcp/",
+        "command": "Point your MCP client at http://127.0.0.1:14242/mcp",
         "docsUrl": "/docs/integrations#model-context-protocol-mcp"
       },
       "toolNaming": {

--- a/mcp.json
+++ b/mcp.json
@@ -1,7 +1,7 @@
 {
   "mcpServers": {
     "nowledge-mem": {
-      "url": "http://127.0.0.1:14242/mcp/",
+      "url": "http://127.0.0.1:14242/mcp",
       "type": "streamableHttp",
       "headers": {
         "APP": "<MCP Client App Name here>",

--- a/nowledge-mem-agent-plugin/README.md
+++ b/nowledge-mem-agent-plugin/README.md
@@ -25,7 +25,7 @@ After install, start Nowledge Mem Desktop or point your local `nmem` CLI at your
 The standard `mcp.json` deliberately points to local Mem:
 
 ```text
-http://127.0.0.1:14242/mcp/
+http://127.0.0.1:14242/mcp
 ```
 
 Agent Plugins 1.0 allows literal HTTP headers, but does not define a safe cross-client credential reference for API keys. Do not publish private keys in this package.

--- a/nowledge-mem-agent-plugin/mcp.json
+++ b/nowledge-mem-agent-plugin/mcp.json
@@ -3,7 +3,7 @@
   "mcpServers": {
     "nowledge-mem": {
       "type": "streamable-http",
-      "url": "http://127.0.0.1:14242/mcp/"
+      "url": "http://127.0.0.1:14242/mcp"
     }
   }
 }

--- a/nowledge-mem-cindy-connector/README.md
+++ b/nowledge-mem-cindy-connector/README.md
@@ -28,7 +28,7 @@ In Cindy, add a custom MCP server named `nowledge-mem` using the generated URL
 and headers. For local desktop Mem, that points to:
 
 ```text
-http://127.0.0.1:14242/mcp/
+http://127.0.0.1:14242/mcp
 ```
 
 For Nowledge Cloud, Access Anywhere, or a self-hosted server, configure the

--- a/nowledge-mem-codebuddy-plugin/.mcp.json
+++ b/nowledge-mem-codebuddy-plugin/.mcp.json
@@ -2,7 +2,7 @@
   "mcpServers": {
     "nowledge-mem": {
       "type": "http",
-      "url": "http://127.0.0.1:14242/mcp/",
+      "url": "http://127.0.0.1:14242/mcp",
       "headers": {
         "APP": "CodeBuddy"
       }

--- a/nowledge-mem-codex-plugin/.mcp.json
+++ b/nowledge-mem-codex-plugin/.mcp.json
@@ -2,7 +2,7 @@
   "mcpServers": {
     "nowledge-mem": {
       "type": "http",
-      "url": "http://127.0.0.1:14242/mcp/",
+      "url": "http://127.0.0.1:14242/mcp",
       "http_headers": {
         "APP": "Codex"
       }

--- a/nowledge-mem-codex-plugin/README.md
+++ b/nowledge-mem-codex-plugin/README.md
@@ -170,7 +170,7 @@ On current Codex builds, enabled plugins contribute `hooks/hooks.json` automatic
 
 The same setup asks `nmem` for a Codex MCP config and writes a managed `mcp_servers.nowledge-mem` block into `~/.codex/config.toml`. Besides remote URL and authentication, this block maps `NMEM_AGENT_ID`, `NMEM_HOST_AGENT_ID`, and `NMEM_SPACE` through Codex's native environment-backed HTTP headers. A named Raft/Codex worker therefore appears automatically under **Context → AI Identities**, and its MCP searches and writes use that identity's configured default Space. Existing user-owned MCP blocks are never replaced.
 
-The package still includes a local fallback MCP server at `http://127.0.0.1:14242/mcp/`, but its static plugin manifest cannot resolve process-specific environment values. Rerun `scripts/install_hooks.py` after updating the plugin so named agents receive the identity-aware managed block.
+The package still includes a local fallback MCP server at `http://127.0.0.1:14242/mcp`, but its static plugin manifest cannot resolve process-specific environment values. Rerun `scripts/install_hooks.py` after updating the plugin so named agents receive the identity-aware managed block.
 
 If you prefer to copy a bundled example, see [`codex.config.example.toml`](./codex.config.example.toml).
 

--- a/nowledge-mem-codex-plugin/codex.config.example.toml
+++ b/nowledge-mem-codex-plugin/codex.config.example.toml
@@ -42,7 +42,7 @@ enabled = true
 # nmem config mcp show --host codex
 #
 # [mcp_servers.nowledge-mem]
-# url = "https://mem.example.com/mcp/"
+# url = "https://mem.example.com/mcp"
 # env_http_headers = { "X-Nmem-Agent-Id" = "NMEM_AGENT_ID", "X-Nmem-Host-Agent-Id" = "NMEM_HOST_AGENT_ID", "X-Nmem-Space-Id" = "NMEM_SPACE" }
 #
 # [mcp_servers.nowledge-mem.http_headers]

--- a/nowledge-mem-codex-plugin/tests/test_codex_plugin.py
+++ b/nowledge-mem-codex-plugin/tests/test_codex_plugin.py
@@ -1379,7 +1379,7 @@ class InstallHookTests(unittest.TestCase):
             "rendered": "\n".join(
                 [
                     "[mcp_servers.nowledge-mem]",
-                    'url = "http://127.0.0.1:14242/mcp/"',
+                    'url = "http://127.0.0.1:14242/mcp"',
                     "",
                     "[mcp_servers.nowledge-mem.http_headers]",
                     'APP = "Codex"',
@@ -1418,7 +1418,7 @@ class InstallHookTests(unittest.TestCase):
             "rendered": "\n".join(
                 [
                     "[mcp_servers.nowledge-mem]",
-                    'url = "http://127.0.0.1:14242/mcp/"',
+                    'url = "http://127.0.0.1:14242/mcp"',
                     "",
                     "[mcp_servers.nowledge-mem.http_headers]",
                     'APP = "Codex"',
@@ -1455,7 +1455,7 @@ class InstallHookTests(unittest.TestCase):
             "rendered": "\n".join(
                 [
                     "[mcp_servers.nowledge-mem]",
-                    'url = "http://127.0.0.1:14242/mcp/"',
+                    'url = "http://127.0.0.1:14242/mcp"',
                     "",
                     "[mcp_servers.nowledge-mem.http_headers]",
                     'Authorization = "Bearer nmem_test"',
@@ -1492,7 +1492,7 @@ class InstallHookTests(unittest.TestCase):
             "rendered": "\n".join(
                 [
                     "[mcp_servers.nowledge-mem]",
-                    'url = "http://127.0.0.1:14242/mcp/"',
+                    'url = "http://127.0.0.1:14242/mcp"',
                     "",
                     "[mcp_servers.nowledge-mem.http_headers]",
                     'Authorization = "Bearer nmem_test"',
@@ -1511,12 +1511,12 @@ class InstallHookTests(unittest.TestCase):
     def test_install_codex_mcp_config_writes_identity_aware_local_override(self):
         payload = {
             "apiKeyConfigured": False,
-            "endpoint": "http://127.0.0.1:14242/mcp/",
+            "endpoint": "http://127.0.0.1:14242/mcp",
             "warnings": [],
             "rendered": "\n".join(
                 [
                     "[mcp_servers.nowledge-mem]",
-                    'url = "http://127.0.0.1:14242/mcp/"',
+                    'url = "http://127.0.0.1:14242/mcp"',
                     'env_http_headers = { "X-Nmem-Agent-Id" = "NMEM_AGENT_ID" }',
                     "",
                     "[mcp_servers.nowledge-mem.http_headers]",
@@ -1554,12 +1554,12 @@ class InstallHookTests(unittest.TestCase):
         )
         payload = {
             "apiKeyConfigured": False,
-            "endpoint": "http://127.0.0.1:14242/mcp/",
+            "endpoint": "http://127.0.0.1:14242/mcp",
             "warnings": [],
             "rendered": "\n".join(
                 [
                     "[mcp_servers.nowledge-mem]",
-                    'url = "http://127.0.0.1:14242/mcp/"',
+                    'url = "http://127.0.0.1:14242/mcp"',
                     'env_http_headers = { "X-Nmem-Agent-Id" = "NMEM_AGENT_ID" }',
                     "",
                     "[mcp_servers.nowledge-mem.http_headers]",
@@ -1600,7 +1600,7 @@ class InstallHookTests(unittest.TestCase):
             "rendered": "\n".join(
                 [
                     "[mcp_servers.nowledge-mem]",
-                    'url = "http://127.0.0.1:14242/mcp/"',
+                    'url = "http://127.0.0.1:14242/mcp"',
                     "",
                     "[mcp_servers.nowledge-mem.http_headers]",
                     'Authorization = "Bearer nmem_test"',

--- a/nowledge-mem-craft-agent-connector/source-config.example.json
+++ b/nowledge-mem-craft-agent-connector/source-config.example.json
@@ -7,7 +7,7 @@
   "type": "mcp",
   "mcp": {
     "transport": "http",
-    "url": "http://127.0.0.1:14242/mcp/",
+    "url": "http://127.0.0.1:14242/mcp",
     "authType": "none",
     "headers": {
       "APP": "Craft Agent"

--- a/nowledge-mem-deepseek-harness-plugin/README.md
+++ b/nowledge-mem-deepseek-harness-plugin/README.md
@@ -26,7 +26,7 @@ nmem config mcp show --host deepseek-harness
 The bundle connects to the local Mem MCP endpoint by default:
 
 ```text
-http://127.0.0.1:14242/mcp/
+http://127.0.0.1:14242/mcp
 ```
 
 For Nowledge Cloud or another remote Mem, set:

--- a/nowledge-mem-deepseek-harness-plugin/cordis.patch.yml
+++ b/nowledge-mem-deepseek-harness-plugin/cordis.patch.yml
@@ -21,7 +21,7 @@
       config:
         serverName: nowledge_mem
         transport: streamable-http
-        url: !!js process.env.NMEM_MCP_URL ?? process.env.NOWLEDGE_MEM_MCP_URL ?? 'http://127.0.0.1:14242/mcp/'
+        url: !!js (process.env.NMEM_MCP_URL ?? process.env.NOWLEDGE_MEM_MCP_URL ?? 'http://127.0.0.1:14242/mcp').replace(/\/+$/, '')
         headers: !!js >
           Object.fromEntries(Object.entries({
             APP: 'DeepSeek Harness',

--- a/nowledge-mem-devin-plugin/mcp_config.json
+++ b/nowledge-mem-devin-plugin/mcp_config.json
@@ -1,7 +1,7 @@
 {
   "mcpServers": {
     "nowledge-mem": {
-      "serverUrl": "http://127.0.0.1:14242/mcp/",
+      "serverUrl": "http://127.0.0.1:14242/mcp",
       "headers": {
         "APP": "Devin"
       }

--- a/nowledge-mem-devin-plugin/scripts/validate-plugin.mjs
+++ b/nowledge-mem-devin-plugin/scripts/validate-plugin.mjs
@@ -42,7 +42,7 @@ if (existsSync(join(root, ".mcp.json"))) {
   errors.push("Devin loads mcp_config.json, not .mcp.json");
 }
 const server = mcp.mcpServers?.["nowledge-mem"];
-if (server?.serverUrl !== "http://127.0.0.1:14242/mcp/") {
+if (server?.serverUrl !== "http://127.0.0.1:14242/mcp") {
   errors.push("bundled MCP must remain credential-free loopback");
 }
 if (JSON.stringify(mcp).match(/api[_-]?key|authorization|bearer/i)) {

--- a/nowledge-mem-hermes/setup.ps1
+++ b/nowledge-mem-hermes/setup.ps1
@@ -171,14 +171,14 @@ function Install-McpMode {
         Write-Host "[ok] MCP server already in $ConfigPath"
         $McpReady = $true
     } elseif (-not (Test-Path -LiteralPath $ConfigPath)) {
-        Write-Utf8File $ConfigPath "mcp_servers:`n  nowledge-mem:`n    url: `"http://127.0.0.1:14242/mcp/`"`n    timeout: 120`n"
+        Write-Utf8File $ConfigPath "mcp_servers:`n  nowledge-mem:`n    url: `"http://127.0.0.1:14242/mcp`"`n    timeout: 120`n"
         Write-Host "[ok] Created $ConfigPath with Nowledge Mem MCP server"
         $McpReady = $true
     } else {
         Write-Host "`n[action needed] $ConfigPath exists but does not contain nowledge-mem."
         Write-Host "Add this under the existing mcp_servers block:"
         Write-Host "  nowledge-mem:"
-        Write-Host '    url: "http://127.0.0.1:14242/mcp/"'
+        Write-Host '    url: "http://127.0.0.1:14242/mcp"'
         Write-Host "    timeout: 120"
     }
 

--- a/nowledge-mem-hermes/setup.sh
+++ b/nowledge-mem-hermes/setup.sh
@@ -435,7 +435,7 @@ elif [ ! -f "$CONFIG" ]; then
   cat > "$CONFIG" << 'YAML'
 mcp_servers:
   nowledge-mem:
-    url: "http://127.0.0.1:14242/mcp/"
+    url: "http://127.0.0.1:14242/mcp"
     timeout: 120
 YAML
   echo "[ok] Created $CONFIG with Nowledge Mem MCP server"
@@ -446,7 +446,7 @@ else
   echo "Add the following under your existing mcp_servers: block:"
   echo ""
   echo "    nowledge-mem:"
-  echo '      url: "http://127.0.0.1:14242/mcp/"'
+  echo '      url: "http://127.0.0.1:14242/mcp"'
   echo "      timeout: 120"
   echo ""
 fi

--- a/nowledge-mem-hermes/tests/test_setup.ps1
+++ b/nowledge-mem-hermes/tests/test_setup.ps1
@@ -51,7 +51,10 @@ try {
 
     $McpHome = Join-Path $TempRoot "mcp"
     & $Setup -Mcp -HermesHome $McpHome | Out-Null
-    Assert (([IO.File]::ReadAllText((Join-Path $McpHome "config.yaml"))).Contains("http://127.0.0.1:14242/mcp/")) "MCP config missing"
+    $McpConfig = [IO.File]::ReadAllText((Join-Path $McpHome "config.yaml"))
+    Assert ($McpConfig.Contains('url: "http://127.0.0.1:14242/mcp"')) "MCP config missing"
+    $LegacyMcpUrl = "http://127.0.0.1:14242/mcp" + "/"
+    Assert (-not $McpConfig.Contains($LegacyMcpUrl)) "MCP config uses legacy trailing slash"
     Assert (([IO.File]::ReadAllText((Join-Path $McpHome "SOUL.md"))).Contains("# Nowledge Mem for Hermes")) "MCP guidance missing"
 
     Write-Host "[ok] Hermes native PowerShell installer regression checks passed"

--- a/nowledge-mem-hermes/tests/test_setup.sh
+++ b/nowledge-mem-hermes/tests/test_setup.sh
@@ -214,7 +214,7 @@ set -e
 
 [ "$mcp_status" -eq 0 ] \
   || { echo "$mcp_output" >&2; fail "mcp-no-python exited non-zero without Python"; }
-grep -Fq 'http://127.0.0.1:14242/mcp/' "$mcp_hermes/config.yaml" \
+grep -Fqx '    url: "http://127.0.0.1:14242/mcp"' "$mcp_hermes/config.yaml" \
   || fail "mcp-no-python did not write MCP server config to config.yaml"
 grep -Fq 'nowledge-mem:' "$mcp_hermes/config.yaml" \
   || fail "mcp-no-python did not write nowledge-mem MCP entry"

--- a/nowledge-mem-kimi-work-connector/README.md
+++ b/nowledge-mem-kimi-work-connector/README.md
@@ -7,7 +7,7 @@ Kimi Work is separate from the Kimi Code CLI you may have installed yourself. It
 ## What You Get
 
 - Startup guidance that tells Kimi Work when to read Context Bundle or Working Memory.
-- A bundled local MCP declaration for Mem running at `http://127.0.0.1:14242/mcp/`.
+- A bundled local MCP declaration for Mem running at `http://127.0.0.1:14242/mcp`.
 - CLI fallback for memory search, save, status, and thread search.
 - Historical Kimi Work conversation import with `nmem t sync --from kimi-work`.
 

--- a/nowledge-mem-kimi-work-connector/kimi.plugin.json
+++ b/nowledge-mem-kimi-work-connector/kimi.plugin.json
@@ -15,7 +15,7 @@
   "skillInstructions": "Use Nowledge Mem for durable cross-tool memory. Prefer MCP tools when they are connected; use nmem CLI as the fallback and for Kimi Work transcript import.",
   "mcpServers": {
     "nowledge-mem": {
-      "url": "http://127.0.0.1:14242/mcp/",
+      "url": "http://127.0.0.1:14242/mcp",
       "enabled": true
     }
   },

--- a/nowledge-mem-langgraph/src/nowledge_mem_langgraph/config.py
+++ b/nowledge-mem-langgraph/src/nowledge_mem_langgraph/config.py
@@ -93,7 +93,7 @@ class NowledgeSettings:
         return NowledgeSettings(
             api_url=api_url,
             api_key=_clean(self.api_key),
-            mcp_url=(self.mcp_url or f"{api_url}/mcp/").rstrip("/") + "/",
+            mcp_url=(self.mcp_url or f"{api_url}/mcp").rstrip("/"),
             application_id=application_id,
             identity=self.identity.normalized(),
             include_context=self.include_context,

--- a/nowledge-mem-langgraph/tests/test_connector.py
+++ b/nowledge-mem-langgraph/tests/test_connector.py
@@ -72,6 +72,21 @@ def runtime(
     )
 
 
+@pytest.mark.parametrize(
+    ("mcp_url", "expected"),
+    [
+        (None, "http://mem.test/mcp"),
+        ("https://cloud.nowledge.co/mcp/", "https://cloud.nowledge.co/mcp"),
+    ],
+)
+def test_settings_normalize_mcp_url_without_trailing_slash(
+    mcp_url: str | None, expected: str
+) -> None:
+    settings = NowledgeSettings(api_url="http://mem.test/", mcp_url=mcp_url).normalized()
+
+    assert settings.mcp_url == expected
+
+
 def test_runtime_identity_is_atomic_and_server_identity_is_only_host_provenance() -> None:
     settings = NowledgeSettings(
         identity=NowledgeIdentity(

--- a/nowledge-mem-proma-plugin/README.md
+++ b/nowledge-mem-proma-plugin/README.md
@@ -46,7 +46,7 @@ Local Nowledge Mem:
 {
   "servers": {
     "nowledge-mem": {
-      "url": "http://127.0.0.1:14242/mcp/",
+      "url": "http://127.0.0.1:14242/mcp",
       "type": "streamableHttp",
       "enabled": true,
       "headers": {
@@ -63,7 +63,7 @@ Remote Nowledge Mem:
 {
   "servers": {
     "nowledge-mem": {
-      "url": "https://mem.example.com/mcp/",
+      "url": "https://mem.example.com/mcp",
       "type": "streamableHttp",
       "enabled": true,
       "headers": {
@@ -267,7 +267,7 @@ Logs are written to:
 
 - Proma uses `"servers"` as the top-level key in `mcp.json`, not `"mcpServers"`.
 - The `nowledge-mem` entry must include `"enabled": true`; recent Proma builds skip disabled or missing-enabled MCP entries and their related hooks.
-- Confirm the endpoint ends with `/mcp/`.
+- Confirm the endpoint ends with `/mcp` and has no trailing slash.
 - Restart Proma after changing `mcp.json`.
 
 **Hooks do not run**

--- a/nowledge-mem-workbuddy-plugin/.mcp.json
+++ b/nowledge-mem-workbuddy-plugin/.mcp.json
@@ -2,7 +2,7 @@
   "mcpServers": {
     "nowledge-mem": {
       "type": "http",
-      "url": "http://127.0.0.1:14242/mcp/",
+      "url": "http://127.0.0.1:14242/mcp",
       "headers": {
         "APP": "WorkBuddy"
       }

--- a/tests/plugin_e2e/test_key_plugins_e2e.py
+++ b/tests/plugin_e2e/test_key_plugins_e2e.py
@@ -381,7 +381,7 @@ def test_key_plugin_static_contracts_are_declared():
     assert agent_plugin_mcp["$schema"] == "https://agent-plugins.org/schemas/1.0.0/mcp.schema.json"
     assert agent_plugin_mcp["mcpServers"]["nowledge-mem"] == {
         "type": "streamable-http",
-        "url": "http://127.0.0.1:14242/mcp/",
+        "url": "http://127.0.0.1:14242/mcp",
     }
     assert "Authorization" not in json.dumps(agent_plugin_mcp)
     assert "Bearer" not in json.dumps(agent_plugin_mcp)
@@ -406,6 +406,10 @@ def test_key_plugin_static_contracts_are_declared():
     assert codex_manifest["mcpServers"] == "./.mcp.json"
     assert codex_manifest["hooks"] == "./hooks/hooks.json"
     assert codex_mcp["mcpServers"]["nowledge-mem"]["type"] == "http"
+    assert (
+        codex_mcp["mcpServers"]["nowledge-mem"]["url"]
+        == "http://127.0.0.1:14242/mcp"
+    )
     assert {"SessionStart", "SubagentStart", "UserPromptSubmit", "Stop"} <= set(codex_hooks)
     assert "nmem-context.py" in json.dumps(codex_hooks["SessionStart"])
     assert "nmem-context.py" in json.dumps(codex_hooks["SubagentStart"])
@@ -684,6 +688,10 @@ def test_key_plugin_static_contracts_are_declared():
         workbuddy_mcp["mcpServers"]["nowledge-mem"]["headers"]["APP"]
         == "WorkBuddy"
     )
+    assert (
+        workbuddy_mcp["mcpServers"]["nowledge-mem"]["url"]
+        == "http://127.0.0.1:14242/mcp"
+    )
     assert {"SessionStart", "UserPromptSubmit", "PreCompact", "Stop", "SubagentStop", "SessionEnd"} <= set(
         workbuddy_hooks
     )
@@ -863,7 +871,7 @@ def test_key_plugin_static_contracts_are_declared():
     assert kimi_work_manifest["sessionStart"]["skill"] == "nowledge-mem"
     assert (
         kimi_work_manifest["mcpServers"]["nowledge-mem"]["url"]
-        == "http://127.0.0.1:14242/mcp/"
+        == "http://127.0.0.1:14242/mcp"
     )
     assert "hooks" not in kimi_work_manifest
     assert "nmem --json context --source-app kimi-work" in kimi_work_skill
@@ -1612,6 +1620,7 @@ def test_deepseek_harness_plugin_static_contract_is_self_contained():
     assert "id: nowledge-mem-mcp" in patch
     assert "name: '@deepseek-ai/dsh-mcp-client'" in patch
     assert "serverName: nowledge_mem" in patch
+    assert "'http://127.0.0.1:14242/mcp').replace(/\\/+$/, '')" in patch
     assert "'X-Nowledge-Tool-Schema-Profile': 'slim'" in patch
     assert "Object.fromEntries(Object.entries" in patch
     assert "typeof value === 'string' && value.length > 0" in patch

--- a/tests/plugin_e2e/test_mcp_endpoint_contract.py
+++ b/tests/plugin_e2e/test_mcp_endpoint_contract.py
@@ -1,0 +1,78 @@
+from __future__ import annotations
+
+import subprocess
+import unittest
+from pathlib import Path
+
+
+COMMUNITY_ROOT = Path(__file__).resolve().parents[2]
+TEXT_SUFFIXES = {
+    ".cjs",
+    ".cts",
+    ".json",
+    ".jsx",
+    ".md",
+    ".mjs",
+    ".mts",
+    ".ps1",
+    ".py",
+    ".sh",
+    ".toml",
+    ".ts",
+    ".tsx",
+    ".txt",
+    ".yaml",
+    ".yml",
+}
+class McpEndpointContractTest(unittest.TestCase):
+    def test_active_artifacts_do_not_emit_the_legacy_trailing_slash_route(self) -> None:
+        legacy_route = "/mcp" + "/"
+        legacy_fixture_markers = {
+            "nowledge-mem-codex-plugin/tests/test_codex_plugin.py": (
+                "https://user.example" + legacy_route,
+                "https://old.example" + legacy_route,
+            ),
+            "nowledge-mem-hermes/CHANGELOG.md": (
+                "http://127.0.0.1:14242" + legacy_route,
+            ),
+            "nowledge-mem-langgraph/tests/test_connector.py": (
+                "https://cloud.nowledge.co" + legacy_route,
+            ),
+        }
+        unexpected: list[str] = []
+        repository_files = subprocess.run(
+            [
+                "git",
+                "ls-files",
+                "-z",
+                "--cached",
+                "--others",
+                "--exclude-standard",
+            ],
+            cwd=COMMUNITY_ROOT,
+            check=True,
+            capture_output=True,
+        ).stdout.decode("utf-8").split("\0")
+
+        for relative in repository_files:
+            path = COMMUNITY_ROOT / relative
+            if not relative or path.suffix not in TEXT_SUFFIXES:
+                continue
+            lines = path.read_text(encoding="utf-8").splitlines()
+            for line_number, line in enumerate(lines, 1):
+                if legacy_route not in line:
+                    continue
+                allowed_markers = legacy_fixture_markers.get(relative, ())
+                if any(marker in line for marker in allowed_markers):
+                    continue
+                unexpected.append(f"{relative}:{line_number}")
+
+        self.assertEqual(
+            [],
+            unexpected,
+            "active connector artifacts must use the exact /mcp route",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
### Issue

Issue Number: ref #551

### Background

Community-owned connector manifests, installers, examples, and generated configurations still used the historical `/mcp/` route. The current exact endpoint is `/mcp`: the hosted endpoint reaches authentication at `/mcp` (`401`) but returns `404` for `/mcp/`.

The same canonical route is used for local Desktop connections. Historical behavior recorded in #24 and existing user-owned configuration fixtures remain unchanged.

### What problem does this PR solve?

New or refreshed connector installations could receive an endpoint that does not match the current local or Cloud MCP route, causing initialization to fail before authentication.

### How does it work?

- Updates active local and remote MCP manifests, setup scripts, examples, and documentation to emit `/mcp` without a trailing slash.
- Normalizes legacy trailing-slash input in the LangGraph connector and DeepSeek Harness environment override.
- Keeps Codex user-owned configuration compatibility fixtures and historical changelog text intact.
- Adds a repository-wide tracked-source contract test and a lightweight pull-request workflow that rejects new active `/mcp/` artifacts.

### Tests

- `python -m unittest tests/plugin_e2e/test_mcp_endpoint_contract.py`
- `python -m unittest nowledge-mem-codex-plugin/tests/test_codex_plugin.py` (72 passed)
- `uv run --group dev pytest tests/test_connector.py -q` from `nowledge-mem-langgraph` (passed)
- `bash nowledge-mem-hermes/tests/test_setup.sh`
- `node nowledge-mem-devin-plugin/scripts/validate-plugin.mjs`
- `npm test` from `nowledge-mem-deepseek-harness-plugin` (21 passed)
- `actionlint .github/workflows/mcp-endpoint-contract.yml`
- JSON parsing for every changed JSON manifest
- Live unauthenticated route probe: `/mcp` returned `401`; `/mcp/` returned `404`

The broader `test_key_plugins_e2e.py` static-contract selection still has two unrelated baseline failures: its Copilot assertion expects the source-app flag in `hooks.json` although the hook delegates to a script, and its DeepSeek Harness assertion omits the current `sessions` injection. The endpoint-specific assertions complete before those failures, and this PR does not alter those existing contracts.

### Side effects / risks

- Existing user-managed Codex MCP blocks are not rewritten.
- Historical changelog entries keep the route contract that was true for their release.
- Older Mem server builds that required `/mcp/` are outside the current endpoint contract and should be upgraded.
- No server route, authentication, protocol, release-version, or parent submodule-pointer changes are included.
