### PR TITLE
fix(minimax): retry rejected first submissions as new

### DIFF
--- a/integrations.json
+++ b/integrations.json
@@ -2532,7 +2532,7 @@
       "name": "MiniMax Code & Agent",
       "category": "coding",
       "type": "plugin",
-      "version": "0.1.2",
+      "version": "0.1.3",
       "directory": "nowledge-mem-minimax-plugin",
       "transport": "plugin+skill+mcp",
       "capabilities": {

--- a/nowledge-mem-minimax-plugin/.minimax-plugin/plugin.json
+++ b/nowledge-mem-minimax-plugin/.minimax-plugin/plugin.json
@@ -2,7 +2,7 @@
   "schemaVersion": 1,
   "name": "nowledge-mem",
   "displayName": "Nowledge Mem",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "Give MiniMax durable, cross-tool memory with scoped context, recall, and knowledge capture.",
   "author": "Nowledge Labs",
   "icon": "icon.png",

--- a/nowledge-mem-minimax-plugin/SUBMISSION.md
+++ b/nowledge-mem-minimax-plugin/SUBMISSION.md
@@ -5,10 +5,12 @@ This file is the owner handoff for the MiniMax Marketplace form. It is not a run
 ## Package
 
 - Plugin name: `nowledge-mem`
-- Package version: `0.1.2`
+- Package version: `0.1.3`
 - Source: `https://github.com/nowledge-co/community/tree/main/nowledge-mem-minimax-plugin`
 - Manifest: `.minimax-plugin/plugin.json`
-- Operation: `Update` after the initial `PLUGIN-202609040138` validation failure.
+- Operation: `New plugin` until the first submission passes validation.
+
+A validation failure does not create an existing Marketplace plugin. Retry a rejected first submission as `New plugin`; use `Update` only after MiniMax has accepted an earlier submission and established the listing.
 
 ## Requested catalog placement
 

--- a/nowledge-mem-minimax-plugin/tests/test_minimax_plugin.py
+++ b/nowledge-mem-minimax-plugin/tests/test_minimax_plugin.py
@@ -19,7 +19,7 @@ def main() -> None:
 
     assert manifest["name"] == "nowledge-mem"
     assert manifest["displayName"] == "Nowledge Mem"
-    assert manifest["version"] == "0.1.2"
+    assert manifest["version"] == "0.1.3"
     assert manifest["icon"] == "icon.png"
     example_queries = manifest["exampleQueries"]
     assert 0 <= len(example_queries) <= 3

--- a/tests/plugin_e2e/test_minimax_plugin.py
+++ b/tests/plugin_e2e/test_minimax_plugin.py
@@ -53,12 +53,19 @@ def test_minimax_live_probe_ignores_empty_sse_keepalive() -> None:
     ]
 
 
+def test_minimax_submission_retry_stays_new_until_listing_exists() -> None:
+    submission = (PLUGIN_ROOT / "SUBMISSION.md").read_text(encoding="utf-8")
+
+    assert "- Operation: `New plugin` until the first submission passes validation." in submission
+    assert "A validation failure does not create an existing Marketplace plugin." in submission
+
+
 def test_minimax_manifest_matches_official_package_contract() -> None:
     manifest = read_json(MANIFEST_PATH)
 
     assert manifest["schemaVersion"] == 1
     assert manifest["name"] == "nowledge-mem"
-    assert manifest["version"] == "0.1.2"
+    assert manifest["version"] == "0.1.3"
     assert manifest["author"] == "Nowledge Labs"
     assert manifest["apps"] == []
     assert manifest["mcpServers"] == ["nowledge-mem-local.mcp.json"]


### PR DESCRIPTION
### Issue

Issue Number: ref nowledge-co/mem#1384

### Background

MiniMax Marketplace submission state is part of the owner handoff under `nowledge-mem-minimax-plugin/SUBMISSION.md`. The package follows the dual-plane contract in `docs/design/INTEGRATION_UNIFICATION.md`: Desktop uses the installed Mem App over loopback, while Cloud waits for MiniMax's managed Nowledge Cloud App provider.

### What problem does this PR solve?

The first `New Plugin` submission (`PLUGIN-202609040138`) failed schema validation before a Marketplace listing was created. The 0.1.2 handoff incorrectly treated that failed attempt as an existing plugin and instructed the retry to use `Update`. MiniMax rejected the resulting `PLUGIN-202609040139` with `PLUGIN_NOT_FOUND_FOR_UPDATE (CN)`.

### How does it work?

The handoff now states the actual lifecycle rule: retries remain `New plugin` until one submission passes validation and establishes the listing; `Update` is only for an accepted existing listing. A focused regression assertion protects both sentences. Because the public package content changes, the manifest and registry advance together to 0.1.3.

No runtime connector behavior changed. The 0.1.2 maximum-three example-query fix and SSE keepalive parser remain intact, and MiniMax Agent Cloud remains pending provider confirmation.

### Tests

- [x] Unit / source-pin test
- [x] Integration test
- [x] Live / manual test (commands and observations below)

Red evidence before the handoff fix:

```text
uv run --with pytest pytest -q tests/plugin_e2e/test_minimax_plugin.py::test_minimax_submission_retry_stays_new_until_listing_exists
1 failed in 0.04s
```

Green evidence:

```text
python3 nowledge-mem-minimax-plugin/tests/test_minimax_plugin.py
minimax plugin package: PASS

uv run --with pytest pytest tests/plugin_e2e/test_key_plugins_e2e.py::test_registry_connect_contract_points_agent_prompts_to_universal_skill tests/plugin_e2e/test_minimax_plugin.py -q
9 passed, 1 skipped in 0.28s

NMEM_MINIMAX_LIVE=1 uv run --with pytest pytest -q tests/plugin_e2e/test_minimax_plugin.py
9 passed in 0.09s

git diff --check
(no output)
```

### Side effects / risks

None of the production-traffic, database-migration, shared-wire-contract, or REST-payload risk classes apply. The parent submodule pointer will advance only after this child PR merges.
