### PR TITLE
feat(openai): add official Cloud connector package

### DIFF
--- a/.github/workflows/codex-plugin.yml
+++ b/.github/workflows/codex-plugin.yml
@@ -6,6 +6,7 @@ on:
       - ".github/workflows/codex-plugin.yml"
       - "integrations.json"
       - "nowledge-mem-codex-plugin/**"
+      - "nowledge-mem-openai-plugin/**"
       - "tests/plugin_e2e/**"
   push:
     branches:
@@ -14,6 +15,7 @@ on:
       - ".github/workflows/codex-plugin.yml"
       - "integrations.json"
       - "nowledge-mem-codex-plugin/**"
+      - "nowledge-mem-openai-plugin/**"
       - "tests/plugin_e2e/**"
 
 permissions:
@@ -41,3 +43,5 @@ jobs:
         run: python -m unittest nowledge-mem-codex-plugin/tests/test_codex_plugin.py
       - name: Validate package contract
         run: node nowledge-mem-codex-plugin/scripts/validate-plugin.mjs
+      - name: Test OpenAI Cloud plugin package
+        run: python nowledge-mem-openai-plugin/tests/test_openai_plugin.py

--- a/integrations.json
+++ b/integrations.json
@@ -11,7 +11,8 @@
       "claude-code", "grok", "grok-bot", "codex-cli", "cursor", "gemini-cli", "google-antigravity", "copilot-cli",
       "openclaw", "hermes", "ekko", "droid", "alma", "bub", "pi", "opencode", "craft-agent", "workbuddy", "codebuddy",
       "kimi-code", "kimi-work", "zcode", "deepseek-harness", "mimo-code", "omp", "claude-desktop", "proma",
-      "raft", "lody", "multica", "cumora", "paseo", "langgraph", "mirasim", "cindy", "amp", "agent-plugins", "mcp-direct"
+      "raft", "lody", "multica", "cumora", "paseo", "langgraph", "mirasim", "cindy", "amp", "agent-plugins", "mcp-direct",
+      "chatgpt-cloud", "claude-cloud"
     ],
     "doesNotApplyTo": ["cradle", "arkloop", "opticlm", "browser-extension", "raycast", "antigravity-extractor", "windsurf-extractor"]
   },
@@ -168,6 +169,105 @@
         "convention": "mcp-backend",
         "prefix": "memory_",
         "note": "Grok Bot uses the standard Nowledge Mem MCP tool surface. The exact tool names are supplied by the connected MCP server. A compatible package may add skills and lifecycle hooks when enabled by the host, but that optional path does not by itself grant access to the Bot's private transcript."
+      },
+      "skills": [],
+      "slashCommands": []
+    },
+    {
+      "id": "chatgpt-cloud",
+      "name": "ChatGPT Web and Desktop",
+      "category": "cloud",
+      "type": "plugin",
+      "version": "0.1.0",
+      "directory": "nowledge-mem-openai-plugin",
+      "transport": "openai-plugin+mcp",
+      "capabilities": {
+        "workingMemory": true,
+        "search": true,
+        "distill": true,
+        "autoRecall": false,
+        "autoCapture": false,
+        "graphExploration": false,
+        "status": false
+      },
+      "threadSave": {
+        "method": "none",
+        "note": "Remote MCP gives ChatGPT access to Mem but not Mem access to ChatGPT transcripts. Use the browser extension or an official export for capture."
+      },
+      "autonomy": {
+        "bootstrap": "guided",
+        "recall": "guided",
+        "distill": "guided",
+        "threads": "none",
+        "bestResultRequires": [
+          "Use the public Cloud MCP endpoint ending in /mcp",
+          "Complete the host's OAuth connector approval when requested",
+          "Treat the universal public plugin as pending until OpenAI assigns a real production MCP technical ID and approves the submission",
+          "Use the browser extension or an official export when you need conversation capture",
+          "Keep ChatGPT's connector identity separate from any local ChatGPT export source"
+        ]
+      },
+      "install": {
+        "publicDirectoryStatus": "pending-production-app-registration-and-submission",
+        "detectionHint": "ChatGPT Web and desktop are cloud clients and are not locally detectable by the desktop app",
+        "agentGuide": {
+          "prompt": "Read https://mem.nowledge.co/SKILL.md and follow the ChatGPT Cloud path. Until the universal Nowledge Mem plugin is published, configure the public Nowledge Mem Cloud MCP endpoint through ChatGPT's custom connector flow, complete OAuth, and verify a search plus one scoped write. Never invent a plugin_asdk_app ID. Use the browser extension or official export for conversation capture; do not claim MCP captures ChatGPT threads.",
+          "promptZh": "读取 https://mem.nowledge.co/SKILL.md，并按 ChatGPT 云端路径操作。在通用 Nowledge Mem plugin 正式发布前，请通过 ChatGPT 自定义 connector 流程配置公开的 Nowledge Mem Cloud MCP 地址，完成 OAuth，并验证一次搜索和一次有范围的写入。不要伪造 plugin_asdk_app ID。对话捕获请使用浏览器扩展或官方导出；不要声称 MCP 会捕获 ChatGPT 会话。"
+        },
+        "docsUrl": "/docs/integrations/chatgpt-web"
+      },
+      "toolNaming": {
+        "convention": "openai-plugin+mcp-backend",
+        "note": "The plugin contributes the reusable workflow; the registered Cloud MCP connection supplies tools. The dedicated Codex package remains the local hook and transcript-capture path."
+      },
+      "skills": ["nowledge-mem"],
+      "slashCommands": []
+    },
+    {
+      "id": "claude-cloud",
+      "name": "Claude Cloud",
+      "category": "cloud",
+      "type": "connector",
+      "version": null,
+      "directory": null,
+      "transport": "mcp",
+      "capabilities": {
+        "workingMemory": true,
+        "search": true,
+        "distill": true,
+        "autoRecall": false,
+        "autoCapture": false,
+        "graphExploration": false,
+        "status": false
+      },
+      "threadSave": {
+        "method": "none",
+        "note": "Remote MCP does not expose Claude's private hosted transcripts. Use a supported export or the local Claude Code connector for capture."
+      },
+      "autonomy": {
+        "bootstrap": "guided",
+        "recall": "guided",
+        "distill": "guided",
+        "threads": "none",
+        "bestResultRequires": [
+          "Use Claude or Claude Desktop on a Pro, Max, Team, or Enterprise plan while remote custom connectors remain in beta",
+          "Add the public Cloud /mcp endpoint under Settings > Connectors, not claude_desktop_config.json",
+          "Complete Claude's remote custom connector OAuth approval",
+          "Use an export or local Claude Code connector for transcript capture",
+          "Configure a durable AI Identity explicitly when several Claude agents share a workspace"
+        ]
+      },
+      "install": {
+        "detectionHint": "Claude Cloud is a hosted client and is not locally detectable by the desktop app",
+        "agentGuide": {
+          "prompt": "Read https://mem.nowledge.co/SKILL.md and follow the Claude Cloud path. In Claude Settings > Connectors, add the public Nowledge Mem Cloud /mcp endpoint as a custom connector, approve the requested workspace scopes, and verify a search plus one scoped write. Do not put this remote server in claude_desktop_config.json, use localhost, or claim automatic transcript capture.",
+          "promptZh": "读取 https://mem.nowledge.co/SKILL.md，并按 Claude 云端路径操作。在 Claude 的 Settings > Connectors 中，把公开的 Nowledge Mem Cloud /mcp 地址添加为自定义 connector，确认请求的 workspace scopes，并验证一次搜索和一次有范围的写入。不要把这个远程 server 写进 claude_desktop_config.json，不要使用 localhost，也不要声称会自动捕获对话。"
+        },
+        "docsUrl": "/docs/integrations/claude-cloud"
+      },
+      "toolNaming": {
+        "convention": "mcp-backend",
+        "note": "The connected Cloud MCP server supplies the tool names; Claude Cloud has no local Nowledge hook in this connector."
       },
       "skills": [],
       "slashCommands": []

--- a/nowledge-mem-openai-plugin/.codex-plugin/plugin.json
+++ b/nowledge-mem-openai-plugin/.codex-plugin/plugin.json
@@ -1,0 +1,28 @@
+{
+  "name": "nowledge-mem-cloud",
+  "version": "0.1.0",
+  "description": "Search and update a Nowledge Mem Cloud workspace from ChatGPT and Codex with explicit scope and transcript boundaries.",
+  "author": {
+    "name": "Nowledge Labs",
+    "url": "https://mem.nowledge.co"
+  },
+  "homepage": "https://mem.nowledge.co/docs/integrations/chatgpt-web",
+  "repository": "https://github.com/nowledge-co/community/tree/main/nowledge-mem-openai-plugin",
+  "license": "MIT",
+  "keywords": ["memory", "knowledge", "mcp", "chatgpt", "codex"],
+  "skills": "./skills/",
+  "interface": {
+    "displayName": "Nowledge Mem Cloud",
+    "shortDescription": "Memory that follows you across AI tools",
+    "longDescription": "Use a scoped Nowledge Mem Cloud connection to recall decisions, search threads and Library context, and save durable knowledge. Remote MCP does not import ChatGPT or Codex transcripts.",
+    "developerName": "Nowledge Labs",
+    "category": "Productivity",
+    "capabilities": ["Read", "Write"],
+    "websiteURL": "https://mem.nowledge.co",
+    "defaultPrompt": [
+      "Search my Mem for the decision relevant to this task.",
+      "Read my current working context from Mem.",
+      "Save the durable takeaway from this conversation."
+    ]
+  }
+}

--- a/nowledge-mem-openai-plugin/README.md
+++ b/nowledge-mem-openai-plugin/README.md
@@ -1,0 +1,30 @@
+# Nowledge Mem Cloud for ChatGPT and Codex
+
+This is the public OpenAI plugin package for using a Nowledge Mem Cloud workspace from ChatGPT and Codex.
+
+The checked-in package is intentionally skills-only. OpenAI requires an `.app.json` entry to reference a production MCP connection registered in ChatGPT developer mode. That registration has not produced a technical `plugin_asdk_app_…` ID yet, so this repository does not contain an invented ID or a placeholder `.app.json`.
+
+## Current package
+
+- `.codex-plugin/plugin.json`: universal ChatGPT/Codex plugin metadata
+- `skills/nowledge-mem/SKILL.md`: the host-independent memory workflow and safety boundary
+- `scripts/finalize-app-connection.mjs`: owner-only finalization after OpenAI returns the real technical ID
+- `SUBMISSION.md`: registration, validation, smoke, and public-directory handoff
+
+The package contains no workspace URL, credential, or user-specific Access Anywhere address. The production connection must point to the stable public Nowledge Mem Cloud `/mcp` endpoint and complete OAuth per user.
+
+## Separate local connector
+
+This package does not replace `nowledge-mem-codex-plugin`. The dedicated Codex connector provides local MCP, lifecycle hooks, startup context, and transcript capture. The public Cloud plugin provides portable skills and the registered hosted MCP connection; MCP alone does not capture ChatGPT or Codex conversations.
+
+## Validation
+
+```bash
+python3 nowledge-mem-openai-plugin/tests/test_openai_plugin.py
+```
+
+Maintainers should additionally run the `plugin-creator` package validator
+available in their Codex installation before submission. The repository test is
+self-contained and is the cross-platform CI contract.
+
+Licensed under this repository's MIT license.

--- a/nowledge-mem-openai-plugin/SUBMISSION.md
+++ b/nowledge-mem-openai-plugin/SUBMISSION.md
@@ -1,0 +1,27 @@
+# OpenAI Universal Plugin Submission
+
+Owner handoff for the public directory shared by ChatGPT and Codex. Do not put credentials, customer data, or a user-specific endpoint into the submission.
+
+## Before finalizing the package
+
+1. Deploy the production Nowledge Mem Cloud MCP endpoint and verify its public `/mcp`, protected-resource metadata, authorization-server metadata, OAuth consent, token, refresh, revocation, and scope challenges.
+2. In ChatGPT, enable **Settings → Security and login → Developer mode**.
+3. Open ChatGPT Plugins, create a production MCP connection for the stable public Cloud `/mcp` endpoint, and complete a real member OAuth smoke.
+4. Copy the technical ID from the connection URL. It must start with `plugin_asdk_app_`.
+5. Run `node scripts/finalize-app-connection.mjs plugin_asdk_app_…` from this package.
+6. Review the generated `.app.json` and the new `"apps": "./.app.json"` manifest field. Never substitute a guessed ID.
+7. Run both validators from the README and test the installed local package in a fresh ChatGPT conversation and a fresh Codex session.
+
+## Required live evidence
+
+- anonymous MCP request returns a protected-resource challenge
+- wrong resource, expired/revoked credential, inactive member, and missing write scope fail closed
+- approved context read, memory search, scoped memory write, thread read, and Library read succeed
+- refreshing rotates the refresh token; replay invalidates its grant family
+- no ChatGPT or Codex transcript-capture claim appears in the installed package
+
+## Public submission
+
+Use the OpenAI plugin submission portal with Nowledge Labs publisher details, product/support/privacy URLs, exact test credentials or reviewer instructions, and the live evidence above. Submit the production MCP connection and bundled skill together after `.app.json` contains the real registered ID.
+
+The owner must retain the submission ID and review correspondence. Publication in a private workspace or local marketplace is not publication in the universal public directory.

--- a/nowledge-mem-openai-plugin/scripts/finalize-app-connection.mjs
+++ b/nowledge-mem-openai-plugin/scripts/finalize-app-connection.mjs
@@ -1,0 +1,26 @@
+#!/usr/bin/env node
+
+import { readFile, writeFile } from 'node:fs/promises';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const technicalId = process.argv[2] ?? '';
+if (!/^plugin_asdk_app_[a-f0-9]{32}$/.test(technicalId)) {
+  console.error('Expected the real OpenAI technical ID: plugin_asdk_app_…');
+  process.exit(2);
+}
+
+const packageRoot = resolve(dirname(fileURLToPath(import.meta.url)), '..');
+const manifestPath = resolve(packageRoot, '.codex-plugin', 'plugin.json');
+const appPath = resolve(packageRoot, '.app.json');
+const manifest = JSON.parse(await readFile(manifestPath, 'utf8'));
+
+manifest.apps = './.app.json';
+await writeFile(
+  appPath,
+  `${JSON.stringify({ apps: { 'nowledge-mem': { id: technicalId } } }, null, 2)}\n`,
+  'utf8',
+);
+await writeFile(manifestPath, `${JSON.stringify(manifest, null, 2)}\n`, 'utf8');
+
+console.log(`Wired ${technicalId} into ${appPath}`);

--- a/nowledge-mem-openai-plugin/skills/nowledge-mem/SKILL.md
+++ b/nowledge-mem-openai-plugin/skills/nowledge-mem/SKILL.md
@@ -1,0 +1,33 @@
+---
+name: nowledge-mem
+description: Use a connected Nowledge Mem Cloud workspace for cross-tool context, memory search, scoped knowledge writes, thread lookup, and Library retrieval in ChatGPT or Codex.
+---
+
+# Nowledge Mem Cloud
+
+Use the connected Nowledge Mem tools when the answer depends on prior decisions, current working context, exact earlier conversations, or durable knowledge that should survive this chat.
+
+## Connect
+
+If the Nowledge Mem tools are unavailable, direct the user to the official setup guide at `https://mem.nowledge.co/docs/integrations/chatgpt-web`. The MCP endpoint must be public HTTPS and end in `/mcp`. Complete the host's OAuth flow; never ask the user to paste a Nowledge API key into chat.
+
+This public plugin package is skills-only until its production MCP connection is registered with OpenAI. Do not invent an app identifier or imply that installing the skill alone creates a Cloud connection.
+
+## Use
+
+1. Start with `read_context_bundle` when broad current context is useful.
+2. Use `memory_search` for focused recall and `get_memory_by_id` for exact follow-up.
+3. Use `thread_search` and thread message tools only when exact prior conversation evidence matters.
+4. Use Library tools for source-backed material.
+5. Before `memory_add` or `memory_update`, make the intended Space and durable claim clear. A write may require separately approved `mem:write` scope.
+
+Respect the tools actually exposed by the connected server. Do not claim access to hidden administrative, identity, scheduler, deletion, or review/governance tools.
+
+## Boundaries
+
+- Remote MCP lets ChatGPT or Codex call Mem. It does not let Mem read the host's private transcript.
+- Use the browser extension or an official export for ChatGPT conversation capture. Use the dedicated local Codex connector for Codex lifecycle hooks and transcript capture.
+- A client name and `source_app` are provenance, not an AI Identity or Space selector.
+- Never create a new Space merely to make a connection succeed.
+
+When a task materially depends on remembered context, cite or summarize the retrieved evidence honestly. Do not describe a retrieval as proof that the memory helped unless the user or downstream work confirms it.

--- a/nowledge-mem-openai-plugin/tests/test_openai_plugin.py
+++ b/nowledge-mem-openai-plugin/tests/test_openai_plugin.py
@@ -1,0 +1,60 @@
+from __future__ import annotations
+
+import json
+import shutil
+import subprocess
+import tempfile
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def read_json(path: Path) -> dict:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def main() -> None:
+    manifest = read_json(ROOT / ".codex-plugin" / "plugin.json")
+    skill = (ROOT / "skills" / "nowledge-mem" / "SKILL.md").read_text(encoding="utf-8")
+    readme = (ROOT / "README.md").read_text(encoding="utf-8")
+    submission = (ROOT / "SUBMISSION.md").read_text(encoding="utf-8")
+    finalizer = ROOT / "scripts" / "finalize-app-connection.mjs"
+
+    assert manifest["name"] == "nowledge-mem-cloud"
+    assert manifest["skills"] == "./skills/"
+    assert "apps" not in manifest
+    assert not (ROOT / ".app.json").exists()
+    assert "plugin_asdk_app_" not in json.dumps(manifest)
+    assert "never ask the user to paste a Nowledge API key" in skill
+    assert "does not let Mem read the host's private transcript" in skill
+    assert "does not replace `nowledge-mem-codex-plugin`" in readme
+    assert "Never substitute a guessed ID" in submission
+
+    with tempfile.TemporaryDirectory(prefix="nmem-openai-plugin-") as temp:
+        probe = Path(temp) / ROOT.name
+        shutil.copytree(ROOT, probe)
+        rejected = subprocess.run(
+            ["node", str(probe / "scripts" / finalizer.name), "plugin_asdk_app_TODO"],
+            text=True,
+            capture_output=True,
+            check=False,
+        )
+        assert rejected.returncode == 2
+        accepted_id = "plugin_asdk_app_" + ("0123456789abcdef" * 2)
+        subprocess.run(
+            ["node", str(probe / "scripts" / finalizer.name), accepted_id],
+            text=True,
+            capture_output=True,
+            check=True,
+        )
+        assert read_json(probe / ".app.json") == {
+            "apps": {"nowledge-mem": {"id": accepted_id}}
+        }
+        assert read_json(probe / ".codex-plugin" / "plugin.json")["apps"] == "./.app.json"
+
+    print("openai plugin package: PASS")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

- add the official universal OpenAI plugin package for ChatGPT and Codex
- keep the checked-in package skills-only until OpenAI assigns the real
  production MCP technical ID
- register honest ChatGPT Cloud and Claude Cloud connector contracts
- add cross-platform CI coverage for the new package

## Important boundary

This PR is stacked on #527, which is stacked on Grok #569. Merge in that order;
this diff then contains only the ChatGPT/Claude registry and OpenAI package.

The package is code-review ready but not yet published. OpenAI requires a real
production MCP connection ID before `.app.json` can be committed. The finalizer
rejects placeholders and only wires an ID with the documented
`plugin_asdk_app_…` shape. Production registration, public-directory review, and
real ChatGPT/Claude hosted-client smokes remain explicit owner/deployment gates.

Remote MCP gives each host scoped Mem tools; it does not expose private host
transcripts. The existing `nowledge-mem-codex-plugin` remains the separate local
hook and transcript-capture package.

## Verification

- plugin-creator package validator: passed
- `python3 nowledge-mem-openai-plugin/tests/test_openai_plugin.py`: passed
- `git diff --check`: passed
- JSON registry parse: passed
- inherited MiniMax package regression: `6 passed, 1 live probe skipped`

Issue Number: ref nowledge-co/mem#2632, ref nowledge-co/mem#2784, ref nowledge-co/mem#1405
