### PR TITLE
test(cursor): pin the durable capture queue contract

### DIFF
--- a/tests/plugin_e2e/test_key_plugins_e2e.py
+++ b/tests/plugin_e2e/test_key_plugins_e2e.py
@@ -637,8 +637,9 @@ def test_key_plugin_static_contracts_are_declared():
     assert "NMEM_HOST_AGENT_ID" in cursor_runtime
     assert "rendered_markdown" in cursor_runtime
     assert "'t'," in cursor_stop_hook
-    assert "'save'," in cursor_stop_hook
+    assert "'capture'," in cursor_stop_hook
     assert "'--session-id'," in cursor_stop_hook
+    assert "result.data?.status === 'enqueued'" in cursor_stop_hook
     assert "ATTEMPT_DELAYS_MS" in cursor_stop_hook
     assert "latest" not in cursor_stop_hook.lower()
     for cursor_guidance in (cursor_readme, cursor_rule, cursor_working_memory_skill):


### PR DESCRIPTION
### Issue

Ref: nowledge-co/mem#2125

### Problem

Cursor automatic capture moved from synchronous `nmem t save` to `nmem t capture` with durable-queue acknowledgement. Package tests and changelog already describe that architecture, but the shared static gate still required the old subcommand.

### Fix

Pin `t capture` and `status === enqueued` while preserving the exact session ID, bounded retry, and no-latest-fallback assertions. No Cursor runtime or package behavior changes.

### Tests

- `node --test nowledge-mem-cursor-plugin/tests/*.test.mjs` -> 7 passed, 0 failed.
- Focused durable capture source pins -> 6 assertions passed.
- The full shared static function passes the Cursor section and proceeds through WorkBuddy, CodeBuddy, Pi, and OMP; it then exposes an independent pre-existing Kimi `--apply` assertion drift.
- `git diff --check` -> pass.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Only static test assertions in the plugin E2E suite change; no production Cursor hook or CLI behavior is modified.
> 
> **Overview**
> Updates the shared **Cursor** section of `test_key_plugin_static_contracts_are_declared` so it matches the current stop-hook implementation, not the old synchronous save path.
> 
> The stop-hook source pin now expects **`t capture`** instead of **`t save`**, and requires acknowledgement via **`result.data?.status === 'enqueued'`**. Existing pins for exact **`--session-id`**, **`ATTEMPT_DELAYS_MS`**, and **no `latest` fallback** stay in place.
> 
> This is test-only alignment with the durable-queue capture architecture; it does not change Cursor plugin runtime or package behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit df75490b885b7a290dc71cbcdf33ebd1033b47e1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->