### PR TITLE
fix(minimax): satisfy Marketplace example query schema

### DIFF
--- a/integrations.json
+++ b/integrations.json
@@ -2532,7 +2532,7 @@
       "name": "MiniMax Code & Agent",
       "category": "coding",
       "type": "plugin",
-      "version": "0.1.1",
+      "version": "0.1.2",
       "directory": "nowledge-mem-minimax-plugin",
       "transport": "plugin+skill+mcp",
       "capabilities": {

--- a/nowledge-mem-minimax-plugin/.minimax-plugin/plugin.json
+++ b/nowledge-mem-minimax-plugin/.minimax-plugin/plugin.json
@@ -2,7 +2,7 @@
   "schemaVersion": 1,
   "name": "nowledge-mem",
   "displayName": "Nowledge Mem",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "Give MiniMax durable, cross-tool memory with scoped context, recall, and knowledge capture.",
   "author": "Nowledge Labs",
   "icon": "icon.png",
@@ -10,8 +10,7 @@
   "exampleQueries": [
     "What decisions have I made about this project?",
     "Read my current context and continue where I left off",
-    "Save this decision and its rationale for future sessions",
-    "查找我之前关于这个项目的决定"
+    "保存这个决定和理由，供以后继续使用"
   ],
   "apps": [],
   "mcpServers": [

--- a/nowledge-mem-minimax-plugin/SUBMISSION.md
+++ b/nowledge-mem-minimax-plugin/SUBMISSION.md
@@ -5,10 +5,10 @@ This file is the owner handoff for the MiniMax Marketplace form. It is not a run
 ## Package
 
 - Plugin name: `nowledge-mem`
-- Package version: `0.1.1`
+- Package version: `0.1.2`
 - Source: `https://github.com/nowledge-co/community/tree/main/nowledge-mem-minimax-plugin`
 - Manifest: `.minimax-plugin/plugin.json`
-- Operation: `New plugin` for the first submission; use `Update` for later package versions.
+- Operation: `Update` after the initial `PLUGIN-202609040138` validation failure.
 
 ## Requested catalog placement
 

--- a/nowledge-mem-minimax-plugin/tests/test_minimax_plugin.py
+++ b/nowledge-mem-minimax-plugin/tests/test_minimax_plugin.py
@@ -19,8 +19,14 @@ def main() -> None:
 
     assert manifest["name"] == "nowledge-mem"
     assert manifest["displayName"] == "Nowledge Mem"
-    assert manifest["version"] == "0.1.1"
+    assert manifest["version"] == "0.1.2"
     assert manifest["icon"] == "icon.png"
+    example_queries = manifest["exampleQueries"]
+    assert 0 <= len(example_queries) <= 3
+    assert all(
+        isinstance(query, str) and query.strip() and len(query) <= 4_096
+        for query in example_queries
+    )
     assert manifest["mcpServers"] == ["nowledge-mem-local.mcp.json"]
     assert mcp["mcpServers"]["nowledge-mem"]["type"] == "streamable-http"
     assert mcp["mcpServers"]["nowledge-mem"]["url"] == "http://127.0.0.1:14242/mcp"

--- a/tests/plugin_e2e/test_minimax_plugin.py
+++ b/tests/plugin_e2e/test_minimax_plugin.py
@@ -26,17 +26,49 @@ def read_json(path: Path) -> dict:
     return json.loads(path.read_text(encoding="utf-8"))
 
 
+def parse_sse_messages(body: str) -> list[dict]:
+    messages = []
+    for event in body.replace("\r\n", "\n").split("\n\n"):
+        data_lines = []
+        for line in event.splitlines():
+            if line.startswith("data:"):
+                data = line.removeprefix("data:").lstrip()
+                if data:
+                    data_lines.append(data)
+        if data_lines:
+            messages.append(json.loads("\n".join(data_lines)))
+    return messages
+
+
+def test_minimax_live_probe_ignores_empty_sse_keepalive() -> None:
+    body = (
+        "data: \n"
+        "id: 0\n"
+        "retry: 3000\n\n"
+        'data: {"jsonrpc":"2.0","id":1,"result":{"ok":true}}\n\n'
+    )
+
+    assert parse_sse_messages(body) == [
+        {"jsonrpc": "2.0", "id": 1, "result": {"ok": True}}
+    ]
+
+
 def test_minimax_manifest_matches_official_package_contract() -> None:
     manifest = read_json(MANIFEST_PATH)
 
     assert manifest["schemaVersion"] == 1
     assert manifest["name"] == "nowledge-mem"
-    assert manifest["version"] == "0.1.1"
+    assert manifest["version"] == "0.1.2"
     assert manifest["author"] == "Nowledge Labs"
     assert manifest["apps"] == []
     assert manifest["mcpServers"] == ["nowledge-mem-local.mcp.json"]
     assert manifest["skills"] == ["skills/nowledge-mem/SKILL.md"]
-    assert manifest["exampleQueries"]
+    example_queries = manifest["exampleQueries"]
+    assert 0 <= len(example_queries) <= 3
+    assert all(
+        isinstance(query, str) and query.strip() and len(query) <= 4_096
+        for query in example_queries
+    )
 
     referenced = [manifest["icon"], *manifest["mcpServers"], *manifest["skills"]]
     for relative in referenced:
@@ -150,15 +182,7 @@ def test_minimax_local_mcp_initialize_and_tool_discovery() -> None:
         if not body.strip():
             pytest.fail("MCP response body was empty")
         if body.lstrip().startswith(("event:", "data:")):
-            messages = []
-            for event in body.replace("\r\n", "\n").split("\n\n"):
-                data_lines = [
-                    line.removeprefix("data:").lstrip()
-                    for line in event.splitlines()
-                    if line.startswith("data:")
-                ]
-                if data_lines:
-                    messages.append(json.loads("\n".join(data_lines)))
+            messages = parse_sse_messages(body)
             assert messages, "SSE response did not contain a data event"
             expected_id = payload.get("id")
             return next(


### PR DESCRIPTION
### Issue

Issue Number: ref nowledge-co/mem#1384

### Background

MiniMax Marketplace consumes the package under `nowledge-mem-minimax-plugin/` for the dual-plane connector defined by `docs/design/INTEGRATION_UNIFICATION.md` and tracked in nowledge-co/mem#1384. The package was already public and its first owner-authorized CN/US, Desktop/Cloud submission reached MiniMax automatic validation.

### What problem does this PR solve?

Submission `PLUGIN-202609040138` was rejected with `SCHEMA_INVALID` at `.minimax-plugin/plugin.json.exampleQueries`. The current MiniMax Marketplace V1 guide permits zero to three non-empty example queries, while package version 0.1.1 supplied four. During the required local MCP live probe, the test harness also attempted to JSON-decode MiniMax-compatible SSE keepalive frames whose `data:` field is intentionally empty.

### How does it work?

The manifest now carries three examples covering recall, current context, and durable capture across English and Chinese, and the package/registry version advances to 0.1.2 because package contents changed. Both static validation layers enforce MiniMax's zero-to-three query bound, non-empty strings, and 4,096-character per-query limit.

The live probe now discards empty SSE `data:` keepalive frames before decoding application messages, with a focused regression fixture matching the local Mem server response. The connector boundary does not change: MiniMax Code Desktop still uses credential-free loopback MCP, while MiniMax Agent Cloud remains unavailable until MiniMax confirms and configures its managed App provider.

### Tests

- [x] Unit / source-pin test
- [x] Integration test
- [x] Live / manual test (commands and observations below)

Red evidence before the manifest fix:

```text
python3 nowledge-mem-minimax-plugin/tests/test_minimax_plugin.py
AssertionError: assert 0 <= len(example_queries) <= 3
```

Green evidence:

```text
python3 nowledge-mem-minimax-plugin/tests/test_minimax_plugin.py
minimax plugin package: PASS

uv run --with pytest pytest tests/plugin_e2e/test_key_plugins_e2e.py::test_registry_connect_contract_points_agent_prompts_to_universal_skill tests/plugin_e2e/test_minimax_plugin.py -q
8 passed, 1 skipped in 1.59s

NMEM_MINIMAX_LIVE=1 uv run --with pytest pytest -q tests/plugin_e2e/test_minimax_plugin.py
8 passed in 0.08s

git diff --check
(no output)
```

The live run exercised `initialize`, `notifications/initialized`, and `tools/list` against Nowledge Mem 0.10.77 at the package's exact loopback endpoint.

### Side effects / risks

None of the production-traffic, database-migration, shared-wire-contract, or REST-payload risk classes apply. The parent `nowledge-co/mem` submodule pointer will be updated only after this child PR is merged and its commit is reachable.
