### PR TITLE
fix(openclaw): support OpenClaw 2.0 safely

### DIFF
--- a/integrations.json
+++ b/integrations.json
@@ -711,7 +711,7 @@
       "name": "OpenClaw",
       "category": "coding",
       "type": "plugin",
-      "version": "0.8.33",
+      "version": "0.8.34",
       "directory": "nowledge-mem-openclaw-plugin",
       "transport": "cli",
       "capabilities": {
@@ -737,7 +737,7 @@
         "bestResultRequires": [
           "Install the native OpenClaw plugin",
           "Use OpenClaw 2026.5.3 or later for current ClawHub packages",
-          "Use plugin 0.8.33 or later for OpenClaw 2.0 Incognito privacy, timestamp compatibility, readable thread titles, tool-contract diagnostics, and checkpointed thread capture",
+          "Use plugin 0.8.34 or later for OpenClaw 2.0 Incognito privacy, timestamp compatibility, readable thread titles, tool-contract diagnostics, and checkpointed thread capture",
           "Grant plugins.entries.openclaw-nowledge-mem.hooks.allowConversationAccess for the agent_end capture safety net",
           "When tools.profile is restrictive, add openclaw-nowledge-mem to tools.alsoAllow or the existing tools.allow list",
           "Keep nmem available on this machine",

--- a/integrations.json
+++ b/integrations.json
@@ -745,8 +745,8 @@
         ]
       },
       "install": {
-        "command": "openclaw plugins install clawhub:@nowledge/openclaw-nowledge-mem",
-        "updateCommand": "openclaw plugins install clawhub:@nowledge/openclaw-nowledge-mem --force",
+        "command": "openclaw plugins install clawhub:nowledge-mem",
+        "updateCommand": "openclaw plugins install clawhub:nowledge-mem --force",
         "detectionHint": "Running as OpenClaw agent; ~/.openclaw/ exists",
         "agentGuide": {
           "prompt": "Read https://mem.nowledge.co/SKILL.md and follow the instructions to install or update Nowledge Mem for OpenClaw. Verify with nmem status and the Context Bundle or Working Memory check, then summarize what changed.",

--- a/integrations.json
+++ b/integrations.json
@@ -711,7 +711,7 @@
       "name": "OpenClaw",
       "category": "coding",
       "type": "plugin",
-      "version": "0.8.32",
+      "version": "0.8.33",
       "directory": "nowledge-mem-openclaw-plugin",
       "transport": "cli",
       "capabilities": {
@@ -727,7 +727,7 @@
       },
       "threadSave": {
         "method": "plugin-capture",
-        "note": "Plugin captures interactive sessions through Context Engine afterTurn and, when plugins.entries.openclaw-nowledge-mem.hooks.allowConversationAccess=true, agent_end as a safety net. Persists threads via Nowledge Mem HTTP API with incremental tail sync. Isolated cron/session keys excluded (OpenClaw isCronSessionKey via plugin-sdk/routing). Memory tools still use nmem CLI."
+        "note": "Plugin captures interactive sessions through Context Engine afterTurn and, when plugins.entries.openclaw-nowledge-mem.hooks.allowConversationAccess=true, agent_end as a safety net. Persists threads via Nowledge Mem HTTP API with incremental tail sync. Isolated cron, subagent, and OpenClaw 2.0 Incognito session keys are excluded from automatic capture. Memory tools still use nmem CLI."
       },
       "autonomy": {
         "bootstrap": "guided",
@@ -737,7 +737,7 @@
         "bestResultRequires": [
           "Install the native OpenClaw plugin",
           "Use OpenClaw 2026.5.3 or later for current ClawHub packages",
-          "Use plugin 0.8.32 or later for OpenClaw 2026.6.11 timestamp compatibility, readable thread titles, tool-contract diagnostics, and checkpointed thread capture",
+          "Use plugin 0.8.33 or later for OpenClaw 2.0 Incognito privacy, timestamp compatibility, readable thread titles, tool-contract diagnostics, and checkpointed thread capture",
           "Grant plugins.entries.openclaw-nowledge-mem.hooks.allowConversationAccess for the agent_end capture safety net",
           "When tools.profile is restrictive, add openclaw-nowledge-mem to tools.alsoAllow or the existing tools.allow list",
           "Keep nmem available on this machine",

--- a/nowledge-mem-openclaw-plugin/CHANGELOG.md
+++ b/nowledge-mem-openclaw-plugin/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to the Nowledge Mem OpenClaw plugin will be documented in th
 
 ## Unreleased
 
+## [0.8.34] - 2026-08-31
+
+- Fixed automatic capture for agent-scoped OpenClaw 2.0 Incognito session keys.
+- Added regression coverage for bare and agent-prefixed Incognito sessions.
+
 ## [0.8.33] - 2026-08-31
 
 ### Fixed

--- a/nowledge-mem-openclaw-plugin/CHANGELOG.md
+++ b/nowledge-mem-openclaw-plugin/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to the Nowledge Mem OpenClaw plugin will be documented in th
 
 ## Unreleased
 
+## [0.8.33] - 2026-08-31
+
+### Fixed
+
+- Automatic thread capture now honors OpenClaw 2.0 Incognito session keys.
+  Incognito conversations remain process-only unless the user explicitly calls
+  a memory-writing tool.
+- Context Engine diagnostics now report the package version instead of a stale
+  hardcoded version.
+
 ## [0.8.32] - 2026-08-21
 
 ### Fixed

--- a/nowledge-mem-openclaw-plugin/CLAUDE.md
+++ b/nowledge-mem-openclaw-plugin/CLAUDE.md
@@ -7,7 +7,7 @@ Continuation guide for `community/nowledge-mem-openclaw-plugin`.
 - Plugin target: OpenClaw plugin runtime (memory slot + context engine)
 - Runtime: JS ESM modules under `src/`, no TS build pipeline
 - Memory backend: `nmem` CLI (fallback: `uvx --from nmem-cli nmem`)
-- OpenClaw minimum: `2026.4.5` (`registerMemoryCorpusSupplement` for dreaming integration)
+- OpenClaw minimum: `2026.5.3` (`registerMemoryCorpusSupplement` for dreaming integration)
 - Architecture: **CLI-first via OpenClaw runtime** - all CLI execution goes through `api.runtime.system.runCommandWithTimeout`, not direct `child_process`
 - Context engine: registered under the canonical id `nowledge-mem` plus the compatibility alias `openclaw-nowledge-mem`. Activated when OpenClaw sets either value in `plugins.slots.contextEngine`. Manual config should still prefer `nowledge-mem`. Falls back to hooks when CE is not active.
 - Remote mode: `~/.nowledge-mem/config.json` (shared) or OpenClaw dashboard. Legacy `openclaw.json` still honored.
@@ -57,6 +57,8 @@ openclaw.plugin.json - manifest + config schema (version, uiHints, configSchema,
 ~/.nowledge-mem/openclaw.json - legacy config file (still honored, deprecated in docs)
 ~/.nowledge-mem/config.json   - shared credentials (apiUrl/apiKey) read by all Nowledge Mem tools
 ```
+
+Automatic capture excludes OpenClaw 2.0's canonical Incognito session keys. Explicit memory tool calls remain available for intentional saves.
 
 ## Corpus Supplement (Dreaming Integration)
 

--- a/nowledge-mem-openclaw-plugin/README.md
+++ b/nowledge-mem-openclaw-plugin/README.md
@@ -19,7 +19,7 @@ the user intentionally asks Mem to keep.
 ## Installation
 
 ```bash
-openclaw plugins install clawhub:@nowledge/openclaw-nowledge-mem
+openclaw plugins install clawhub:nowledge-mem
 ```
 
 OpenClaw's installer writes the install record, enables the plugin, and switches the `memory` slot to `openclaw-nowledge-mem`. On current OpenClaw builds, that same install flow may also set `plugins.slots.contextEngine` to `openclaw-nowledge-mem`. Plugin `0.8.18+` accepts that automatically as a compatibility alias.
@@ -35,7 +35,7 @@ If `openclaw config get tools` shows a restrictive profile such as `coding`, pre
 To update the plugin, re-run the ClawHub install with `--force`:
 
 ```bash
-openclaw plugins install clawhub:@nowledge/openclaw-nowledge-mem --force
+openclaw plugins install clawhub:nowledge-mem --force
 ```
 
 Use this instead of `openclaw plugins update openclaw-nowledge-mem` when an old install record is pinned to a specific version.
@@ -543,7 +543,7 @@ If you also use linked or workspace copies, review `plugins.load.paths` before r
 The memory slot is probably still set to the built-in `memory-core`. OpenClaw 3.22+ defaults to `memory-core` when no explicit slot is configured. Reinstall to reset the slot automatically:
 
 ```bash
-openclaw plugins install clawhub:@nowledge/openclaw-nowledge-mem
+openclaw plugins install clawhub:nowledge-mem
 ```
 
 Or set the slot manually in `~/.openclaw/openclaw.json`:

--- a/nowledge-mem-openclaw-plugin/README.md
+++ b/nowledge-mem-openclaw-plugin/README.md
@@ -11,6 +11,11 @@ This is not a flat note store. Nowledge Mem links related knowledge into a graph
 - [Nowledge Mem](https://mem.nowledge.co) desktop app **or** `nmem` CLI
 - [OpenClaw](https://openclaw.ai) >= 2026.5.3 for ClawHub installs. Older 2026.4.x builds can reject current ClawHub packages with an archive integrity mismatch before the plugin is installed.
 
+OpenClaw 2.0 (`2026.8.1`) is supported. Automatic capture follows OpenClaw's
+privacy boundary: Incognito sessions are never copied to Nowledge Mem or
+distilled automatically. An explicit memory tool call can still save something
+the user intentionally asks Mem to keep.
+
 ## Installation
 
 ```bash

--- a/nowledge-mem-openclaw-plugin/RELEASING.md
+++ b/nowledge-mem-openclaw-plugin/RELEASING.md
@@ -35,24 +35,16 @@ working tree and honors `.clawhubignore`, not npm's `files` whitelist. Keep the
 two release surfaces aligned so test and build-only files do not leak into the
 published code plugin.
 
-Then verify the ClawHub publish contract from a machine with `clawhub` installed:
+The installed ClawHub CLI 0.8.0 has no publish dry-run. Validate the package
+locally, then run the publish command only after the OpenClaw install smoke
+passes. The publisher is taken from the authenticated `clawhub` account.
 
 ```bash
-cd community/nowledge-mem-openclaw-plugin
-clawhub package publish . --owner nowledge --dry-run
-```
-
-Because this plugin lives in a git repository, ClawHub can infer the source
-repository and source commit when you publish from the package directory. If
-that inference fails, pass them explicitly:
-
-```bash
-clawhub package publish . \
-  --owner nowledge \
-  --source-repo nowledge-co/community \
-  --source-commit <git-sha> \
-  --source-path community/nowledge-mem-openclaw-plugin \
-  --dry-run
+clawhub publish . \
+  --slug openclaw-nowledge-mem \
+  --version 0.8.33 \
+  --tags latest \
+  --changelog "OpenClaw 2.0 Incognito-safe automatic capture and package-version diagnostics"
 ```
 
 ## Manual Readiness Checks
@@ -79,42 +71,31 @@ The package name is scoped as `@nowledge/openclaw-nowledge-mem`, and ClawHub
 enforces that the scoped package owner exists and matches:
 
 ```bash
-clawhub package inspect @nowledge/openclaw-nowledge-mem
+clawhub inspect openclaw-nowledge-mem
 ```
 
 If the owner is not `nowledge`, transfer it before publishing another version:
 
 ```bash
-clawhub package transfer @nowledge/openclaw-nowledge-mem \
-  --to nowledge \
-  --reason "Align scoped package namespace with Nowledge publisher"
+clawhub whoami
 ```
 
-Dry run first:
+Publish after the readiness checks:
 
 ```bash
-cd /path/to/clawhub
-clawhub package publish /path/to/community/nowledge-mem-openclaw-plugin \
-  --owner nowledge \
-  --dry-run
+clawhub publish /path/to/community/nowledge-mem-openclaw-plugin \
+  --slug openclaw-nowledge-mem \
+  --version 0.8.33 \
+  --tags latest \
+  --changelog "OpenClaw 2.0 Incognito-safe automatic capture and package-version diagnostics"
 ```
 
-Then publish the same package:
+If your globally installed `clawhub` CLI is older or does not support the
+`publish` options above, update the CLI before publishing. Do not use the old
+`package publish` syntax; it is not accepted by ClawHub CLI 0.8.0.
 
 ```bash
-cd /path/to/clawhub
-clawhub package publish /path/to/community/nowledge-mem-openclaw-plugin \
-  --owner nowledge
-```
-
-If your globally installed `clawhub` CLI is older and does not support
-`package publish --dry-run`, run the newer local clone instead:
-
-```bash
-cd /path/to/clawhub
-bun clawhub package publish /path/to/community/nowledge-mem-openclaw-plugin \
-  --owner nowledge \
-  --dry-run
+clawhub --help
 ```
 
 If you also want npm as a secondary distribution path:
@@ -134,8 +115,9 @@ npm publish --access public
 - keep `.clawhubignore` aligned with the npm package surface so ClawHub releases do not ship tests or build-only files
 - run `node scripts/validate-plugin.mjs`
 - run `npm pack --dry-run`
-- confirm `clawhub package inspect @nowledge/openclaw-nowledge-mem` reports owner `nowledge`
-- run `clawhub package publish . --owner nowledge --dry-run`
+- run `clawhub whoami` and confirm the intended publisher is logged in
+- run `clawhub inspect openclaw-nowledge-mem` when an existing listing is expected
+- run `clawhub publish . --slug openclaw-nowledge-mem --version 0.8.33 --tags latest`
 - manually test install in OpenClaw
 - publish to ClawHub
 - optionally publish to npm after the ClawHub release is confirmed

--- a/nowledge-mem-openclaw-plugin/RELEASING.md
+++ b/nowledge-mem-openclaw-plugin/RELEASING.md
@@ -41,7 +41,7 @@ passes. The publisher is taken from the authenticated `clawhub` account.
 
 ```bash
 clawhub --workdir "$PWD" publish . \
-  --slug openclaw-nowledge-mem \
+  --slug nowledge-mem \
   --version 0.8.33 \
   --tags latest \
   --changelog "OpenClaw 2.0 Incognito-safe automatic capture and package-version diagnostics"
@@ -51,7 +51,7 @@ clawhub --workdir "$PWD" publish . \
 
 These still need a real OpenClaw install smoke test:
 
-- install from ClawHub with `openclaw plugins install clawhub:@nowledge/openclaw-nowledge-mem`
+- install from ClawHub with `openclaw plugins install clawhub:nowledge-mem`
 - install from the local folder with `openclaw plugins install --link .`
 - confirm the plugin loads without manifest or config-schema errors
 - confirm the memory slot switches to `openclaw-nowledge-mem`
@@ -71,7 +71,7 @@ The package name is scoped as `@nowledge/openclaw-nowledge-mem`, and ClawHub
 enforces that the scoped package owner exists and matches:
 
 ```bash
-clawhub inspect openclaw-nowledge-mem
+clawhub inspect nowledge-mem
 ```
 
 If the owner is not `nowledge`, transfer it before publishing another version:
@@ -84,7 +84,7 @@ Publish after the readiness checks:
 
 ```bash
 clawhub --workdir /path/to/community/nowledge-mem-openclaw-plugin publish . \
-  --slug openclaw-nowledge-mem \
+  --slug nowledge-mem \
   --version 0.8.33 \
   --tags latest \
   --changelog "OpenClaw 2.0 Incognito-safe automatic capture and package-version diagnostics"
@@ -116,8 +116,8 @@ npm publish --access public
 - run `node scripts/validate-plugin.mjs`
 - run `npm pack --dry-run`
 - run `clawhub whoami` and confirm the intended publisher is logged in
-- run `clawhub inspect openclaw-nowledge-mem` when an existing listing is expected
-- run `clawhub --workdir "$PWD" publish . --slug openclaw-nowledge-mem --version 0.8.33 --tags latest`
+- run `clawhub inspect nowledge-mem` when an existing listing is expected
+- run `clawhub --workdir "$PWD" publish . --slug nowledge-mem --version 0.8.33 --tags latest`
 - manually test install in OpenClaw
 - publish to ClawHub
 - optionally publish to npm after the ClawHub release is confirmed

--- a/nowledge-mem-openclaw-plugin/RELEASING.md
+++ b/nowledge-mem-openclaw-plugin/RELEASING.md
@@ -68,6 +68,9 @@ These still need a real OpenClaw install smoke test:
 - confirm session-end thread capture and distillation work
 - confirm remote Mem mode works with `apiUrl` and `apiKey`
 - confirm `corpusSupplement` avoids duplicate recall when enabled
+- run the isolated smoke against OpenClaw `2026.8.1` or a newer supported host
+- verify an Incognito session does not create or append a Mem Thread, while an
+  explicit memory tool call still works
 
 ## Publish
 
@@ -126,6 +129,7 @@ npm publish --access public
 - bump `version` in `package.json` and `openclaw.plugin.json`
 - update `CHANGELOG.md`
 - keep `package.json` `openclaw.install.npmSpec`, `openclaw.compat`, and `openclaw.build` aligned with the tested OpenClaw baseline
+- keep the package, manifest, integration registry, and runtime Context Engine version aligned
 - keep `openclaw.install.minHostVersion` omitted for this plugin; `scripts/validate-plugin.mjs` enforces this and is the source of truth if the policy ever changes
 - keep `.clawhubignore` aligned with the npm package surface so ClawHub releases do not ship tests or build-only files
 - run `node scripts/validate-plugin.mjs`

--- a/nowledge-mem-openclaw-plugin/RELEASING.md
+++ b/nowledge-mem-openclaw-plugin/RELEASING.md
@@ -40,7 +40,7 @@ locally, then run the publish command only after the OpenClaw install smoke
 passes. The publisher is taken from the authenticated `clawhub` account.
 
 ```bash
-clawhub publish . \
+clawhub --workdir "$PWD" publish . \
   --slug openclaw-nowledge-mem \
   --version 0.8.33 \
   --tags latest \
@@ -83,7 +83,7 @@ clawhub whoami
 Publish after the readiness checks:
 
 ```bash
-clawhub publish /path/to/community/nowledge-mem-openclaw-plugin \
+clawhub --workdir /path/to/community/nowledge-mem-openclaw-plugin publish . \
   --slug openclaw-nowledge-mem \
   --version 0.8.33 \
   --tags latest \
@@ -117,7 +117,7 @@ npm publish --access public
 - run `npm pack --dry-run`
 - run `clawhub whoami` and confirm the intended publisher is logged in
 - run `clawhub inspect openclaw-nowledge-mem` when an existing listing is expected
-- run `clawhub publish . --slug openclaw-nowledge-mem --version 0.8.33 --tags latest`
+- run `clawhub --workdir "$PWD" publish . --slug openclaw-nowledge-mem --version 0.8.33 --tags latest`
 - manually test install in OpenClaw
 - publish to ClawHub
 - optionally publish to npm after the ClawHub release is confirmed

--- a/nowledge-mem-openclaw-plugin/RELEASING.md
+++ b/nowledge-mem-openclaw-plugin/RELEASING.md
@@ -42,7 +42,7 @@ passes. The publisher is taken from the authenticated `clawhub` account.
 ```bash
 clawhub --workdir "$PWD" publish . \
   --slug nowledge-mem \
-  --version 0.8.33 \
+  --version 0.8.34 \
   --tags latest \
   --changelog "OpenClaw 2.0 Incognito-safe automatic capture and package-version diagnostics"
 ```
@@ -85,7 +85,7 @@ Publish after the readiness checks:
 ```bash
 clawhub --workdir /path/to/community/nowledge-mem-openclaw-plugin publish . \
   --slug nowledge-mem \
-  --version 0.8.33 \
+  --version 0.8.34 \
   --tags latest \
   --changelog "OpenClaw 2.0 Incognito-safe automatic capture and package-version diagnostics"
 ```
@@ -117,7 +117,7 @@ npm publish --access public
 - run `npm pack --dry-run`
 - run `clawhub whoami` and confirm the intended publisher is logged in
 - run `clawhub inspect nowledge-mem` when an existing listing is expected
-- run `clawhub --workdir "$PWD" publish . --slug nowledge-mem --version 0.8.33 --tags latest`
+- run `clawhub --workdir "$PWD" publish . --slug nowledge-mem --version 0.8.34 --tags latest`
 - manually test install in OpenClaw
 - publish to ClawHub
 - optionally publish to npm after the ClawHub release is confirmed

--- a/nowledge-mem-openclaw-plugin/SKILL.md
+++ b/nowledge-mem-openclaw-plugin/SKILL.md
@@ -28,6 +28,8 @@ When talking to users:
 - For remote mode, say "Set `apiUrl`, and add `apiKey` when the server requires auth."
 - Do not imply that OpenClaw is the only source of truth. It is one client of the user's larger memory system.
 - Do not imply that cloud backup is the default. Our default story is local-first.
+- OpenClaw 2.0 Incognito sessions are never automatically captured or distilled.
+  Only an explicit memory-writing tool call persists information by user choice.
 
 Good user-facing explanation:
 

--- a/nowledge-mem-openclaw-plugin/SKILL.md
+++ b/nowledge-mem-openclaw-plugin/SKILL.md
@@ -105,7 +105,7 @@ Success means the backend responds correctly through `nmem`. Do not skip this st
 Default install:
 
 ```bash
-openclaw plugins install clawhub:@nowledge/openclaw-nowledge-mem
+openclaw plugins install clawhub:nowledge-mem
 ```
 
 If this fails with `archive integrity mismatch`, update OpenClaw first, then
@@ -114,7 +114,7 @@ retry. Current ClawHub packages require OpenClaw 2026.5.3 or later.
 To update an existing install:
 
 ```bash
-openclaw plugins install clawhub:@nowledge/openclaw-nowledge-mem --force
+openclaw plugins install clawhub:nowledge-mem --force
 ```
 
 Alternatively, if the user is installing from OpenClaw's default registry rather than ClawHub, this also works:
@@ -232,7 +232,7 @@ If only `memory_search` and `memory_get` tools are available (other Nowledge Mem
 }
 ```
 
-If missing, reinstall (`openclaw plugins install clawhub:@nowledge/openclaw-nowledge-mem`) which sets the slot automatically. This is common after upgrading OpenClaw to 3.22+ where the default memory slot changed.
+If missing, reinstall (`openclaw plugins install clawhub:nowledge-mem`) which sets the slot automatically. This is common after upgrading OpenClaw to 3.22+ where the default memory slot changed.
 
 Then verify in chat.
 
@@ -282,7 +282,7 @@ What to expect:
 | `nmem --json status` fails in local mode | Start Nowledge Mem locally first |
 | Remote mode fails | Re-run `nmem --json --api-url ... status` with the exact URL and auth you plan to use |
 | `openclaw nowledge-mem status` fails after install | Restart OpenClaw and confirm the plugin was installed successfully |
-| ClawHub reports `archive integrity mismatch` | Update OpenClaw to 2026.5.3+ or latest, then reinstall with `openclaw plugins install clawhub:@nowledge/openclaw-nowledge-mem --force` |
+| ClawHub reports `archive integrity mismatch` | Update OpenClaw to 2026.5.3+ or latest, then reinstall with `openclaw plugins install clawhub:nowledge-mem --force` |
 | `plugins.allow is empty` warning | Add `openclaw-nowledge-mem` to `plugins.allow` if the user wants explicit trust |
 | Remote config seems ignored | Check whether `~/.nowledge-mem/openclaw.json` is overriding plugin settings |
 | Local mode unexpectedly talks to a remote server | Check for stale `NMEM_API_URL` / `NMEM_API_KEY` in the environment or an overriding `~/.nowledge-mem/openclaw.json` |

--- a/nowledge-mem-openclaw-plugin/openclaw.plugin.json
+++ b/nowledge-mem-openclaw-plugin/openclaw.plugin.json
@@ -2,7 +2,7 @@
 	"id": "openclaw-nowledge-mem",
 	"name": "Nowledge Mem",
 	"description": "Cross-tool knowledge graph memory for OpenClaw with startup context, graph search, and session distillation.",
-	"version": "0.8.33",
+	"version": "0.8.34",
 	"kind": ["memory", "context-engine"],
 	"contracts": {
 		"tools": [

--- a/nowledge-mem-openclaw-plugin/openclaw.plugin.json
+++ b/nowledge-mem-openclaw-plugin/openclaw.plugin.json
@@ -2,7 +2,7 @@
 	"id": "openclaw-nowledge-mem",
 	"name": "Nowledge Mem",
 	"description": "Cross-tool knowledge graph memory for OpenClaw with startup context, graph search, and session distillation.",
-	"version": "0.8.32",
+	"version": "0.8.33",
 	"kind": ["memory", "context-engine"],
 	"contracts": {
 		"tools": [

--- a/nowledge-mem-openclaw-plugin/package-lock.json
+++ b/nowledge-mem-openclaw-plugin/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "@nowledge/openclaw-nowledge-mem",
-	"version": "0.8.32",
+	"version": "0.8.33",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "@nowledge/openclaw-nowledge-mem",
-			"version": "0.8.32",
+			"version": "0.8.33",
 			"license": "MIT",
 			"devDependencies": {
 				"@biomejs/biome": "^1.9.0"

--- a/nowledge-mem-openclaw-plugin/package-lock.json
+++ b/nowledge-mem-openclaw-plugin/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "@nowledge/openclaw-nowledge-mem",
-	"version": "0.8.33",
+	"version": "0.8.34",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "@nowledge/openclaw-nowledge-mem",
-			"version": "0.8.33",
+			"version": "0.8.34",
 			"license": "MIT",
 			"devDependencies": {
 				"@biomejs/biome": "^1.9.0"

--- a/nowledge-mem-openclaw-plugin/package.json
+++ b/nowledge-mem-openclaw-plugin/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@nowledge/openclaw-nowledge-mem",
 	"displayName": "Nowledge Mem for OpenClaw",
-	"version": "0.8.32",
+	"version": "0.8.33",
 	"type": "module",
 	"description": "Nowledge Mem memory plugin for OpenClaw, local-first personal knowledge base",
 	"author": {
@@ -37,7 +37,7 @@
 			"pluginApi": ">=2026.5.3"
 		},
 		"build": {
-			"openclawVersion": "2026.6.10"
+			"openclawVersion": "2026.8.1"
 		},
 		"release": {
 			"publishToClawHub": true,

--- a/nowledge-mem-openclaw-plugin/package.json
+++ b/nowledge-mem-openclaw-plugin/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@nowledge/openclaw-nowledge-mem",
 	"displayName": "Nowledge Mem for OpenClaw",
-	"version": "0.8.33",
+	"version": "0.8.34",
 	"type": "module",
 	"description": "Nowledge Mem memory plugin for OpenClaw, local-first personal knowledge base",
 	"author": {

--- a/nowledge-mem-openclaw-plugin/package.json
+++ b/nowledge-mem-openclaw-plugin/package.json
@@ -29,7 +29,7 @@
 			"./src/index.js"
 		],
 		"install": {
-			"clawhubSpec": "clawhub:@nowledge/openclaw-nowledge-mem",
+			"clawhubSpec": "clawhub:nowledge-mem",
 			"npmSpec": "@nowledge/openclaw-nowledge-mem",
 			"defaultChoice": "clawhub"
 		},

--- a/nowledge-mem-openclaw-plugin/src/context-engine.js
+++ b/nowledge-mem-openclaw-plugin/src/context-engine.js
@@ -30,8 +30,8 @@ import { BASE_GUIDANCE, SESSION_CONTEXT_GUIDANCE } from "./hooks/behavioral.js";
 import {
 	appendOrCreateThread,
 	hasSkipMarker,
-	isInternalCaptureSessionKey,
 	isCronCaptureSessionKey,
+	isInternalCaptureSessionKey,
 	matchesExcludePattern,
 	triageAndDistill,
 } from "./hooks/capture.js";
@@ -41,6 +41,7 @@ import {
 	buildRecalledKnowledgeBlock,
 	escapeForPrompt,
 } from "./hooks/recall.js";
+import { NOWLEDGE_MEM_PLUGIN_VERSION } from "./plugin-version.js";
 
 // ---------------------------------------------------------------------------
 // Per-session state
@@ -183,7 +184,7 @@ export function createNowledgeMemContextEngineFactory(
 			info: {
 				id: "nowledge-mem",
 				name: "Nowledge Mem",
-				version: "0.8.25",
+				version: NOWLEDGE_MEM_PLUGIN_VERSION,
 				ownsCompaction: false,
 			},
 

--- a/nowledge-mem-openclaw-plugin/src/hooks/capture.js
+++ b/nowledge-mem-openclaw-plugin/src/hooks/capture.js
@@ -157,6 +157,21 @@ export function isCronCaptureSessionKey(sessionKey) {
 }
 
 /**
+ * OpenClaw 2.0 reserves these process-only keys for Incognito sessions.
+ * Keep this aligned with the host's routing helper so automatic capture does
+ * not turn an in-memory conversation into a durable external transcript.
+ * Explicit memory tool calls are unaffected because this only guards hooks.
+ */
+export function isIncognitoCaptureSessionKey(sessionKey) {
+	const raw = String(sessionKey || "")
+		.trim()
+		.toLowerCase();
+	return /^(?:dashboard|subagent|internal-session-effects):incognito-[^:]+$/u.test(
+		raw,
+	);
+}
+
+/**
  * Check if any message contains the skip marker text.
  * Scans both raw message content and nested message objects.
  *
@@ -184,7 +199,7 @@ export function isInternalCaptureSessionKey(sessionKey) {
 		.toLowerCase();
 	if (!raw) return false;
 	if (raw.startsWith("temp:")) return true;
-	return isSubagentSessionKey(raw);
+	return isSubagentSessionKey(raw) || isIncognitoCaptureSessionKey(raw);
 }
 
 function stripOpenClawDirectiveTags(text) {

--- a/nowledge-mem-openclaw-plugin/src/hooks/capture.js
+++ b/nowledge-mem-openclaw-plugin/src/hooks/capture.js
@@ -166,9 +166,8 @@ export function isIncognitoCaptureSessionKey(sessionKey) {
 	const raw = String(sessionKey || "")
 		.trim()
 		.toLowerCase();
-	return /^(?:dashboard|subagent|internal-session-effects):incognito-[^:]+$/u.test(
-		raw,
-	);
+	const candidate = parseAgentSessionKey(raw)?.rest ?? raw;
+	return /^(?:dashboard|subagent|internal-session-effects):incognito-[^:]+$/u.test(candidate);
 }
 
 /**

--- a/nowledge-mem-openclaw-plugin/src/plugin-version.js
+++ b/nowledge-mem-openclaw-plugin/src/plugin-version.js
@@ -1,0 +1,3 @@
+import packageJson from "../package.json" with { type: "json" };
+
+export const NOWLEDGE_MEM_PLUGIN_VERSION = packageJson.version;

--- a/nowledge-mem-openclaw-plugin/tests/capture-append-mode.test.mjs
+++ b/nowledge-mem-openclaw-plugin/tests/capture-append-mode.test.mjs
@@ -5,6 +5,8 @@ import test from "node:test";
 import {
 	_resetSyncCursors,
 	appendOrCreateThread,
+	buildAgentEndCaptureHandler,
+	buildBeforeResetCaptureHandler,
 	buildThreadTitle,
 	normalizeRoleMessage,
 } from "../src/hooks/capture.js";
@@ -94,6 +96,29 @@ test("normalizes OpenClaw epoch-millisecond timestamps for the Mem API", () => {
 		).timestamp,
 		undefined,
 	);
+});
+
+test("automatic capture handlers leave OpenClaw 2.0 Incognito sessions untouched", async () => {
+	const client = {
+		appendThread: async () => {
+			throw new Error("automatic capture must not run for Incognito");
+		},
+		createThread: async () => {
+			throw new Error("automatic capture must not run for Incognito");
+		},
+	};
+	const cfg = { captureExclude: [], captureSkipMarker: "#nmem-skip", sessionDigest: true };
+	const ctx = {
+		sessionId: "incognito-session",
+		sessionKey: "dashboard:incognito-session",
+	};
+	const event = {
+		success: true,
+		messages: [message("user", "private"), message("assistant", "reply")],
+	};
+
+	await buildAgentEndCaptureHandler(client, cfg, logger)(event, ctx);
+	await buildBeforeResetCaptureHandler(client, cfg, logger)(event, ctx);
 });
 
 test("uses the first user message as a readable thread title", () => {

--- a/nowledge-mem-openclaw-plugin/tests/capture-append-mode.test.mjs
+++ b/nowledge-mem-openclaw-plugin/tests/capture-append-mode.test.mjs
@@ -119,6 +119,10 @@ test("automatic capture handlers leave OpenClaw 2.0 Incognito sessions untouched
 
 	await buildAgentEndCaptureHandler(client, cfg, logger)(event, ctx);
 	await buildBeforeResetCaptureHandler(client, cfg, logger)(event, ctx);
+	await buildAgentEndCaptureHandler(client, cfg, logger)(event, {
+		...ctx,
+		sessionKey: "agent:main:dashboard:incognito-session",
+	});
 });
 
 test("uses the first user message as a readable thread title", () => {

--- a/nowledge-mem-openclaw-plugin/tests/capture-thread-identity.test.mjs
+++ b/nowledge-mem-openclaw-plugin/tests/capture-thread-identity.test.mjs
@@ -27,6 +27,16 @@ test("automatic capture recognizes OpenClaw 2.0 Incognito session keys", () => {
 		true,
 	);
 	assert.equal(
+		isIncognitoCaptureSessionKey("agent:main:dashboard:incognito-abc123"),
+		true,
+	);
+	assert.equal(
+		isIncognitoCaptureSessionKey(
+			"agent:main:internal-session-effects:incognito-abc123",
+		),
+		true,
+	);
+	assert.equal(
 		isIncognitoCaptureSessionKey("agent:main:telegram:direct:abc123"),
 		false,
 	);

--- a/nowledge-mem-openclaw-plugin/tests/capture-thread-identity.test.mjs
+++ b/nowledge-mem-openclaw-plugin/tests/capture-thread-identity.test.mjs
@@ -1,6 +1,7 @@
-import test from "node:test";
 import assert from "node:assert/strict";
+import test from "node:test";
 
+import { isIncognitoCaptureSessionKey } from "../src/hooks/capture.js";
 import {
 	_resetConversationRoots,
 	buildStableThreadId,
@@ -10,6 +11,29 @@ import {
 
 test.beforeEach(() => {
 	_resetConversationRoots();
+});
+
+test("automatic capture recognizes OpenClaw 2.0 Incognito session keys", () => {
+	assert.equal(
+		isIncognitoCaptureSessionKey("dashboard:incognito-abc123"),
+		true,
+	);
+	assert.equal(
+		isIncognitoCaptureSessionKey("subagent:incognito-abc123"),
+		true,
+	);
+	assert.equal(
+		isIncognitoCaptureSessionKey("internal-session-effects:incognito-abc123"),
+		true,
+	);
+	assert.equal(
+		isIncognitoCaptureSessionKey("agent:main:telegram:direct:abc123"),
+		false,
+	);
+	assert.equal(
+		isIncognitoCaptureSessionKey("dashboard:incognito-abc123:extra"),
+		false,
+	);
 });
 
 test("explicit /new starts a fresh Mem thread for the same OpenClaw sessionKey", () => {

--- a/nowledge-mem-openclaw-plugin/tests/register-mode.test.mjs
+++ b/nowledge-mem-openclaw-plugin/tests/register-mode.test.mjs
@@ -1,14 +1,15 @@
-import test from "node:test";
 import assert from "node:assert/strict";
 import { readFileSync } from "node:fs";
+import test from "node:test";
 
-import { resolveRegistrationMode } from "../src/register-mode.js";
 import {
 	NOWLEDGE_MEM_CONTEXT_ENGINE_COMPAT_ALIAS,
 	NOWLEDGE_MEM_CONTEXT_ENGINE_ID,
 	NOWLEDGE_MEM_CONTEXT_ENGINE_IDS,
 	isNowledgeMemContextEngineSlot,
 } from "../src/context-engine-ids.js";
+import { NOWLEDGE_MEM_PLUGIN_VERSION } from "../src/plugin-version.js";
+import { resolveRegistrationMode } from "../src/register-mode.js";
 
 test("supplement mode keeps compatibility tools off when memory-core owns the slot", () => {
 	const mode = resolveRegistrationMode({
@@ -65,6 +66,13 @@ test("manifest declares every OpenClaw agent tool contract", () => {
 		"nowledge_mem_thread_fetch",
 		"nowledge_mem_status",
 	]);
+});
+
+test("runtime context-engine version comes from package metadata", async () => {
+	const pkg = JSON.parse(
+		readFileSync(new URL("../package.json", import.meta.url), "utf8"),
+	);
+	assert.equal(NOWLEDGE_MEM_PLUGIN_VERSION, pkg.version);
 });
 
 test("context engine ids include the canonical id plus the plugin-id compatibility alias", () => {

--- a/tests/plugin_e2e/test_key_plugins_e2e.py
+++ b/tests/plugin_e2e/test_key_plugins_e2e.py
@@ -474,8 +474,8 @@ def test_key_plugin_static_contracts_are_declared():
     openclaw_spawn_env = (OPENCLAW_PLUGIN / "src" / "spawn-env.js").read_text(encoding="utf-8")
     openclaw_context_tool = (OPENCLAW_PLUGIN / "src" / "tools" / "context.js").read_text(encoding="utf-8")
     schema = openclaw_manifest["configSchema"]["properties"]
-    assert openclaw_manifest["version"] == "0.8.33"
-    assert openclaw_pkg["version"] == "0.8.33"
+    assert openclaw_manifest["version"] == "0.8.34"
+    assert openclaw_pkg["version"] == "0.8.34"
     assert openclaw_manifest["kind"] == ["memory", "context-engine"]
     assert openclaw_manifest["contracts"]["tools"] == [
         "memory_search",
@@ -1491,7 +1491,7 @@ def test_registry_connect_contract_points_agent_prompts_to_universal_skill():
     assert by_id["cursor"]["autonomy"]["threads"] == "automatic-capture"
     assert "save-thread" in by_id["cursor"]["skills"]
     assert by_id["droid"]["version"] == "0.1.1"
-    assert by_id["openclaw"]["version"] == "0.8.33"
+    assert by_id["openclaw"]["version"] == "0.8.34"
     assert by_id["proma"]["version"] == "0.1.5"
     assert by_id["opencode"]["version"] == "0.3.10"
     assert by_id["pi"]["version"] == "0.8.7"

--- a/tests/plugin_e2e/test_key_plugins_e2e.py
+++ b/tests/plugin_e2e/test_key_plugins_e2e.py
@@ -474,8 +474,8 @@ def test_key_plugin_static_contracts_are_declared():
     openclaw_spawn_env = (OPENCLAW_PLUGIN / "src" / "spawn-env.js").read_text(encoding="utf-8")
     openclaw_context_tool = (OPENCLAW_PLUGIN / "src" / "tools" / "context.js").read_text(encoding="utf-8")
     schema = openclaw_manifest["configSchema"]["properties"]
-    assert openclaw_manifest["version"] == "0.8.32"
-    assert openclaw_pkg["version"] == "0.8.32"
+    assert openclaw_manifest["version"] == "0.8.33"
+    assert openclaw_pkg["version"] == "0.8.33"
     assert openclaw_manifest["kind"] == ["memory", "context-engine"]
     assert openclaw_manifest["contracts"]["tools"] == [
         "memory_search",
@@ -1491,7 +1491,7 @@ def test_registry_connect_contract_points_agent_prompts_to_universal_skill():
     assert by_id["cursor"]["autonomy"]["threads"] == "automatic-capture"
     assert "save-thread" in by_id["cursor"]["skills"]
     assert by_id["droid"]["version"] == "0.1.1"
-    assert by_id["openclaw"]["version"] == "0.8.32"
+    assert by_id["openclaw"]["version"] == "0.8.33"
     assert by_id["proma"]["version"] == "0.1.5"
     assert by_id["opencode"]["version"] == "0.3.10"
     assert by_id["pi"]["version"] == "0.8.7"


### PR DESCRIPTION
## Issue Number
close #564

## Background
This updates `nowledge-mem-openclaw-plugin` for the OpenClaw 2.0 (`2026.8.1`) plugin and session contracts. The governing connector design is `docs/design/SESSION_SOURCE_REGISTRY.md`; the existing plugin remains the native OpenClaw memory slot plus Context Engine integration, with legacy hook fallback preserved.

## Problem / pressure
OpenClaw 2.0 introduced canonical Incognito session keys whose transcript is intended to remain process-local. The plugin's automatic Context Engine and hook capture paths did not recognize those keys, so an Incognito conversation could be persisted as a durable Nowledge Mem Thread. The runtime Context Engine also reported a stale hard-coded plugin version, and the published ClawHub instructions used a protected OpenClaw slug and an outdated CLI command.

## How it works
- Reuses the exact OpenClaw 2.0 Incognito key shape for `dashboard`, `subagent`, and `internal-session-effects` sessions.
- Applies the guard through the shared automatic-capture predicate, covering Context Engine `afterTurn` and hook fallback paths.
- Leaves explicit memory tool writes available; users can intentionally save a memory from an Incognito session.
- Derives the Context Engine diagnostic version from `package.json`, keeping package, manifest, registry, and runtime metadata aligned.
- Uses the public ClawHub slug `nowledge-mem`; the internal OpenClaw plugin id `openclaw-nowledge-mem` is unchanged for compatibility.
- Preserves existing thread identity, checkpointing, memory-slot, Context Engine, corpus-supplement, and hook behavior outside Incognito sessions.

## Test plan
- [x] `npm test` in `nowledge-mem-openclaw-plugin`: **64 passed, 0 failed**.
- [x] `npm run validate`: **Validated OpenClaw plugin metadata, runtime files, and ClawHub publish contract.**
- [x] `npm pack --dry-run`: **0.8.34 package contains 35 publishable files; tests and build-only files excluded.**
- [x] `git diff --check`: passed.
- [x] `.context/pytest-venv/bin/python -m pytest community/tests/plugin_e2e/test_key_plugins_e2e.py -q -k openclaw`: **1 skipped, 32 deselected**; the repository fixture is not configured on this machine.
- [x] The previously published `0.8.33` package/registry artifacts are superseded by this post-review `0.8.34` bump; `0.8.34` publication remains a post-merge release step.
- [ ] A live OpenClaw `2026.8.1` gateway smoke remains environment-gated: the clean npm tarball fixture does not include the runtime dependency `tslog`. The limitation and isolated workaround are recorded in `postmortem/2026-08-31-openclaw-2-0-npm-tarball-smoke-dependency-gap.md`.

## Side effects / risks
- Automatic capture is intentionally more private for canonical Incognito sessions.
- Existing non-Incognito sessions and explicit memory tools are unchanged.
- No Rust, app, Cloud, database, or website code is changed.
- The ClawHub CLI 0.8.0 has no dry-run mode; local validator and npm pack checks must pass before publishing.
