### PR TITLE
test(kimi): pin durable capture queue contract

### DIFF
--- a/tests/plugin_e2e/test_key_plugins_e2e.py
+++ b/tests/plugin_e2e/test_key_plugins_e2e.py
@@ -861,8 +861,11 @@ def test_key_plugin_static_contracts_are_declared():
     assert "--from" in kimi_hook
     assert "kimi-code" in kimi_hook
     assert "--session-id" in kimi_hook
-    assert "--apply" in kimi_hook
-    assert "NMEM_KIMI_SYNC_TIMEOUT" in kimi_hook
+    assert '"capture"' in kimi_hook
+    assert '"--sync"' in kimi_hook
+    assert '"--all-projects"' in kimi_hook
+    assert "ENQUEUE_TIMEOUT_SECONDS = 5" in kimi_hook
+    assert 'payload.get("status") == "enqueued"' in kimi_hook
     assert "CREATE_NO_WINDOW" in kimi_hook
 
     kimi_work_manifest = _read_json(KIMI_WORK_CONNECTOR / "kimi.plugin.json")


### PR DESCRIPTION
## Issue Number

Issue Number: close nowledge-co/mem#2126

## Background

The community repository's shared plugin E2E gate duplicates a small set of source-level invariants so integration contract drift is caught across all supported plugins. Kimi Code automatic capture moved to the shared durable capture queue in community PR #514.

## Problem

The Kimi section still required `t sync --apply` and `NMEM_KIMI_SYNC_TIMEOUT`, both intentionally removed by #514. The gate therefore failed on the supported Kimi implementation and blocked unrelated community changes after earlier stale assertions were repaired.

## How it works

- replace the obsolete synchronous-import pins with the current `capture --sync --all-projects` queue contract
- pin the five-second enqueue budget and explicit `status=enqueued` acknowledgement
- retain the existing source, session ID, and Windows hidden-process assertions

The Kimi hook runtime and manual historical-import commands do not change.

## Tests

- [x] Automated regression tests

```text
python3 -m pytest nowledge-mem-kimi-code-plugin/tests/test_kimi_sync_hook.py -q
3 passed in 0.05s

python3 - <<'PY'
import sys, tomli, pytest
sys.modules['tomllib'] = tomli
raise SystemExit(pytest.main([
    'tests/plugin_e2e/test_key_plugins_e2e.py::test_key_plugin_static_contracts_are_declared',
    '-q',
]))
PY
1 passed in 0.34s
```

## Side effects / risks

- No runtime behavior changes.
- No production traffic, schema, release, or submodule changes.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Only E2E static contract assertions were updated; no production or hook runtime code changes in this PR.
> 
> **Overview**
> Updates the **Kimi Code** static contract checks in `test_key_plugin_static_contracts_are_declared` so they match the hook’s **durable capture queue** behavior instead of the old synchronous `t sync --apply` path.
> 
> The gate now requires `kimi-sync-hook.py` to invoke **`capture` with `--sync` and `--all-projects`**, enforce a **5-second enqueue timeout** (`ENQUEUE_TIMEOUT_SECONDS`), and treat **`status=enqueued`** as success. It **drops** pins on `--apply` and `NMEM_KIMI_SYNC_TIMEOUT`. Other Kimi assertions (source app, session id, Windows hidden process) are unchanged.
> 
> **Test-only** change; no plugin runtime behavior in this diff.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 31252e42396b47eaaf96769c6d569b3bdbe88f6b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->